### PR TITLE
rtmp-services: Remove unnecessary iNSTAGIB.tv entry

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 3,
+	"version": 4,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 3
+			"version": 4
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -392,15 +392,6 @@
             ]
         },
         {
-            "name": "iNSTAGIB.tv",
-            "servers": [
-                {
-                    "name": "US Chicago (Primary)",
-                    "url": "rtmp://live.instagib.tv:443/live"
-                }
-            ]
-        },
-        {
             "name": "CyberGame.TV",
             "servers": [
                 {


### PR DESCRIPTION
iNSTAGIB.tv and Vaughn Live share the same ingestion system. Having
this entry is therefore unnecessary.

Both live.instagib.tv and live.vaughnsoft.net resolve also to the same 
addresses.
Also iNSTAGIB.tv tells you to use the Vaughn Live Ingest URLs.