### PR TITLE
Removed an unnecesary setSizeConstraint call

### DIFF
--- a/obs/properties-view.cpp
+++ b/obs/properties-view.cpp
@@ -61,7 +61,7 @@ void OBSPropertiesView::RefreshProperties()
 	QSizePolicy mainPolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 	QSizePolicy policy(QSizePolicy::Preferred, QSizePolicy::Preferred);
 	//widget->setSizePolicy(policy);
-	layout->setSizeConstraint(QLayout::SetMaximumSize);
+
 	layout->setLabelAlignment(Qt::AlignRight);
 
 	obs_property_t *property = obs_properties_first(properties.get());


### PR DESCRIPTION
This setSizeConstraint(QLayout::SetMaximumSize) call
caused the widgets to be improperly sized.
For example: combo boxes with long texts ('big' widget width) not
being completly visible.