### PR TITLE
Fix issues with XComposite Window Capture.

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -354,8 +354,7 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 
 	uint8_t *texData = new uint8_t[width() * height() * 4];
 
-	memset(texData, 0, sizeof(texData));
-
+	memset(texData, 0, width() * height() * 4);
 
 	const uint8_t* texDataArr[] = { texData, 0 };
 

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -354,12 +354,8 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 
 	uint8_t *texData = new uint8_t[width() * height() * 4];
 
-	for (unsigned int i = 0; i < width() * height() * 4; i += 4) {
-		texData[i + 0] = p->swapRedBlue ? 0 : 0xFF;
-		texData[i + 1] = 0;
-		texData[i + 2] = p->swapRedBlue ? 0xFF : 0;
-		texData[i + 3] = 0xFF;
-	}
+	memset(texData, 0, sizeof(texData));
+
 
 	const uint8_t* texDataArr[] = { texData, 0 };
 

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -516,6 +516,10 @@ void XCompcapMain::tick(float seconds)
 void XCompcapMain::render(gs_effect_t *effect)
 {
 	PLock lock(&p->lock, true);
+
+	if (!p->win)
+		return;
+
 	effect = obs_get_base_effect(OBS_EFFECT_OPAQUE);
 
 	if (!lock.isLocked() || !p->tex)


### PR DESCRIPTION
1. Fixed issue where OBS would continue to show old window source texture even after window was closed.
2. Fixed issue where OBS would show old window source texture from closed window after matching window would start up again (did not appear until issue 1 was fixed).
3. Removed red background from window source texture.