### PR TITLE
rtmp-services: Update Hitbox servers list

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -154,6 +154,10 @@
                     "url": "rtmp://live.cdg.hitbox.tv/push"
                 },
                 {
+                    "name": "EU-East: Vienna, Austria",
+                    "url": "rtmp://live.vie.hitbox.tv/push"
+                },
+                {
                     "name": "EU-North: London, United Kingdom",
                     "url": "rtmp://live.lhr.hitbox.tv/push"
                 },


### PR DESCRIPTION
Added: EU-East (Vienna, Austria)