### PR TITLE
Fix required packages for Fedora

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -158,7 +158,7 @@ Linux (Manually compiling on Redhat-based distros such as Fedora)
 	sudo yum install libX11-devel libGL-devel ffmpeg-devel libv4l-devel \
                 pulseaudio-libs-devel x264-devel freetype-devel \
                 fontconfig-devel libXcomposite-devel libXinerama-devel \
-                qt5-qtbase-devel qt5-qtx11extras-devel
+                qt5-qtbase-devel qt5-qtx11extras-devel libcurl-devel
 
   - Building and installing OBS:
 


### PR DESCRIPTION
Tried to build on Fedora 21, complained about missing libcurl-devel.