### PR TITLE
rtmp-services: Add recommended video bitrate for Livecoding.tv

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -206,7 +206,10 @@
                 "name": "Primary",
                 "url": "rtmp://usmedia3.livecoding.tv/livecodingtv"
             }
-        ]
+        ],
+        "recommended": {
+            "max video bitrate": 1300
+        }
     },
     {
         "name": "Vaughn Live / iNSTAGIB.tv",


### PR DESCRIPTION
Livecoding.tv terminates streams with more than 1300 Kbps bitrate.

Source: https://www.livecoding.tv/support/#why-does-livecodingtv-terminate-streams-rates-above-13mbps