### PR TITLE
Doesn't need to loop on the height value

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -472,12 +472,8 @@ static inline void copy_rgbx_frame(
 {
 	uint8_t *in_ptr = input->data[0];
 	uint8_t *out_ptr = output->data[0];
-
-	for (size_t y = 0; y < info->height; y++) {
-		memcpy(out_ptr, in_ptr, info->width * 4);
-		in_ptr += input->linesize[0];
-		out_ptr += output->linesize[0];
-	}
+	
+	memcpy(out_ptr, in_ptr, info->width * info->height * 4);
 }
 
 static inline void output_video_data(struct obs_core_video *video,


### PR DESCRIPTION
copy_rgbx_frame: Just shot one memcpy() instead of looping through the height value.