### PR TITLE
Correct Fedora compile/install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -151,9 +151,10 @@ Linux (Manually compiling on Redhat-based distros such as Fedora)
         git clone https://github.com/jp9000/obs-studio.git
         cd obs-studio
         mkdir build && cd build
-        cmake -DUNIX_STRUCTURE=1 ..
+        cmake -DUNIX_STRUCTURE=1 -DCMAKE_INSTALL_PREFIX=/usr ..
         make -j4
         sudo make install
+        sudo ldconfig
 
 
 Linux (Manually compiling on Debian-based distros)


### PR DESCRIPTION
With the current Fedora instructions, libobs cannot be found. Thus, the application doesn't run. This adds the necessary compile/install steps to successfully compile and run obs-studio on Fedora 21.

The changes are based on:
http://www.xpd259.co.uk/2014/11/building-open-broadcast-software-on.html