### PR TITLE
Buildfix for older FFmpeg versions (F20 RPMFusion)

### DIFF
--- a/deps/libff/libff/ff-util.c
+++ b/deps/libff/libff/ff-util.c
@@ -251,6 +251,7 @@ static inline bool is_output_device(const AVClass *avclass)
 	if (!avclass)
 		return 0;
 
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(52, 66, 101)
 	switch (avclass->category) {
 	case AV_CLASS_CATEGORY_DEVICE_VIDEO_OUTPUT:
 	case AV_CLASS_CATEGORY_DEVICE_AUDIO_OUTPUT:
@@ -259,6 +260,9 @@ static inline bool is_output_device(const AVClass *avclass)
 	default:
 		return false;
 	}
+#else
+	return (avclass->category == AV_CLASS_CATEGORY_OUTPUT);
+#endif
 }
 
 const struct ff_format_desc *ff_format_supported()

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -404,8 +404,10 @@ static obs_properties_t *ffmpeg_source_getproperties(void *data)
 			AVDISCARD_NONREF);
 	obs_property_list_add_int(prop, obs_module_text("DiscardBiDir"),
 			AVDISCARD_BIDIR);
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(55, 67, 100)
 	obs_property_list_add_int(prop, obs_module_text("DiscardNonIntra"),
 			AVDISCARD_NONINTRA);
+#endif
 	obs_property_list_add_int(prop, obs_module_text("DiscardNonKey"),
 			AVDISCARD_NONKEY);
 	obs_property_list_add_int(prop, obs_module_text("DiscardAll"),


### PR DESCRIPTION
This adds a couple version checks to some of the FFmpeg-related files to allow building with Fedora 20's FFmpeg version (from RPMFusion).

Related FFmpeg commits/versions:

https://github.com/FFmpeg/FFmpeg/commit/19b3a25048d956622ebcc26b722a0a5c5155553f
https://github.com/FFmpeg/FFmpeg/commit/b152152df3b778d0a86dcda5d4f5d065b4175a7b