### PR TITLE
UI: Fix GCC 4.8 compilation issue

### DIFF
--- a/obs/window-basic-main-transitions.cpp
+++ b/obs/window-basic-main-transitions.cpp
@@ -407,7 +407,7 @@ void OBSBasic::CreateProgramDisplay()
 			ResizeProgram(ovi.base_width, ovi.base_height);
 	};
 
-	connect(program, &OBSQTDisplay::DisplayResized,
+	connect(program.data(), &OBSQTDisplay::DisplayResized,
 			displayResize);
 
 	auto addDisplay = [this] (OBSQTDisplay *window)
@@ -420,7 +420,7 @@ void OBSBasic::CreateProgramDisplay()
 			ResizeProgram(ovi.base_width, ovi.base_height);
 	};
 
-	connect(program, &OBSQTDisplay::DisplayCreated, addDisplay);
+	connect(program.data(), &OBSQTDisplay::DisplayCreated, addDisplay);
 
 	program->setSizePolicy(QSizePolicy::Expanding,
 			QSizePolicy::Expanding);


### PR DESCRIPTION
Apparently using QPointer container for the QObject being given to the
connect function makes it so it can't find the actual function to use.
I'm guessing this is incomplete functionality or a bug that existed in
GCC 4.8.  Doesn't happen in 4.9+.

Same issue as before in: https://obsproject.com/mantis/view.php?id=276.
Current bug: https://obsproject.com/mantis/view.php?id=411.