### PR TITLE
Generate proper DL_OPENGL value

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -523,7 +523,7 @@ function(define_graphic_modules target)
 		if(TARGET libobs-${dl_lib})
 			target_compile_definitions(${target}
 				PRIVATE
-				DL_${dl_lib_upper}="$<TARGET_FILE_NAME:libobs-${dl_lib}>"
+				DL_${dl_lib_upper}="$<TARGET_SONAME_FILE:libobs-${dl_lib}>"
 				)
 		else()
 			target_compile_definitions(${target}

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -523,7 +523,7 @@ function(define_graphic_modules target)
 		if(TARGET libobs-${dl_lib})
 			target_compile_definitions(${target}
 				PRIVATE
-				DL_${dl_lib_upper}="$<TARGET_SONAME_FILE:libobs-${dl_lib}>"
+				DL_${dl_lib_upper}="$<TARGET_SONAME_FILE_NAME:libobs-${dl_lib}>"
 				)
 		else()
 			target_compile_definitions(${target}

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -521,10 +521,17 @@ function(define_graphic_modules target)
 	foreach(dl_lib opengl d3d9 d3d11)
 		string(TOUPPER ${dl_lib} dl_lib_upper)
 		if(TARGET libobs-${dl_lib})
-			target_compile_definitions(${target}
-				PRIVATE
-				DL_${dl_lib_upper}="$<TARGET_SONAME_FILE_NAME:libobs-${dl_lib}>"
-				)
+			if(UNIX)
+				target_compile_definitions(${target}
+					PRIVATE
+					DL_${dl_lib_upper}="$<TARGET_SONAME_FILE_NAME:libobs-${dl_lib}>"
+					)
+			else()
+				target_compile_definitions(${target}
+					PRIVATE
+					DL_${dl_lib_upper}="$<TARGET_FILE_NAME:libobs-${dl_lib}>"
+					)
+			endif()
 		else()
 			target_compile_definitions(${target}
 				PRIVATE

--- a/libobs-opengl/CMakeLists.txt
+++ b/libobs-opengl/CMakeLists.txt
@@ -67,7 +67,7 @@ set(libobs-opengl_HEADERS
 	gl-shaderparser.h
 	gl-subsystem.h)
 
-add_library(libobs-opengl MODULE
+add_library(libobs-opengl SHARED
 	${libobs-opengl_SOURCES}
 	${libobs-opengl_HEADERS})
 


### PR DESCRIPTION
Since we rely on the dynamic linker to find the library for us via
dlopen(), we need to have DL_OPENGL be .so.N, not the full library
filename, as ldconfig doesn't cache the full filename

Use of TARGET_SONAME_FILE requires the library to be marked as SHARED,
not MODULE

I don't believe TARGET_SONAME_FILE should yield a different value than TARGET_FILE_NAME on windows, however the cmake docs don't state anything about its behavior on windows, and I don't personally have a windows env to test it on.