### PR TITLE
ffmpeg: Use default video path

### DIFF
--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -440,6 +440,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_string(basicConfig, "AdvOut", "RecEncoder",
 			"none");
 
+	config_set_default_string(basicConfig, "AdvOut", "FFURL",
+			(GetDefaultVideoSavePath() + "/out.mkv").c_str());
 	config_set_default_uint  (basicConfig, "AdvOut", "FFVBitrate", 2500);
 	config_set_default_bool  (basicConfig, "AdvOut", "FFUseRescale",
 			false);


### PR DESCRIPTION
"File path" may be confusing as everything else uses a directory. If no
previous value is saved, initialize the feild with the default video
path and a filename.mkv. This way it is clear obs expects a filename
with extension.