### PR TITLE
libobs: Copy property name and description

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -143,8 +143,8 @@ static inline void frame_rate_data_free(struct frame_rate_data *data)
 struct obs_properties;
 
 struct obs_property {
-	const char              *name;
-	const char              *desc;
+	char                   *name;
+	char                   *desc;
 	enum obs_property_type  type;
 	bool                    visible;
 	bool                    enabled;
@@ -221,6 +221,8 @@ static void obs_property_destroy(struct obs_property *property)
 	else if (property->type == OBS_PROPERTY_FRAME_RATE)
 		frame_rate_data_free(get_property_data(property));
 
+	bfree(property->name);
+	bfree(property->desc);
 	bfree(property);
 }
 
@@ -322,8 +324,8 @@ static inline struct obs_property *new_prop(struct obs_properties *props,
 	p->enabled = true;
 	p->visible = true;
 	p->type    = type;
-	p->name    = name;
-	p->desc    = desc;
+	p->name    = bstrdup(name);
+	p->desc    = bstrdup(desc);
 	propertes_add(props, p);
 
 	return p;
@@ -602,7 +604,10 @@ void obs_property_set_enabled(obs_property_t *p, bool enabled)
 
 void obs_property_set_description(obs_property_t *p, const char *description)
 {
-	if (p) p->desc = description;
+	if (p) {
+		bfree(p->desc);
+		p->desc = bstrdup(description);
+	}
 }
 
 const char *obs_property_name(obs_property_t *p)


### PR DESCRIPTION
Copy property name and description so that plugins don't have to
manage strings longer than necessary.