### PR TITLE
Xcomposite: Log warning when unable to query windows

### DIFF
--- a/plugins/linux-capture/xcompcap-helper.cpp
+++ b/plugins/linux-capture/xcompcap-helper.cpp
@@ -47,9 +47,76 @@ namespace XCompcap
 		return res;
 	}
 
+	bool ewmhIsSupported()
+	{
+		// Specification for checking for ewmh support at
+		// http://standards.freedesktop.org/wm-spec/wm-spec-latest.html#idm140200472693600
+		Display *display = disp();
+		Atom netSupportingWmCheck = XInternAtom(display, "_NET_SUPPORTING_WM_CHECK", true);
+		Atom actualType;
+		int format = 0;
+		unsigned long num = 0, bytes = 0;
+		unsigned char *data = NULL;
+		Window ewmh_window = 0;
+
+		int status = XGetWindowProperty(
+				display,
+				DefaultRootWindow(display),
+				netSupportingWmCheck,
+				0L,
+				1L,
+				false,
+				XA_WINDOW,
+				&actualType,
+				&format,
+				&num,
+				&bytes,
+				&data);
+
+		if (status == Success) {
+			if (num > 0) {
+				ewmh_window = ((Window*)data)[0];
+			}
+			if (data) {
+				XFree(data);
+				data = NULL;
+			}
+		}
+
+		if (ewmh_window) {
+			status = XGetWindowProperty(
+					display,
+					ewmh_window,
+					netSupportingWmCheck,
+					0L,
+					1L,
+					false,
+					XA_WINDOW,
+					&actualType,
+					&format,
+					&num,
+					&bytes,
+					&data);
+			if (status != Success || num == 0 || ewmh_window != ((Window*)data)[0]) {
+				ewmh_window = 0;
+			}
+			if (status == Success && data) {
+				XFree(data);
+			}
+		}
+
+		return ewmh_window != 0;
+	}
+
 	std::list<Window> getTopLevelWindows()
 	{
 		std::list<Window> res;
+
+		if (!ewmhIsSupported()) {
+			blog(LOG_WARNING, "Unable to query windows because Window Manager "
+					"does not support Extended Window Manager Hints");
+			return res;
+		}
 
 		Atom netClList = XInternAtom(disp(), "_NET_CLIENT_LIST", true);
 		Atom actualType;

--- a/plugins/linux-capture/xcompcap-helper.hpp
+++ b/plugins/linux-capture/xcompcap-helper.hpp
@@ -67,6 +67,7 @@ namespace XCompcap
 	int getRootWindowScreen(Window root);
 	std::string getWindowName(Window win);
 	int getWindowPid(Window win);
+	bool ewmhIsSupported();
 	std::list<Window> getTopLevelWindows();
 	std::list<Window> getAllWindows();
 


### PR DESCRIPTION
Checks whether window manager supports ewmh. Logs warning if ewmh is not
supported.

I thought this might be useful to others. My window manager doesn't support ewmh by default, and the xcomposite capture module silently failed due to lack of ewmh support. While debugging the issue, I threw together the following code to log a warning if the window manager doesn't supports ewmh. This will provide more information to users who encounter the same problem as I did. It should be compliant with the spec at http://standards.freedesktop.org/wm-spec/wm-spec-latest.html#idm140200472693600