### PR TITLE
Visual Studio 2015 fixes

### DIFF
--- a/deps/jansson/CMakeLists.txt
+++ b/deps/jansson/CMakeLists.txt
@@ -80,6 +80,7 @@ include (CheckFunctionExists)
 include (CheckFunctionKeywords)
 include (CheckIncludeFiles)
 include (CheckTypeSize)
+include (CheckSymbolExists)
 
 
 if (MSVC)
@@ -221,8 +222,8 @@ else (HAVE_INLINE)
 endif (HAVE_INLINE)
 
 # Find our snprintf
-check_function_exists (snprintf HAVE_SNPRINTF)
-check_function_exists (_snprintf HAVE__SNPRINTF)
+check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
+check_symbol_exists(_snprintf "stdio.h" HAVE__SNPRINTF)
 
 if (HAVE_SNPRINTF)
    set (JSON_SNPRINTF snprintf)

--- a/deps/w32-pthreads/pthread.h
+++ b/deps/w32-pthreads/pthread.h
@@ -205,6 +205,10 @@
 typedef unsigned long DWORD_PTR;
 typedef unsigned long ULONG_PTR;
 #endif
+
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+#define HAVE_STRUCT_TIMESPEC
+#endif
 /*
  * -----------------
  * autoconf switches

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -450,10 +450,6 @@ static inline void from_locale(char *buffer)
 		*pos = '.';
 }
 
-#ifdef _WIN32
-#define snprintf _snprintf
-#endif
-
 double os_strtod(const char *str)
 {
 	char buf[64];

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -137,6 +137,9 @@ EXPORT int os_mkdir(const char *path);
 
 #ifdef _MSC_VER
 #define strtoll _strtoi64
+#if _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/obs/obs-app.cpp
+++ b/obs/obs-app.cpp
@@ -38,7 +38,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #else
 #include <signal.h>
 #endif


### PR DESCRIPTION
Fixes some build and runtime issues with obs-studio and dependencies when built with Visual Studio 2015 RC.

Running obs-studio had some issues while saving and loading JSON config files, which had missing values or garbage written over the integer and real values. This was caused by sprintf checks in CMake configuration file, which failed thanks to Microsoft's new CRT changes.

Should be also noted that building Qt projects with VS2015 is not officially supported, so a temporary workaround to build the solution is to set Platform Toolset for 'obs' project to VS2013. Proper VS2015 support is getting added to Qt 5.5.