### PR TITLE
obs: Enable load of stylesheet.qss from config dir

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -38,7 +38,7 @@ const char *get_module_extension(void)
 
 static const char *module_bin[] = {
 	"../../obs-plugins/" BIT_STRING,
-	OBS_INSTALL_PREFIX "lib/obs-plugins",
+	OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION
 };
 
 static const char *module_data[] = {

--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -80,6 +80,11 @@ OBSBasic::OBSBasic(QWidget *parent)
 {
 	ui->setupUi(this);
 
+	QString styleSheetPath(os_get_config_path("obs-studio/stylesheet.qss"));
+	QFile styleSheet(styleSheetPath);
+	styleSheet.open(QFile::ReadOnly);
+	setStyleSheet(styleSheet.readAll());
+
 	qRegisterMetaType<OBSScene>    ("OBSScene");
 	qRegisterMetaType<OBSSceneItem>("OBSSceneItem");
 	qRegisterMetaType<OBSSource>   ("OBSSource");


### PR DESCRIPTION
This will allow obs to load stylesheet.qss (Qt stylesheet). It enables
users to theme obs how they please within Qt stylesheet guidelines. A
default stylesheet is not yet available.