### PR TITLE
change SOVERSION to match VERSION

### DIFF
--- a/libobs-opengl/CMakeLists.txt
+++ b/libobs-opengl/CMakeLists.txt
@@ -87,7 +87,7 @@ set_target_properties(libobs-opengl
 	PROPERTIES
 		OUTPUT_NAME obs-opengl
 		VERSION 0.0
-		SOVERSION 0
+		SOVERSION 0.0
 		)
 endif()
 


### PR DESCRIPTION
changed SOVERSION from 0 to 0.0 - otherwise obs-studio crashes at startup because it wants to import a library which isn't on the filesystem