### PR TITLE
UI: Add Okay/Cancel Buttons to Properties Dialog

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -109,6 +109,8 @@ Basic.PropertiesWindow="Properties for '%1'"
 Basic.PropertiesWindow.AutoSelectFormat="%1 (unsupported; autoselect: %2)"
 Basic.PropertiesWindow.SelectColor="Select color"
 Basic.PropertiesWindow.SelectFont="Select font"
+Basic.PropertiesWindow.ConfirmTitle="Settings Changed"
+Basic.PropertiesWindow.Confirm="There are unsaved changes. Do you want to save them?"
 
 # interaction window
 Basic.InteractionWindow="Interacting with '%1'"

--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -1505,6 +1505,17 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	if (!event->isAccepted())
 		return;
 
+	/* Check all child dialogs and ensure they run their proper closeEvent
+	 * methods before exiting the application.  Otherwise Qt doesn't send
+	 * the proper QCloseEvent messages. 
+	 */
+	QList<QDialog*> childDialogs = this->findChildren<QDialog *>();
+	if (!childDialogs.isEmpty()){
+		for (int i = 0; i < childDialogs.size(); ++i) {
+			childDialogs.at(i)->close();
+		}
+	}
+
 	// remove draw callback in case our drawable surfaces go away before
 	// the destructor gets called
 	obs_remove_draw_callback(OBSBasic::RenderMain, this);

--- a/obs/window-basic-properties.hpp
+++ b/obs/window-basic-properties.hpp
@@ -18,8 +18,8 @@
 #pragma once
 
 #include <QDialog>
+#include <QDialogButtonBox>
 #include <memory>
-
 #include <obs.hpp>
 
 #include "properties-view.hpp"
@@ -34,20 +34,26 @@ class OBSBasicProperties : public QDialog {
 private:
 	OBSBasic   *main;
 	int        resizeTimer;
+	bool       acceptClicked;
 
 	std::unique_ptr<Ui::OBSBasicProperties> ui;
 	OBSSource  source;
 	OBSDisplay display;
 	OBSSignal  removedSignal;
 	OBSSignal  updatePropertiesSignal;
+	OBSData    oldSettings;
 	OBSPropertiesView *view;
+	QDialogButtonBox *buttonBox;
 
 	static void SourceRemoved(void *data, calldata_t *params);
 	static void UpdateProperties(void *data, calldata_t *params);
 	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
+	bool ConfirmQuit();
+	int  CheckSettings();
 
 private slots:
 	void OnPropertiesResized();
+	void on_buttonBox_clicked(QAbstractButton *button);
 
 public:
 	OBSBasicProperties(QWidget *parent, OBSSource source_);


### PR DESCRIPTION
Use QDialogButtonBox to add "Okay" and "Cancel" buttons to the
properties dialog. The core functionality of the dialog is not changed;
I.E. the settings are still applied to the source as the user changes
them. If the user clicks "Okay", the dialog simply exits. If the user
clicks "Cancel", the original settings are reapplied to the source then
the dialog exits. If the window is closed by any other means (I.E. by
the main obs window closing) then the properties dialog prompts the user
if they changed anything and asks if they wish to save their settings.

In order to implement this last feature, a method of checking for open
dialogs and sending each a quit message is added to the closeEvent()
method for OBSBasic.