### PR TITLE
UI: Add a visual cue to sources property window

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -1,4 +1,4 @@
-# Note to translators: *DO NOT* translate this file directly. Instead, visit http://crowdin.com/project/obs-studio and submit your translations there.
+﻿# Note to translators: *DO NOT* translate this file directly. Instead, visit http://crowdin.com/project/obs-studio and submit your translations there.
 # Pull requests for translations outside of CrowdIn will not be accepted.
 # Read this forum post for more instructions on submitting translations: https://obsproject.com/forum/threads/how-to-contribute-translations-for-obs.16327/
 
@@ -118,6 +118,7 @@ Basic.PropertiesWindow.SelectColor="Select color"
 Basic.PropertiesWindow.SelectFont="Select font"
 Basic.PropertiesWindow.ConfirmTitle="Settings Changed"
 Basic.PropertiesWindow.Confirm="There are unsaved changes.  Do you want to keep them?"
+Basic.PropertiesWindow.NoPropertiesLabel="No properties available"
 
 # interaction window
 Basic.InteractionWindow="Interacting with '%1'"

--- a/obs/properties-view.cpp
+++ b/obs/properties-view.cpp
@@ -75,6 +75,7 @@ void OBSPropertiesView::RefreshProperties()
 	layout->setLabelAlignment(Qt::AlignRight);
 
 	obs_property_t *property = obs_properties_first(properties.get());
+	bool hasNoProperties = !property;
 
 	while (property) {
 		AddProperty(property, layout);
@@ -90,6 +91,12 @@ void OBSPropertiesView::RefreshProperties()
 	if (lastWidget) {
 		lastWidget->setFocus(Qt::OtherFocusReason);
 		lastWidget = nullptr;
+	}
+
+	if(hasNoProperties)
+	{
+		QLabel *noPropertiesLabel = new QLabel(QTStr("Basic.PropertiesWindow.NoPropertiesLabel"));
+		layout->addWidget(noPropertiesLabel);
 	}
 }
 


### PR DESCRIPTION
Display a "No properties available" text in source's
property window if that source doesn't have any properties.