### PR TITLE
rtmp-services: Add YouTube Gaming reference

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -118,7 +118,7 @@
             }
         },
         {
-            "name": "YouTube",
+            "name": "YouTube / YouTube Gaming",
             "common": true,
             "servers": [
                 {


### PR DESCRIPTION
YouTube Gaming is live since today (26 August 2015) and people will ask
for it.
This makes it a bit clearer that YouTube and YouTube Gaming 
(which share the same ingestion system) work with OBS MP.

I made this pull request and didn't push directly to master because I don't
know how @jp9000 handles services with the newly implemented remote
updating.