### PR TITLE
Update to recommended settings for Hitbox.tv

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -224,7 +224,7 @@
             ],
             "recommended": {
                 "keyint": 2,
-                "profile": "high",
+                "profile": "main",
                 "max video bitrate": 3500,
                 "max audio bitrate": 320
             }


### PR DESCRIPTION
Hitbox.tv just updated their recommended settings, it is now main instead of fast.