### PR TITLE
linux-v4l2: Build fixes for older versions

### DIFF
--- a/plugins/linux-v4l2/v4l2-helpers.c
+++ b/plugins/linux-v4l2/v4l2-helpers.c
@@ -240,6 +240,12 @@ int_fast32_t v4l2_set_standard(int_fast32_t dev, int *standard)
 int_fast32_t v4l2_enum_dv_timing(int_fast32_t dev, struct v4l2_dv_timings *dvt,
 		int index)
 {
+#ifndef VIDIOC_ENUM_DV_TIMINGS
+	UNUSED_PARAMETER(dev);
+	UNUSED_PARAMETER(dvt);
+	UNUSED_PARAMETER(index);
+	return -1;
+#else
 	if (!dev || !dvt)
 		return -1;
 
@@ -253,6 +259,7 @@ int_fast32_t v4l2_enum_dv_timing(int_fast32_t dev, struct v4l2_dv_timings *dvt,
 	memcpy(dvt, &iter.timings, sizeof(struct v4l2_dv_timings));
 
 	return 0;
+#endif
 }
 
 int_fast32_t v4l2_set_dv_timing(int_fast32_t dev, int *timing)

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -41,6 +41,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "v4l2-udev.h"
 #endif
 
+/* The new dv timing api was introduced in Linux 3.4
+ * Currently we simply disable dv timings when this is not defined */
+#ifndef VIDIOC_ENUM_DV_TIMINGS
+#define V4L2_IN_CAP_DV_TIMINGS 0
+#endif
+
 #define V4L2_DATA(voidptr) struct v4l2_data *data = voidptr;
 
 #define timeval2ns(tv) \
@@ -932,6 +938,9 @@ static void *v4l2_create(obs_data_t *settings, obs_source_t *source)
 	/* Bitch about build problems ... */
 #ifndef V4L2_CAP_DEVICE_CAPS
 	blog(LOG_WARNING, "Plugin built without device caps support!");
+#endif
+#ifndef VIDIOC_ENUM_DV_TIMINGS
+	blog(LOG_WARNING, "Plugin built without dv-timing support!");
 #endif
 
 	v4l2_update(data, settings);

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -298,9 +298,14 @@ static void v4l2_device_list(obs_property_t *prop, obs_data_t *settings)
 			continue;
 		}
 
+#ifndef V4L2_CAP_DEVICE_CAPS
+		caps = video_cap.capabilities;
+#else
+		/* ... since Linux 3.3 */
 		caps = (video_cap.capabilities & V4L2_CAP_DEVICE_CAPS)
 			? video_cap.device_caps
 			: video_cap.capabilities;
+#endif
 
 		if (!(caps & V4L2_CAP_VIDEO_CAPTURE)) {
 			blog(LOG_INFO, "%s seems to not support video capture",
@@ -923,6 +928,11 @@ static void *v4l2_create(obs_data_t *settings, obs_source_t *source)
 	struct v4l2_data *data = bzalloc(sizeof(struct v4l2_data));
 	data->dev = -1;
 	data->source = source;
+
+	/* Bitch about build problems ... */
+#ifndef V4L2_CAP_DEVICE_CAPS
+	blog(LOG_WARNING, "Plugin built without device caps support!");
+#endif
 
 	v4l2_update(data, settings);
 


### PR DESCRIPTION
Improve compatibility of the plugin with older versions of the linux headers. This will most notably allow for the plugin to compile on debian 7.8 which unfortunately ships very old linux headers.