### PR TITLE
Fixes for Authenticated RTMP streams

### DIFF
--- a/plugins/obs-outputs/librtmp/parseurl.c
+++ b/plugins/obs-outputs/librtmp/parseurl.c
@@ -177,6 +177,9 @@ void RTMP_ParsePlaypath(AVal *in, AVal *out)
     out->av_val = NULL;
     out->av_len = 0;
 
+    if (!playpath)
+        return;
+
     if ((*ppstart == '?') &&
             (temp=strstr(ppstart, "slist=")) != 0)
     {

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -633,16 +633,13 @@ int RTMP_SetupURL(RTMP *r, char *url)
 int RTMP_AddStream(RTMP *r, const char *playpath)
 {
     int idx = -1;
+    AVal pp = { (char*)playpath, playpath?(int)strlen(playpath):0 };
 
-    if (playpath && *playpath)
-    {
-        AVal pp = {(char*)playpath, (int)strlen(playpath)};
-        RTMP_ParsePlaypath(&pp, &r->Link.streams[r->Link.nStreams].playpath);
-        r->Link.streams[r->Link.nStreams].id = -1;
+    RTMP_ParsePlaypath(&pp, &r->Link.streams[r->Link.nStreams].playpath);
+    r->Link.streams[r->Link.nStreams].id = -1;
 
-        idx = r->Link.nStreams;
-        r->Link.nStreams++;
-    }
+    idx = r->Link.nStreams;
+    r->Link.nStreams++;
 
     return idx;
 }

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -4221,14 +4221,17 @@ RTMP_Close(RTMP *r)
     }
 
 #if defined(CRYPTO) || defined(USE_ONLY_MD5)
-    for (int idx = 0; idx < r->Link.nStreams; idx++)
+    if (!(r->Link.protocol & RTMP_FEATURE_WRITE) || (r->Link.pFlags & RTMP_PUB_CLEAN))
     {
-        free(r->Link.streams[idx].playpath.av_val);
-        r->Link.streams[idx].playpath.av_val = NULL;
-    }
+        for (int idx = 0; idx < r->Link.nStreams; idx++)
+        {
+            free(r->Link.streams[idx].playpath.av_val);
+            r->Link.streams[idx].playpath.av_val = NULL;
+        }
 
-    r->Link.curStreamIdx = 0;
-    r->Link.nStreams = 0;
+        r->Link.curStreamIdx = 0;
+        r->Link.nStreams = 0;
+    }
 
     if ((r->Link.protocol & RTMP_FEATURE_WRITE) &&
             (r->Link.pFlags & RTMP_PUB_CLEAN) &&

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -2365,11 +2365,19 @@ b64enc(const unsigned char *input, int length, char *output, int maxsize)
         return 0;
     }
 #elif defined(USE_ONLY_MD5)
-    base64_encodestate state;
+    if ((((length + 2) / 3) * 4) <= maxsize)
+    {
+        base64_encodestate state;
 
-    base64_init_encodestate(&state);
-    output += base64_encode_block((const char *)input, length, output, &state);
-    base64_encode_blockend(output, &state);
+        base64_init_encodestate(&state);
+        output += base64_encode_block((const char *)input, length, output, &state);
+        base64_encode_blockend(output, &state);
+    }
+    else
+    {
+        RTMP_Log(RTMP_LOGDEBUG, "%s, error", __FUNCTION__);
+        return 0;
+    }
 
 #else   /* USE_OPENSSL */
     BIO *bmem, *b64;

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -394,6 +394,7 @@ static int try_connect(struct rtmp_stream *stream)
 
 	info("Connecting to RTMP URL %s...", stream->path.array);
 
+	memset(&stream->rtmp.Link, 0, sizeof(stream->rtmp.Link));
 	if (!RTMP_SetupURL(&stream->rtmp, stream->path.array))
 		return OBS_OUTPUT_BAD_PATH;
 


### PR DESCRIPTION
This fixes all the problems I can find with authenticated streams hanging in the "Connecting" state.
If I need to make *any* changes to these commits, I will thoroughly test them again.
I have tested:
 1) connecting to the server
 2) Reconnecting to the server
 3) Connecting with a blank stream key
 4) Attempting to connect with invalid credentials