### PR TITLE
text-freetype2: Use GS_A8 type glyphs texture

### DIFF
--- a/plugins/text-freetype2/data/text_default.effect
+++ b/plugins/text-freetype2/data/text_default.effect
@@ -27,7 +27,8 @@ VertInOut VSDefault(VertInOut vert_in)
 
 float4 PSDrawBare(VertInOut vert_in) : TARGET
 {
-	return image.Sample(def_sampler, vert_in.uv) * vert_in.col;
+	vert_in.col.a *= image.Sample(def_sampler, vert_in.uv).a;
+	return vert_in.col;
 }
 
 float4 PSDrawMatrix(VertInOut vert_in) : TARGET

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -366,7 +366,7 @@ static void ft2_source_update(void *data, obs_data_t *settings)
 		bfree(srcdata->texbuf);
 		srcdata->texbuf = NULL;
 	}
-	srcdata->texbuf = bzalloc(texbuf_w * texbuf_h * 4);
+	srcdata->texbuf = bzalloc(texbuf_w * texbuf_h);
 
 	if (srcdata->font_face)
 		cache_standard_glyphs(srcdata);

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -53,7 +53,7 @@ struct ft2_source {
 
 	FT_Face	font_face;
 
-	uint32_t *texbuf;
+	uint8_t *texbuf;
 	gs_vertbuffer_t *vbuf;
 
 	gs_effect_t *draw_effect;

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -241,7 +241,6 @@ void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs)
 	slot = srcdata->font_face->glyph;
 
 	uint32_t dx = srcdata->texbuf_x, dy = srcdata->texbuf_y;
-	uint8_t alpha;
 
 	int32_t cached_glyphs = 0;
 	size_t len = wcslen(cache_glyphs);
@@ -278,11 +277,9 @@ void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs)
 		src_glyph->xadv = slot->advance.x >> 6;
 
 		for (uint32_t y = 0; y < g_h; y++) {
-			for (uint32_t x = 0; x < g_w; x++) {
-				alpha = slot->bitmap.buffer[glyph_pos];
+			for (uint32_t x = 0; x < g_w; x++)
 				srcdata->texbuf[buf_pos] =
-					0x00FFFFFF ^ ((uint32_t)alpha << 24);
-			}
+					slot->bitmap.buffer[glyph_pos];
 		}
 
 		dx += (g_w + 1);
@@ -310,7 +307,7 @@ void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs)
 		}
 
 		srcdata->tex = gs_texture_create(texbuf_w, texbuf_h,
-			GS_RGBA, 1, (const uint8_t **)&srcdata->texbuf, 0);
+			GS_A8, 1, (const uint8_t **)&srcdata->texbuf, 0);
 
 		obs_leave_graphics();
 	}


### PR DESCRIPTION
Since glyphs are rendered by FT as 8-bit gray levels bitmaps, it would
be a waste of memory to cache glyphs in a RGBA texture.