### PR TITLE
Add $HOME/.obs-plugins as default module search dir on Linux

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -51,8 +51,23 @@ static const int module_patterns_size =
 
 void add_default_module_paths(void)
 {
+	char bin[512];
+	char data[512];
+	int ret;
+
 	for (int i = 0; i < module_patterns_size; i++)
 		obs_add_module_path(module_bin[i], module_data[i]);
+
+	ret = os_get_config_path(bin, sizeof(bin), "obs-plugins/%module%");
+	if (ret <= 0)
+		return;
+
+	strcpy(data, bin);
+	strcat(data, "/data");
+
+	strcat(bin, "/bin/");
+
+	obs_add_module_path(bin, data);
 }
 
 /*


### PR DESCRIPTION
This makes obs look for user modules in $HOME/.obs-plugins on Linux.
