### PR TITLE
obs: bundle Qt platform plugins

### DIFF
--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -229,3 +229,24 @@ if (UNIX AND UNIX_STRUCTURE AND NOT APPLE)
 	install(FILES forms/images/obs.png
 		DESTINATION share/icons/hicolor/256x256/apps)
 endif()
+
+if(APPLE AND DEFINED ENV{FIXUP_BUNDLE})
+	foreach(plugin 
+			Qt5::QCocoaIntegrationPlugin;
+			Qt5::QMinimalIntegrationPlugin;
+			Qt5::QOffscreenIntegrationPlugin)
+		get_target_property(_qt_plugin_path ${plugin} LOCATION)
+		if(EXISTS "${_qt_plugin_path}")
+            list(APPEND _qt_plugin_paths ${_qt_plugin_path})
+			get_filename_component(_qt_plugin_file "${_qt_plugin_path}" NAME)
+			get_filename_component(_qt_plugin_type "${_qt_plugin_path}" PATH)
+			get_filename_component(_qt_plugin_type "${_qt_plugin_type}" NAME)
+			set(_qt_plugin_dest "bin/${_qt_plugin_type}")
+            install(FILES "${_qt_plugin_path}" 
+					PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ 
+					DESTINATION "${_qt_plugin_dest}")
+		else()
+			message(FATAL_ERROR "QT plugin ${_qt_plugin_name} not found")
+		endif()
+	endforeach()
+endif()


### PR DESCRIPTION
When producing myself packages for OSX 10.9, I have noticed that imageformats/platforms Qt plugins are not bundled, while it is the case for official obs-studio releases.

I'm using macports on OSX 10.9 and did set as required `export FIXUP_BUNDLE=1` before running `cmake` and `make package`.

Then, if I disable macports and run `./obs` from `_CPack_Packages/Darwin/Bundle/obs-studio-x64-*/OBS.app/Contents/Resources/bin`, obs fails to start and outputs this error message:
> This application failed to start because it could not find or load the Qt platform plugin "cocoa".
> Reinstalling the application may fix this problem.

Here is a fix for the platforms plugins. I did not include imageformats plugins because obs seems to be able to launch without them. With this fix, any Qt5 plugin known by cmake can be added to the list in `foreach(plugin ...)`.
