### PR TITLE
image-source: Fix repeated reloading when modification check fails

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -30,7 +30,8 @@ struct image_source {
 static time_t get_modified_timestamp(const char *filename)
 {
 	struct stat stats;
-	stat(filename, &stats);
+	if (stat(filename, &stats))
+		return -1;
 	return stats.st_mtime;
 }
 


### PR DESCRIPTION
The implementation of get_modified_timestamp() did not check the
return value of stat(), so in case the check fails the values in the
stats structure can be any garbage on the stack and the value of
stats.st_mtime can change on every call. This can trigger a reload of the
image every second, even if the file was not actually modified.