### PR TITLE
use multiarch compatible plugin lib path

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -38,7 +38,7 @@ const char *get_module_extension(void)
 
 static const char *module_bin[] = {
 	"../../obs-plugins/" BIT_STRING,
-	OBS_INSTALL_PREFIX "lib/obs-plugins",
+	OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION
 };
 
 static const char *module_data[] = {


### PR DESCRIPTION
use OBS_PLUGIN_DESTINATION instead of hardcoded path for module_bin

This is when using multiarch, libraries are to be installed in for example /usr/lib/x86_64-linux-gnu/obs-plugins/ etc..