### PR TITLE
obs: Allow styling of volume meters

### DIFF
--- a/obs/volume-control.cpp
+++ b/obs/volume-control.cpp
@@ -137,11 +137,53 @@ VolControl::~VolControl()
 	obs_volmeter_destroy(obs_volmeter);
 }
 
+QColor VolumeMeter::getBkColor() const
+{
+	return bkColor;
+}
+
+void VolumeMeter::setBkColor(QColor c)
+{
+	bkColor = c;
+}
+
+QColor VolumeMeter::getMagColor() const
+{
+	return magColor;
+}
+
+void VolumeMeter::setMagColor(QColor c)
+{
+	magColor = c;
+}
+
+QColor VolumeMeter::getPeakColor() const
+{
+	return peakColor;
+}
+
+void VolumeMeter::setPeakColor(QColor c)
+{
+	peakColor = c;
+}
+
+QColor VolumeMeter::getPeakHoldColor() const
+{
+	return peakHoldColor;
+}
+
+void VolumeMeter::setPeakHoldColor(QColor c)
+{
+	peakHoldColor = c;
+}
+
+
 VolumeMeter::VolumeMeter(QWidget *parent)
 			: QWidget(parent)
 {
 	setMinimumSize(1, 3);
 
+	//Default meter color settings, they only show if there is no stylesheet, do not remove.
 	bkColor.setRgb(0xDD, 0xDD, 0xDD);
 	magColor.setRgb(0x20, 0x7D, 0x17);
 	peakColor.setRgb(0x3E, 0xF1, 0x2B);

--- a/obs/volume-control.hpp
+++ b/obs/volume-control.hpp
@@ -6,6 +6,11 @@
 class VolumeMeter : public QWidget
 {
 	Q_OBJECT
+	Q_PROPERTY(QColor bkColor READ getBkColor WRITE setBkColor DESIGNABLE true)
+	Q_PROPERTY(QColor magColor READ getMagColor WRITE setMagColor DESIGNABLE true)
+	Q_PROPERTY(QColor peakColor READ getPeakColor WRITE setPeakColor DESIGNABLE true)
+	Q_PROPERTY(QColor peakHoldColor READ getPeakHoldColor WRITE setPeakHoldColor DESIGNABLE true)
+
 private:
 	float mag, peak, peakHold;
 	QColor bkColor, magColor, peakColor, peakHoldColor;
@@ -14,6 +19,15 @@ private:
 public:
 	explicit VolumeMeter(QWidget *parent = 0);
 	void setLevels(float nmag, float npeak, float npeakHold);
+	QColor getBkColor() const;
+	void setBkColor(QColor c);
+	QColor getMagColor() const;
+	void setMagColor(QColor c);
+	QColor getPeakColor() const;
+	void setPeakColor(QColor c);
+	QColor getPeakHoldColor() const;
+	void setPeakHoldColor(QColor c);
+
 protected:
 	void paintEvent(QPaintEvent *event);
 private slots:


### PR DESCRIPTION
This will allow styling of the volume meters so that users are not stuck
with the default colors when they style a theme. Volume meters' colors can
be changed in stylesheet.qss using the following format as an example:

VolumeMeter {
qproperty-bkColor: #DDDDDD;
qproperty-magColor: #207D17;
qproperty-peakColor: #3EF12B;
qproperty-peakHoldColor: #000000;
}