### PR TITLE
Capture BMI Intensity Pro 4K video

### DIFF
--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -8,6 +8,7 @@ protected:
 	struct obs_source_audio currentPacket;
 	DeckLink                *decklink = nullptr;
 	DeckLinkDevice          *device = nullptr;
+	bool                    doRgb = false;
 	DeckLinkDeviceMode      *mode = nullptr;
 	ComPtr<IDeckLinkInput>  input;
 	volatile long           refCount = 1;


### PR DESCRIPTION
This detects the device type (by name, bleh) when initializing the device instance and determines whether to capture YUV (previous cards) or RGB (Pro 4K, perhaps others?).

Please review.