### PR TITLE
Continue capturing windows after they are closed and reopened.

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -274,7 +274,7 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 		const char *windowName = obs_data_get_string(settings,
 				"capture_window");
 
-        p->windowName = windowName;
+		p->windowName = windowName;
 		p->win = getWindowFromString(windowName);
 
 		p->cut_top = obs_data_get_int(settings, "cut_top");

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -106,7 +106,8 @@ void XCompcapMain::defaults(obs_data_t *settings)
 struct XCompcapMain_private
 {
 	XCompcapMain_private()
-		:win(0)
+		:windowName("")
+		,win(0)
 		,cut_top(0), cur_cut_top(0)
 		,cut_left(0), cur_cut_left(0)
 		,cut_right(0), cur_cut_right(0)
@@ -132,6 +133,7 @@ struct XCompcapMain_private
 
 	obs_source_t *source;
 
+	std::string windowName;
 	Window win;
 	int cut_top, cur_cut_top;
 	int cut_left, cur_cut_left;
@@ -272,6 +274,7 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 		const char *windowName = obs_data_get_string(settings,
 				"capture_window");
 
+        p->windowName = windowName;
 		p->win = getWindowFromString(windowName);
 
 		p->cut_top = obs_data_get_int(settings, "cut_top");
@@ -455,6 +458,20 @@ void XCompcapMain::tick(float seconds)
 
 	if (XCompcap::windowWasReconfigured(p->win))
 		updateSettings(0);
+
+	XErrorLock xlock;
+	xlock.resetError();
+	XWindowAttributes attr;
+	if (!XGetWindowAttributes(xdisp, p->win, &attr)) {
+		Window newWin = getWindowFromString(p->windowName);
+		if (XGetWindowAttributes(xdisp, newWin, &attr)) {
+			p->win = newWin;
+			updateSettings(0);
+			return;
+		}else{
+			return;
+		}
+	}
 
 	if (!p->tex || !p->gltex)
 		return;


### PR DESCRIPTION
Normally when you close a window when it's being captured and reopen it, it doesn't update on OBS any more. This patch fixes that behaviour.