### PR TITLE
linux-v4l2: Fix string for translation

### DIFF
--- a/plugins/linux-v4l2/data/locale/en-US.ini
+++ b/plugins/linux-v4l2/data/locale/en-US.ini
@@ -1,7 +1,7 @@
 V4L2Input="Video Capture Device (V4L2)"
 Device="Device"
 Input="Input"
-ImageFormat="Video Format"
+VideoFormat="Video Format"
 VideoStandard="Video Standard"
 DVTiming="DV Timing"
 Resolution="Resolution"


### PR DESCRIPTION
Changed "ImageFormat" for "VideoFormat"
(checked in v4l2-input.c)