### PR TITLE
Check AV_CODEC_ID_H264 is actually libx264

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -150,7 +150,7 @@ static bool open_video_codec(struct ffmpeg_data *data)
 	char **opts = strlist_split(data->config.video_settings, ' ', false);
 	int ret;
 
-	if (data->vcodec->id == AV_CODEC_ID_H264 && data->vcodec->name == "libx264")
+	if (!strcmp(data->vcodec->name, "libx264"))
 		av_opt_set(context->priv_data, "preset", "veryfast", 0);
 
 	if (opts) {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -150,7 +150,7 @@ static bool open_video_codec(struct ffmpeg_data *data)
 	char **opts = strlist_split(data->config.video_settings, ' ', false);
 	int ret;
 
-	if (data->vcodec->id == AV_CODEC_ID_H264)
+	if (data->vcodec->id == AV_CODEC_ID_H264 && data->vcodec->name == "libx264")
 		av_opt_set(context->priv_data, "preset", "veryfast", 0);
 
 	if (opts) {


### PR DESCRIPTION
We need to be sure that we're using libx264 before we pass presets specific to libx264.

libx264 is not the only codec in ffmpeg with the id AV_CODEC_ID_H264 (nvenc and others, for example, share this id because they use h264)

Here we check both the ID and NAME of the codec before applying the preset so we dont encounter "Invalid argument" errors when using other H264 encoders that don't have the same presets.