### PR TITLE
deps-libff: Fix stack corruption in ff_demuxer_reset

### DIFF
--- a/deps/libff/libff/ff-clock.c
+++ b/deps/libff/libff/ff-clock.c
@@ -90,9 +90,9 @@ bool ff_clock_start(struct ff_clock *clock, enum ff_av_sync_type sync_type,
 	return !release && !aborted;
 }
 
-struct ff_clock *ff_clock_init(struct ff_clock *clock)
+struct ff_clock *ff_clock_init()
 {
-	clock = av_mallocz(sizeof(struct ff_clock));
+	struct ff_clock *clock = av_mallocz(sizeof(struct ff_clock));
 
 	if (clock == NULL)
 		return NULL;


### PR DESCRIPTION
ff_clock_init expects a parameter with a pointer where it stores the
address of the newly allocated ff_clock, but ff_demuxer_reset does not
provide this parameter. That somehow writes the pointer to the ff_clock
into the packet->base->buf field on the stack of the ff_demuxer_reset
function. This later causes a segmentation fault when the packet is freed.

### On master
```
Breakpoint 1, ff_demuxer_reset (demuxer=0x860aaa0) at /home/reboot/devel/obs/obs-studio/deps/libff/libff/ff-demuxer.c:335
335		struct ff_packet packet = {0};
(gdb) n
336		struct ff_clock *clock = ff_clock_init();
(gdb) print &packet
$26 = (struct ff_packet *) 0xa91c91c0
(gdb) print packet
$27 = {base = {buf = 0x0, pts = 0, dts = 0, data = 0x0, size = 0, stream_index = 0, flags = 0, side_data = 0x0, side_data_elems = 0, duration = 0, destruct = 0x0, 
	priv = 0x0, pos = 0, convergence_duration = 0}, clock = 0x0}
(gdb) n
337		clock->sync_type = demuxer->clock.sync_type;
(gdb) print &packet
$28 = (struct ff_packet *) 0xa91c91c0
(gdb) print packet
$29 = {base = {buf = 0xa88073a0, pts = 0, dts = 0, data = 0x0, size = 0, stream_index = 0, flags = 0, side_data = 0x0, side_data_elems = 0, duration = 0, 
	destruct = 0x0, priv = 0x0, pos = 0, convergence_duration = 0}, clock = 0x0}
(gdb) print clock
$30 = (struct ff_clock *) 0xa88073a0
```

### With fix_libff_stack_corruption
```
Breakpoint 1, ff_demuxer_reset (demuxer=0x860aac0) at /home/reboot/devel/obs/obs-studio/deps/libff/libff/ff-demuxer.c:335
335		struct ff_packet packet = {0};
(gdb) n     
336		struct ff_clock *clock = ff_clock_init();
(gdb) print packet
$1 = {base = {buf = 0x0, pts = 0, dts = 0, data = 0x0, size = 0, stream_index = 0, flags = 0, side_data = 0x0, side_data_elems = 0, duration = 0, destruct = 0x0, 
    priv = 0x0, pos = 0, convergence_duration = 0}, clock = 0x0}
(gdb) n
[New Thread 0xa68f7b40 (LWP 19116)]
337		clock->sync_type = demuxer->clock.sync_type;
(gdb) print packet
$2 = {base = {buf = 0x0, pts = 0, dts = 0, data = 0x0, size = 0, stream_index = 0, flags = 0, side_data = 0x0, side_data_elems = 0, duration = 0, destruct = 0x0, 
    priv = 0x0, pos = 0, convergence_duration = 0}, clock = 0x0}
```