### PR TITLE
View Log menu entry in Help -> Log Files menu

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -207,6 +207,7 @@ Basic.MainMenu.Help.Logs="&Log Files"
 Basic.MainMenu.Help.Logs.ShowLogs="&Show Log Files"
 Basic.MainMenu.Help.Logs.UploadCurrentLog="Upload &Current Log File"
 Basic.MainMenu.Help.Logs.UploadLastLog="Upload &Last Log File"
+Basic.MainMenu.Help.Logs.ViewCurrentLog="&View Current Log"
 Basic.MainMenu.Help.CheckForUpdates="Check For Updates"
 
 # basic mode settings dialog

--- a/obs/forms/OBSBasic.ui
+++ b/obs/forms/OBSBasic.ui
@@ -581,6 +581,7 @@
      <addaction name="actionShowLogs"/>
      <addaction name="actionUploadCurrentLog"/>
      <addaction name="actionUploadLastLog"/>
+     <addaction name="actionViewCurrentLog"/>
     </widget>
     <addaction name="menuLogFiles"/>
     <addaction name="actionCheckForUpdates"/>
@@ -804,6 +805,11 @@
   <action name="actionUploadCurrentLog">
    <property name="text">
     <string>Basic.MainMenu.Help.Logs.UploadCurrentLog</string>
+   </property>
+  </action>
+  <action name="actionViewCurrentLog">
+   <property name="text">
+    <string>Basic.MainMenu.Help.Logs.ViewCurrentLog</string>
    </property>
   </action>
   <action name="actionUndo">

--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -2111,6 +2111,22 @@ void OBSBasic::on_actionUploadLastLog_triggered()
 	UploadLog(App()->GetLastLog());
 }
 
+void OBSBasic::on_actionViewCurrentLog_triggered()
+{
+	char logDir[512];
+	if (os_get_config_path(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
+		return;
+
+	const char* log = App()->GetCurrentLog();
+
+	string path = (char*)logDir;
+	path += "/";
+	path += log;
+
+	QUrl url = QUrl::fromLocalFile(QT_UTF8(path.c_str()));
+	QDesktopServices::openUrl(url);
+}
+
 void OBSBasic::on_actionCheckForUpdates_triggered()
 {
 	CheckForUpdates();

--- a/obs/window-basic-main.hpp
+++ b/obs/window-basic-main.hpp
@@ -238,6 +238,7 @@ private slots:
 	void on_actionShowLogs_triggered();
 	void on_actionUploadCurrentLog_triggered();
 	void on_actionUploadLastLog_triggered();
+	void on_actionViewCurrentLog_triggered();
 	void on_actionCheckForUpdates_triggered();
 
 	void on_actionEditTransform_triggered();


### PR DESCRIPTION
Since the file being logged to changes with each run, opening a log file is a tad more involved than desirable when it's necessary to view the log each time OBS is run. This new menu entry shortcuts opening the file from the file system manually.

I'm only able to test this on Windows. Please let me know if I missed anything.
Do I need to create stubs in the various locale ini files?