### PR TITLE
UI: Add checkbox for visibility of new scene items

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -157,6 +157,7 @@ Basic.Main.PreviewDisabled="Preview is currently disabled"
 Basic.SourceSelect="Create/Select Source"
 Basic.SourceSelect.CreateNew="Create new"
 Basic.SourceSelect.AddExisting="Add Existing"
+Basic.SourceSelect.AddVisible="Make source visible"
 
 # properties window
 Basic.PropertiesWindow="Properties for '%1'"

--- a/obs/forms/OBSBasicSourceSelect.ui
+++ b/obs/forms/OBSBasicSourceSelect.ui
@@ -49,6 +49,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="sourceVisible">
+       <property name="text">
+        <string>Basic.SourceSelect.AddVisible</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
Adds a checkbox to the "Create/Select source" dialog that lets the user choose if the source should be visible after it has been added to the scene. This is sometimes needed because some sources like the Linux window capture source initially capture the first available window, which you may not want to show on an active stream. It is also useful to position a source before you make it visible.