### PR TITLE
UI: Apply a style sheet using its path instead of content.

### DIFF
--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -87,7 +87,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	if (ret > 0) {
 		QFile styleSheet(QT_UTF8(styleSheetPath));
 		if (styleSheet.open(QFile::ReadOnly))
-			setStyleSheet(styleSheet.readAll());
+			App()->setStyleSheet("file:///" + QT_UTF8(styleSheetPath));
 	}
 
 	qRegisterMetaType<OBSScene>    ("OBSScene");


### PR DESCRIPTION
This allows the usage of other resources in the style sheet,
like icons/etc, relative to the style sheet location.
For example, to change the main window app icon,
add #OBSBasic { qproperty-windowIcon: url("basic/newicon.png") }
in the style sheet, where "basic/newicon.png" is a path
relative to the qss file location.