### PR TITLE
rtmp-services: Update vaughn / instagib ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 1,
+	"version": 2,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 1
+			"version": 2
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -354,10 +354,6 @@
                 {
                     "name": "US: New York 2, NY",
                     "url": "rtmp://live-nyc2.vaughnsoft.net:443/live"
-                },
-                {
-                    "name": "EU: Amsterdam, NL",
-                    "url": "rtmp://live-nl.vaughnsoft.net:443/live"
                 }
             ]
         },


### PR DESCRIPTION
Amsterdam Server got removed.

![28-09-2015_17 04 35](https://cloud.githubusercontent.com/assets/5058319/10139413/09ae8b9e-6603-11e5-883f-ee1dd16a86c5.png)
