### PR TITLE
linux-capture: Fix possible crashes

### DIFF
--- a/plugins/linux-capture/xcursor.c
+++ b/plugins/linux-capture/xcursor.c
@@ -99,6 +99,9 @@ void xcursor_tick(xcursor_t *data) {
 }
 
 void xcursor_render(xcursor_t *data) {
+	if (!data->tex)
+		return;
+
 	gs_effect_t *effect  = gs_get_effect();
 	gs_eparam_t *image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, data->tex);

--- a/plugins/linux-capture/xcursor.c
+++ b/plugins/linux-capture/xcursor.c
@@ -44,6 +44,8 @@ static uint32_t *xcursor_pixels(XFixesCursorImage *xc) {
  */
 static void xcursor_create(xcursor_t *data, XFixesCursorImage *xc) {
 	uint32_t *pixels = xcursor_pixels(xc);
+	if (!pixels)
+		return;
 
 	if (data->tex
 	&& data->last_height == xc->width
@@ -82,6 +84,8 @@ void xcursor_destroy(xcursor_t *data) {
 
 void xcursor_tick(xcursor_t *data) {
 	XFixesCursorImage *xc = XFixesGetCursorImage(data->dpy);
+	if (!xc)
+		return;
 
 	if (!data->tex || data->last_serial != xc->cursor_serial)
 		xcursor_create(data, xc);


### PR DESCRIPTION
Until the xcomposite capture is ported to use xcb, this should fix possible crashes in the old xcursor helper.