### PR TITLE
rtmp-services: Update Twitch Ingests to Include South America

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -55,6 +55,14 @@
                 "url": "rtmp://live-arn.twitch.tv/app"
             },
             {
+                "name": "South America: Rio de Janeiro, Brazil",
+                "url": "rtmp://live-gig.twitch.tv/app"
+            },
+            {
+                "name": "South America: Sao Paulo, Brazil",
+                "url": "rtmp://live-gru.twitch.tv/app"
+            },
+            {
                 "name": "US Central: Dallas, TX",
                 "url": "rtmp://live-dfw.twitch.tv/app"
             },


### PR DESCRIPTION
You should really auto-update these lists from Twitch API.