### PR TITLE
add SOVERSION to libobs-opengl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,6 @@ endif()
 if(NOT INSTALLER_RUN)
 	add_subdirectory(deps)
 
-	add_subdirectory(libobs)
 
 	if(WIN32)
 		add_subdirectory(libobs-d3d11)
@@ -80,6 +79,7 @@ if(NOT INSTALLER_RUN)
 	endif()
 
 	add_subdirectory(libobs-opengl)
+	add_subdirectory(libobs)
 	add_subdirectory(obs)
 	add_subdirectory(plugins)
 	add_subdirectory(test)

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -516,3 +516,19 @@ function(install_obs_plugin_with_data target datadir)
 	install_obs_plugin(${target})
 	install_obs_data(${target} "${datadir}" "obs-plugins/${target}")
 endfunction()
+
+function(define_graphic_modules target)
+	foreach(dl_lib opengl d3d9 d3d11)
+		if(TARGET libobs-${dl_lib})
+			target_compile_definitions(${target}
+				PRIVATE
+				$<UPPER_CASE:DL_${dl_lib}>="$<TARGET_FILE_NAME:libobs-${dl_lib}>"
+				)
+		else()
+			target_compile_definitions(${target}
+				PRIVATE
+				$<UPPER_CASE:DL_${dl_lib}>=""
+				)
+		endif()
+	endforeach()
+endfunction()

--- a/libobs-opengl/CMakeLists.txt
+++ b/libobs-opengl/CMakeLists.txt
@@ -1,6 +1,5 @@
 project(libobs-opengl)
 
-include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/libobs")
 
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
@@ -73,8 +72,10 @@ add_library(libobs-opengl MODULE
 	${libobs-opengl_HEADERS})
 set_target_properties(libobs-opengl
 	PROPERTIES
-		OUTPUT_NAME libobs-opengl
-		PREFIX "")
+		OUTPUT_NAME obs-opengl
+		VERSION 0.0
+		SOVERSION 0
+		)
 target_link_libraries(libobs-opengl
 	libobs
 	glad

--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -179,6 +179,8 @@ target_link_libraries(obs
 	Qt5::Network
 	${obs_PLATFORM_LIBRARIES})
 
+define_graphic_modules(obs)
+
 install_obs_core(obs)
 install_obs_data(obs data obs-studio)
 

--- a/obs/obs-app.cpp
+++ b/obs/obs-app.cpp
@@ -246,7 +246,7 @@ const char *OBSApp::GetRenderModule() const
 			"Renderer");
 
 	return (astrcmpi(renderer, "Direct3D 11") == 0) ?
-		"libobs-d3d11" : "libobs-opengl";
+		DL_D3D11 : DL_OPENGL;
 }
 
 bool OBSApp::OBSInit()

--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -1421,13 +1421,13 @@ int OBSBasic::ResetVideo()
 	ret = AttemptToResetVideo(&ovi);
 	if (IS_WIN32 && ret != OBS_VIDEO_SUCCESS) {
 		/* Try OpenGL if DirectX fails on windows */
-		if (astrcmpi(ovi.graphics_module, "libobs-opengl") != 0) {
+		if (astrcmpi(ovi.graphics_module, DL_OPENGL) != 0) {
 			blog(LOG_WARNING, "Failed to initialize obs video (%d) "
 					  "with graphics_module='%s', retrying "
 					  "with graphics_module='%s'",
 					  ret, ovi.graphics_module,
-					  "libobs-opengl");
-			ovi.graphics_module = "libobs-opengl";
+					  DL_OPENGL);
+			ovi.graphics_module = DL_OPENGL;
 			ret = AttemptToResetVideo(&ovi);
 		}
 	}

--- a/test/osx/CMakeLists.txt
+++ b/test/osx/CMakeLists.txt
@@ -15,3 +15,4 @@ add_executable(osx_test
 target_link_libraries(osx_test
 	libobs
 	${COCOA})
+define_graphic_modules(osx_test)

--- a/test/osx/test.mm
+++ b/test/osx/test.mm
@@ -45,7 +45,7 @@ static void CreateOBS(NSView *view)
 	ovi.adapter         = 0;
 	ovi.fps_num         = 30000;
 	ovi.fps_den         = 1001;
-	ovi.graphics_module = "libobs-opengl";
+	ovi.graphics_module = DL_OPENGL;
 	ovi.output_format   = VIDEO_FORMAT_RGBA;
 	ovi.base_width      = cx;
 	ovi.base_height     = cy;

--- a/test/win/CMakeLists.txt
+++ b/test/win/CMakeLists.txt
@@ -9,3 +9,4 @@ add_executable(win-test WIN32
 	${win-text_SOURCES})
 target_link_libraries(win-test
 	libobs)
+define_graphic_modules(win-test)

--- a/test/win/test.cpp
+++ b/test/win/test.cpp
@@ -80,7 +80,7 @@ static void CreateOBS(HWND hwnd)
 	ovi.base_height     = rc.bottom;
 	ovi.fps_num         = 30000;
 	ovi.fps_den         = 1001;
-	ovi.graphics_module = "libobs-opengl";
+	ovi.graphics_module = DL_OPENGL;
 	ovi.window_width    = rc.right;
 	ovi.window_height   = rc.bottom;
 	ovi.output_format   = VIDEO_FORMAT_RGBA;


### PR DESCRIPTION
as libobs-opengl is a public library, it's custom to have a proper
SONAME embedded in the library file.
Also remove the previx override and remove the prefixing "lib" from the
output name.