### PR TITLE
Fix properties window size grip position on resize

### DIFF
--- a/obs/window-basic-properties.cpp
+++ b/obs/window-basic-properties.cpp
@@ -138,7 +138,7 @@ void OBSBasicProperties::resizeEvent(QResizeEvent *event)
 		resizeTimer = startTimer(100);
 	}
 
-	UNUSED_PARAMETER(event);
+	QDialog::resizeEvent(event);
 }
 
 void OBSBasicProperties::timerEvent(QTimerEvent *event)


### PR DESCRIPTION
To have its position updated, QDialog::resizeEvent must
be called.