### PR TITLE
only write scenes.json when contents has changed

### DIFF
--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -259,13 +259,9 @@ void OBSBasic::Save(const char *file)
 	const char *jsonData = obs_data_get_json(saveData);
 
 	if (!!jsonData) {
-		bool shouldWrite = true;
 		const char *oldJsonData = os_quick_read_utf8_file(file);
-		if (oldJsonData && strcmp(jsonData, oldJsonData) == 0) {
-			shouldWrite = false;
-		}
 
-		if (shouldWrite) {
+		if (!oldJsonData || strcmp(jsonData, oldJsonData) != 0) {
 			/* TODO: maybe a message box here? */
 			bool success = os_quick_write_utf8_file(file, jsonData,
 				strlen(jsonData), false);

--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -259,12 +259,20 @@ void OBSBasic::Save(const char *file)
 	const char *jsonData = obs_data_get_json(saveData);
 
 	if (!!jsonData) {
-		/* TODO: maybe a message box here? */
-		bool success = os_quick_write_utf8_file(file, jsonData,
+		bool shouldWrite = true;
+		const char *oldJsonData = os_quick_read_utf8_file(file);
+		if (oldJsonData && strcmp(jsonData, oldJsonData) == 0) {
+			shouldWrite = false;
+		}
+
+		if (shouldWrite) {
+			/* TODO: maybe a message box here? */
+			bool success = os_quick_write_utf8_file(file, jsonData,
 				strlen(jsonData), false);
-		if (!success)
-			blog(LOG_ERROR, "Could not save scene data to %s",
-					file);
+			if (!success)
+				blog(LOG_ERROR, "Could not save scene data to %s",
+				file);
+		}
 	}
 
 	obs_data_release(saveData);


### PR DESCRIPTION
Right now the `scenes.json` is written to disc every 20 (or so) seconds. Regardless of whether the content has changed or not. Since I'm syncing my settings with `ownCloud` I get a lot of needless sync operations.

I reported this already on Mantis (https://obsproject.com/mantis/view.php?id=207).

This behavior was bothering me quite a lot, so I made this PR.

In this PR I changed `OBSBasic::Save()` to only save files if the content would change (by reading the file and comparing both strings). Please keep in mind that I have no recent experience with C or C++ development, so my changes might break stuff. Although I have been running a self-compiled version of `obs-studio ` with this change for about a week now without any problems.

If this PR breaks stuff or is not up to (your) established C/C++ coding standards please consider adding this behavior yourself or tell me what needs to be changed so the PR will be accepted.

Thank You!