### PR TITLE
obs/window-basic-main.cpp: fix bug 0000331

### DIFF
--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -2653,7 +2653,8 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 
 void OBSBasic::on_sources_customContextMenuRequested(const QPoint &pos)
 {
-	CreateSourcePopupMenu(ui->sources->itemAt(pos), false);
+	if (ui->scenes->count())
+		CreateSourcePopupMenu(ui->sources->itemAt(pos), false);
 }
 
 void OBSBasic::on_sources_itemDoubleClicked(QListWidgetItem *witem)


### PR DESCRIPTION
0000331: trying to add a source with no scenes shouldn't be possible.
CreateSourcePopupMenu will now check count of scenes before
doing the popup.