### PR TITLE
Clean up Intensity Pro 4K commit a bit

### DIFF
--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -17,10 +17,10 @@ DeckLinkDeviceInstance::DeckLinkDeviceInstance(DeckLink *decklink_,
 	// implement BMDDeckLinkPersistentID
 	if (std::string("Intensity Pro 4K").compare(device_->GetName()) == 0) {
 		currentFrame.format = VIDEO_FORMAT_BGRX;
-		doRgb = true;
+		pixelFormat = bmdFormat8BitBGRA;
 	} else {
 		currentFrame.format = VIDEO_FORMAT_UYVY;
-		doRgb = false;
+		pixelFormat = bmdFormat8BitYUV;
 	}
 
 	currentPacket.samples_per_sec = 48000;
@@ -91,13 +91,7 @@ bool DeckLinkDeviceInstance::StartCapture(DeckLinkDeviceMode *mode_)
 
 	input->SetCallback(this);
 
-	BMDPixelFormat pixelFormat;
 	const BMDDisplayMode displayMode = mode_->GetDisplayMode();
-
-	if (doRgb)
-		pixelFormat = bmdFormat8BitBGRA;
-	else
-		pixelFormat = bmdFormat8BitYUV;
 
 	const HRESULT videoResult = input->EnableVideoInput(displayMode,
 			pixelFormat, bmdVideoInputFlagDefault);

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -8,8 +8,8 @@ protected:
 	struct obs_source_audio currentPacket;
 	DeckLink                *decklink = nullptr;
 	DeckLinkDevice          *device = nullptr;
-	bool                    doRgb = false;
 	DeckLinkDeviceMode      *mode = nullptr;
+	BMDPixelFormat          pixelFormat = bmdFormat8BitYUV;
 	ComPtr<IDeckLinkInput>  input;
 	volatile long           refCount = 1;
 


### PR DESCRIPTION
decklink: detect BMDPixelFormat in instance constructor
cleaning up my previous commit a bit. we can just keep the
appropriate BMDPixelFormat as a data member and keep StartCapture() a
bit clearer.

this might also be helpful if (when?) the detection code needs to be
more robust or configurable