### PR TITLE
UI: Allow only left mouse button double clicks for sources list

### DIFF
--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -106,6 +106,7 @@ set(obs_SOURCES
 	volume-control.cpp
 	adv-audio-control.cpp
 	vertical-scroll-area.cpp
+	ldc-list-widget.cpp
 	crash-report.cpp
 	qt-wrappers.cpp)
 
@@ -131,6 +132,7 @@ set(obs_HEADERS
 	volume-control.hpp
 	adv-audio-control.hpp
 	vertical-scroll-area.hpp
+	ldc-list-widget.hpp
 	qt-display.hpp
 	crash-report.hpp
 	qt-wrappers.hpp)

--- a/obs/forms/OBSBasic.ui
+++ b/obs/forms/OBSBasic.ui
@@ -262,7 +262,7 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QListWidget" name="sources">
+              <widget class="LDCListWidget" name="sources">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
                  <horstretch>0</horstretch>
@@ -845,6 +845,11 @@
    <extends>QScrollArea</extends>
    <header>vertical-scroll-area.hpp</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LDCListWidget</class>
+   <extends>QListWidget</extends>
+   <header>ldc-list-widget.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/obs/ldc-list-widget.cpp
+++ b/obs/ldc-list-widget.cpp
@@ -1,0 +1,8 @@
+#include <QMouseEvent>
+#include "ldc-list-widget.hpp"
+
+void LDCListWidget::mouseDoubleClickEvent(QMouseEvent *event)
+{
+	if (event->button() == Qt::LeftButton)
+		QListWidget::mouseDoubleClickEvent(event);
+}

--- a/obs/ldc-list-widget.hpp
+++ b/obs/ldc-list-widget.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include<QListWidget>
+
+class QMouseEvent;
+
+class LDCListWidget : public QListWidget{
+	Q_OBJECT
+public:
+	inline LDCListWidget(QWidget *parent = nullptr)
+		:QListWidget(parent)
+	{
+	}
+
+protected:
+	virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
+};


### PR DESCRIPTION
This fixes an issue where it was possible to have both (when right mouse button double clicking on an 'sources list' item) properties window and context menu shown at the same time.