### PR TITLE
obs-outputs: Fix crash with quit while connecting

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -98,7 +98,7 @@ static void rtmp_stream_destroy(void *data)
 {
 	struct rtmp_stream *stream = data;
 
-	if (stream->active)
+	if (stream->connecting || stream->active)
 		rtmp_stream_stop(data);
 
 	if (stream) {


### PR DESCRIPTION
We need to stop the stream even if it hasn't finished opening yet,
to make sure threads are cleaned up properly.

This fixes https://obsproject.com/mantis/view.php?id=163