### PR TITLE
Adds Y800 color format support

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -307,6 +307,24 @@ float4 PSNV12_Reverse(VertInOut vert_in) : TARGET
 	);
 }
 
+float4 PSY800_Reverse(VertInOut vert_in) : TARGET
+{
+	float x = vert_in.uv.x;
+	float y = vert_in.uv.y;
+	float x_offset   = floor(x * width  + PRECISION_OFFSET);
+	float y_offset   = floor(y * height + PRECISION_OFFSET);
+
+	float lum_offset = y_offset * width + x_offset + PRECISION_OFFSET;
+	lum_offset       = floor(lum_offset);
+
+	return float4(
+		GetOffsetColor(lum_offset),
+		GetOffsetColor(lum_offset),
+		GetOffsetColor(lum_offset),
+		1.0f
+	);
+}
+
 technique Planar420
 {
 	pass
@@ -376,5 +394,14 @@ technique NV12_Reverse
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSNV12_Reverse(vert_in);
+	}
+}
+
+technique Y800_Reverse
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSY800_Reverse(vert_in);
 	}
 }

--- a/libobs/media-io/format-conversion.c
+++ b/libobs/media-io/format-conversion.c
@@ -271,6 +271,15 @@ void decompress_nv12(
 	}
 }
 
+void decompress_y800(
+		const uint8_t *const input[], const uint32_t in_linesize[],
+		uint32_t start_y, uint32_t end_y,
+		uint8_t *output, uint32_t out_linesize)
+{
+	// TODO
+	return;
+}
+
 void decompress_422(
 		const uint8_t *input, uint32_t in_linesize,
 		uint32_t start_y, uint32_t end_y,

--- a/libobs/media-io/format-conversion.h
+++ b/libobs/media-io/format-conversion.h
@@ -47,6 +47,11 @@ EXPORT void decompress_nv12(
 		uint32_t start_y, uint32_t end_y,
 		uint8_t *output, uint32_t out_linesize);
 
+EXPORT void decompress_y800(
+		const uint8_t *const input[], const uint32_t in_linesize[],
+		uint32_t start_y, uint32_t end_y,
+		uint8_t *output, uint32_t out_linesize);
+
 EXPORT void decompress_420(
 		const uint8_t *const input[], const uint32_t in_linesize[],
 		uint32_t start_y, uint32_t end_y,

--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -66,6 +66,13 @@ void video_frame_init(struct video_frame *frame, enum video_format format,
 		frame->linesize[1] = width;
 		break;
 
+	case VIDEO_FORMAT_Y800:
+		size = width * height;
+		ALIGN_SIZE(size, alignment);
+		frame->data[0] = bmalloc(size);
+		frame->linesize[0] = width;
+		break;
+
 	case VIDEO_FORMAT_YVYU:
 	case VIDEO_FORMAT_YUY2:
 	case VIDEO_FORMAT_UYVY:

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -36,6 +36,7 @@ enum video_format {
 	/* planar 420 format */
 	VIDEO_FORMAT_I420, /* three-plane */
 	VIDEO_FORMAT_NV12, /* two-plane, luma and packed chroma */
+	VIDEO_FORMAT_Y800, /* Greyscale, luma plane only, 8-bit per pixel */
 
 	/* packed 422 formats */
 	VIDEO_FORMAT_YVYU,

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -374,6 +374,7 @@ static inline video_format ConvertVideoFormat(VideoFormat format)
 	case VideoFormat::I420:  return VIDEO_FORMAT_I420;
 	case VideoFormat::YV12:  return VIDEO_FORMAT_I420;
 	case VideoFormat::NV12:  return VIDEO_FORMAT_NV12;
+	case VideoFormat::Y800:  return VIDEO_FORMAT_Y800;
 	case VideoFormat::YVYU:  return VIDEO_FORMAT_YVYU;
 	case VideoFormat::YUY2:  return VIDEO_FORMAT_YUY2;
 	case VideoFormat::UYVY:  return VIDEO_FORMAT_UYVY;
@@ -479,6 +480,10 @@ void DShowInput::OnVideoData(const VideoConfig &config,
 		frame.data[1] = frame.data[0] + (cx * cy);
 		frame.linesize[0] = cx;
 		frame.linesize[1] = cx;
+
+	} else if (videoConfig.format == VideoFormat::Y800) {
+		frame.data[0] = data;
+		frame.linesize[0] = cx;
 
 	} else {
 		/* TODO: other formats */
@@ -745,14 +750,24 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	flip = obs_data_get_bool(settings, FLIP_IMAGE);
 
 	DeviceId id;
-	if (!DecodeDeviceId(id, video_device_id.c_str()))
+	if (!DecodeDeviceId(id, video_device_id.c_str())) {
+		blog(LOG_WARNING,
+			"%s: DecodeDeviceId failed",
+			obs_source_get_name(source)
+		);
 		return false;
+	}
 
 	PropertiesData data;
 	Device::EnumVideoDevices(data.devices);
 	VideoDevice dev;
-	if (!data.GetDevice(dev, video_device_id.c_str()))
+	if (!data.GetDevice(dev, video_device_id.c_str())) {
+		blog(LOG_WARNING,
+			"%s: data.GetDevice failed",
+			obs_source_get_name(source)
+		);
 		return false;
+	}
 
 	int resType = (int)obs_data_get_int(settings, RES_TYPE);
 	int cx = 0, cy = 0;
@@ -762,8 +777,13 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	if (resType == ResType_Custom) {
 		bool has_autosel_val;
 		string resolution = obs_data_get_string(settings, RESOLUTION);
-		if (!ResolutionValid(resolution, cx, cy))
+		if (!ResolutionValid(resolution, cx, cy)) {
+			blog(LOG_WARNING,
+				"%s: ResolutionValid failed",
+				obs_source_get_name(source)
+			);
 			return false;
+		}
 
 		has_autosel_val = obs_data_has_autoselect_value(settings,
 				FRAME_INTERVAL);
@@ -778,12 +798,22 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 
 		long long best_interval = numeric_limits<long long>::max();
 		bool video_format_match = false;
-		if (!CapsMatch(dev,
-			ResolutionMatcher(cx, cy),
-			VideoFormatMatcher(format, video_format_match),
-			ClosestFrameRateSelector(interval, best_interval),
-			FrameRateMatcher(interval)) && !video_format_match)
+		if (
+			!CapsMatch(
+				dev,
+				ResolutionMatcher(cx, cy),
+				VideoFormatMatcher(format, video_format_match),
+				ClosestFrameRateSelector(interval, best_interval),
+				FrameRateMatcher(interval)
+			) &&
+			!video_format_match
+		) {
+			blog(LOG_WARNING,
+				"%s: Video format match failed",
+				obs_source_get_name(source)
+			);
 			return false;
+		}
 
 		interval = best_interval;
 	}
@@ -806,13 +836,23 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 	if (videoConfig.internalFormat != VideoFormat::MJPEG)
 		videoConfig.format = videoConfig.internalFormat;
 
-	if (!device.SetVideoConfig(&videoConfig))
+	if (!device.SetVideoConfig(&videoConfig)) {
+		blog(LOG_WARNING,
+			"%s: device.SetVideoConfig failed",
+			obs_source_get_name(source)
+		);
 		return false;
+	}
 
 	if (videoConfig.internalFormat == VideoFormat::MJPEG) {
 		videoConfig.format = VideoFormat::XRGB;
-		if (!device.SetVideoConfig(&videoConfig))
+		if (!device.SetVideoConfig(&videoConfig)) {
+			blog(LOG_WARNING,
+				"%s: device.SetVideoConfig (XRGB) failed",
+				obs_source_get_name(source)
+			);
 			return false;
+		}
 	}
 
 	DStr formatName = GetVideoFormatName(videoConfig.internalFormat);
@@ -1174,6 +1214,7 @@ static const VideoFormatName videoFormatNames[] = {
 	{VideoFormat::I420,  "I420"},
 	{VideoFormat::NV12,  "NV12"},
 	{VideoFormat::YV12,  "YV12"},
+	{VideoFormat::Y800,  "Y800"},
 
 	/* packed YUV formats */
 	{VideoFormat::YVYU,  "YVYU"},


### PR DESCRIPTION
I have a monochrome camera that I need in an OBS scene, but it outputs [Y800](http://www.fourcc.org/yuv.php#Y800) frames.  OBS didn't have support for this color format, so I plumbed it through.

libobs:
- Added Y800 to the `video_format` (`libobs/media-io/video-io.h`) and `convert_type` (`libobs/obs-source.c`) enums, and added case statements to handle it where necessary.
- Adds format conversion effect for GPU-accelerated conversion of Y800 in `format_conversion.effect` 
- Stubs out but doesn't implement the software conversion in `format-conversion.c` mostly because I couldn't figure out how to test it.  I didn't want to put code there that looks like it maybe worked without verifying it.  (Feedback on this is particularly welcome.)

win-dshow:
- Adds Y800 to the `VideoFormat` enum in `dshowcapture.hpp` (libdshowcapture), and handles it where needed.
- Adds Y800 media subtype GUID constant and FOURCC stuff in `dshow-formats.cpp` and  (libdshowcapture) used to identify the device as Y800.
- Adds some warning log statements to `UpdateVideoConfig` in `win-dshow.cpp`.  It can fail in several places but I was only seeing one "Video configuration failed" log line before I figured out I needed to add support for its color format. I figured it'd be handy to log why `UpdateVideoConfig` fails to make it easier to pinpoint what's going on.  So there's a warning for every place it returns false.

Since this required a small change in libdshowcapture, the matching pull request for that submodule is [here](https://github.com/jp9000/libdshowcapture/pull/6).

[Feedback welcome!](https://media.giphy.com/media/xDQ3Oql1BN54c/giphy.gif)