### PR TITLE
rtmp-services: Add recommended video bitrate for Beam.pro

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -290,7 +290,10 @@
                 "name": "Australia: Melbourne",
                 "url": "rtmp://ingest.mel01.beam.pro/beam"
             }
-        ]
+        ],
+        "recommended": {
+            "max video bitrate": 3500
+        }
     },
     {
         "name": "connectcast.tv",


### PR DESCRIPTION
Beam.pro doesn't allow more than 3500 Kbps. If you stream with more they will just disconnect you.