### PR TITLE
Output start/stop notifications for plugins

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -208,7 +208,7 @@ bool obs_output_start(obs_output_t *output)
 	if (!output->context.data)
 		return false;
 
-   signal_handler_signal(obs_get_signal_handler(), "output_starting", NULL);
+	signal_handler_signal(obs_get_signal_handler(), "output_starting", NULL);
 
 	encoded = (output->info.flags & OBS_OUTPUT_ENCODED) != 0;
 
@@ -305,7 +305,7 @@ void obs_output_stop(obs_output_t *output)
 	if (!output->context.data)
 		return;
 
-   signal_handler_signal(obs_get_signal_handler(), "output_stopping", NULL);
+	signal_handler_signal(obs_get_signal_handler(), "output_stopping", NULL);
 
 	encoded = (output->info.flags & OBS_OUTPUT_ENCODED) != 0;
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -208,6 +208,8 @@ bool obs_output_start(obs_output_t *output)
 	if (!output->context.data)
 		return false;
 
+   signal_handler_signal(obs_get_signal_handler(), "output_starting", NULL);
+
 	encoded = (output->info.flags & OBS_OUTPUT_ENCODED) != 0;
 
 	if (encoded && output->delay_sec) {
@@ -302,6 +304,8 @@ void obs_output_stop(obs_output_t *output)
 		return;
 	if (!output->context.data)
 		return;
+
+   signal_handler_signal(obs_get_signal_handler(), "output_stopping", NULL);
 
 	encoded = (output->info.flags & OBS_OUTPUT_ENCODED) != 0;
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -599,6 +599,9 @@ static const char *obs_signals[] = {
 	"void hotkey_unregister(ptr hotkey)",
 	"void hotkey_bindings_changed(ptr hotkey)",
 
+   "void output_starting()",
+   "void output_stopping()",
+
 	NULL
 };
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -599,8 +599,8 @@ static const char *obs_signals[] = {
 	"void hotkey_unregister(ptr hotkey)",
 	"void hotkey_bindings_changed(ptr hotkey)",
 
-   "void output_starting()",
-   "void output_stopping()",
+	"void output_starting()",
+	"void output_stopping()",
 
 	NULL
 };


### PR DESCRIPTION
I would love it if these, or if needed a differently named, signals would be introduced for everyone that can access the default signal handler to indicate that the user has pressed the start or stop button for stream or record.

This would be extremely useful for my plugin, and these were after all features that were available in the original OBS through the OnStartStreaming/OnStartStream/etc dll functions (https://github.com/jp9000/OBS/wiki/Plugin-Callbacks).