### PR TITLE
linux capture: Fix issues with XComposite Window Capture

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -354,12 +354,7 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 
 	uint8_t *texData = new uint8_t[width() * height() * 4];
 
-	for (unsigned int i = 0; i < width() * height() * 4; i += 4) {
-		texData[i + 0] = p->swapRedBlue ? 0 : 0xFF;
-		texData[i + 1] = 0;
-		texData[i + 2] = p->swapRedBlue ? 0xFF : 0;
-		texData[i + 3] = 0xFF;
-	}
+	memset(texData, 0, width() * height() * 4);
 
 	const uint8_t* texDataArr[] = { texData, 0 };
 

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -520,6 +520,10 @@ void XCompcapMain::tick(float seconds)
 void XCompcapMain::render(gs_effect_t *effect)
 {
 	PLock lock(&p->lock, true);
+
+	if (!p->win)
+		return;
+
 	effect = obs_get_base_effect(OBS_EFFECT_OPAQUE);
 
 	if (!lock.isLocked() || !p->tex)


### PR DESCRIPTION
1. Fixes an issue  where a texture would linger after a source window closed.
2. Removes the red background that would be applied to the source texture.

The second commit also fixes an issue introduced by the first commit, where the source texture from the old source window would momentarily appear while the new window was reopened.