### PR TITLE
libcurl-dev added for debian compile guide

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -196,7 +196,7 @@ Linux (Manually compiling on Debian-based distros)
         sudo apt-get install libx11-dev libgl-dev libpulse-dev libxcomposite-dev \
                 libxinerama-dev libv4l-dev libudev-dev libfreetype6-dev \
                 libfontconfig-dev qtbase5-dev libqt5x11extras5-dev libx264-dev \
-                libxcb-xinerama0-dev libxcb-shm0-dev libjack-jackd2-dev
+                libxcb-xinerama0-dev libxcb-shm0-dev libjack-jackd2-dev libcurl-dev
 
   - Building and installing OBS:
 


### PR DESCRIPTION
Add libcurl-dev to required -dev packages for debian guide.

Recently libcurl was added as a required dependency, but it was not updated for the debian install instructions.