### PR TITLE
linux-v4l2: Fix compile error for missing formats

### DIFF
--- a/plugins/linux-v4l2/v4l2-helpers.h
+++ b/plugins/linux-v4l2/v4l2-helpers.h
@@ -63,8 +63,12 @@ static inline enum video_format v4l2_to_obs_video_format(uint_fast32_t format)
 	case V4L2_PIX_FMT_NV12:   return VIDEO_FORMAT_NV12;
 	case V4L2_PIX_FMT_YUV420: return VIDEO_FORMAT_I420;
 	case V4L2_PIX_FMT_YVU420: return VIDEO_FORMAT_I420;
+#ifdef V4L2_PIX_FMT_XBGR32
 	case V4L2_PIX_FMT_XBGR32: return VIDEO_FORMAT_BGRX;
+#endif
+#ifdef V4L2_PIX_FMT_ABGR32
 	case V4L2_PIX_FMT_ABGR32: return VIDEO_FORMAT_BGRA;
+#endif
 	default:                  return VIDEO_FORMAT_NONE;
 	}
 }


### PR DESCRIPTION
Add ifdefs around the video format definitions in order to allow for
compilation with older kernel headers that don't yet have those defined.