### PR TITLE
fix for musl-libc

### DIFF
--- a/libobs/util/threading-posix.c
+++ b/libobs/util/threading-posix.c
@@ -267,7 +267,7 @@ void os_set_thread_name(const char *name)
 	pthread_setname_np(name);
 #elif defined(__FreeBSD__)
 	pthread_set_name_np(pthread_self(), name);
-#elif !defined(__MINGW32__)
+#elif defined(__GLIBC__)
 	pthread_setname_np(pthread_self(), name);
 #endif
 }


### PR DESCRIPTION
musl does not provide pthread_setname_np. the last "catch-all" case in os_set_thread_name was changed to explicitly using __GLIBC__. if something else is missing now, it should be easy to add again.