### PR TITLE
libobs: Implement logging cpu model on bsd

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -81,6 +81,12 @@ char *find_libobs_data_file(const char *file)
 	return NULL;
 }
 
+static void log_processor_cores(void)
+{
+	blog(LOG_INFO, "Processor: %lu logical cores",
+	     sysconf(_SC_NPROCESSORS_ONLN));
+}
+
 static void log_processor_info(void)
 {
 	FILE *fp;
@@ -89,9 +95,6 @@ static void log_processor_info(void)
 	char *line = NULL;
 	size_t linecap = 0;
 	struct dstr processor;
-
-	blog(LOG_INFO, "Processor: %lu logical cores",
-	     sysconf(_SC_NPROCESSORS_ONLN));
 
 	fp = fopen("/proc/cpuinfo", "r");
 	if (!fp)
@@ -191,6 +194,7 @@ static void log_distribution_info(void)
 
 void log_system_info(void)
 {
+	log_processor_cores();
 	log_processor_info();
 	log_memory_info();
 	log_kernel_version();

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -16,10 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#ifdef __FreeBSD__
-#define _WITH_GETLINE
-#endif
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -174,6 +174,7 @@ static void log_kernel_version(void)
 	blog(LOG_INFO, "Kernel Version: %s %s", info.sysname, info.release);
 }
 
+#if defined(__linux__)
 static void log_distribution_info(void)
 {
 	FILE *fp;
@@ -216,6 +217,7 @@ static void log_distribution_info(void)
 	dstr_free(&distro);
 	free(line);
 }
+#endif
 
 void log_system_info(void)
 {
@@ -225,5 +227,7 @@ void log_system_info(void)
 #endif
 	log_memory_info();
 	log_kernel_version();
+#if defined(__linux__)
 	log_distribution_info();
+#endif
 }


### PR DESCRIPTION
These patches clean up the system information logging for linux/bsd.
* Add bsd specific implementation for logging the cpu model
* Make distribution information linux only