### PR TITLE
UI: Add snap-to-center in preview

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -350,6 +350,10 @@ Basic.Settings.General.Theme="Theme"
 Basic.Settings.General.Language="Language"
 Basic.Settings.General.WarnBeforeStartingStream="Show confirmation dialog when starting streams"
 Basic.Settings.General.WarnBeforeStoppingStream="Show confirmation dialog when stopping streams"
+Basic.Settings.General.Snapping="Source Alignment Snapping"
+Basic.Settings.General.ScreenSnapping="Snap Source edges to Screen"
+Basic.Settings.General.CenterSnapping="Snap Sources to horizontal and vertical center"
+Basic.Settings.General.SnapDistance="Snap Sensitivity"
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"

--- a/obs/forms/OBSBasicSettings.ui
+++ b/obs/forms/OBSBasicSettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>896</width>
-    <height>667</height>
+    <width>939</width>
+    <height>674</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -183,6 +183,87 @@
            <property name="text">
             <string>Basic.Settings.General.WarnBeforeStoppingStream</string>
            </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="2">
+          <widget class="Line" name="line_4">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0" colspan="2">
+          <widget class="QGroupBox" name="groupBox_6">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Basic.Settings.General.Snapping</string>
+           </property>
+           <property name="flat">
+            <bool>false</bool>
+           </property>
+           <layout class="QFormLayout" name="formLayout_17">
+            <property name="labelAlignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <item row="0" column="1">
+             <widget class="QCheckBox" name="snappingEnabled">
+              <property name="text">
+               <string>Enable</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QCheckBox" name="screenSnapping">
+              <property name="text">
+               <string>Basic.Settings.General.ScreenSnapping</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QCheckBox" name="centerSnapping">
+              <property name="text">
+               <string>Basic.Settings.General.CenterSnapping</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Basic.Settings.General.SnapDistance</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QDoubleSpinBox" name="snapDistance">
+              <property name="decimals">
+               <number>1</number>
+              </property>
+              <property name="singleStep">
+               <double>0.500000000000000</double>
+              </property>
+              <property name="value">
+               <double>10.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>
@@ -814,7 +895,7 @@
              <item>
               <widget class="QTabWidget" name="advOutTabs">
                <property name="currentIndex">
-                <number>0</number>
+                <number>2</number>
                </property>
                <property name="usesScrollButtons">
                 <bool>true</bool>
@@ -1075,7 +1156,7 @@
                  <item>
                   <widget class="QStackedWidget" name="stackedWidget">
                    <property name="currentIndex">
-                    <number>0</number>
+                    <number>1</number>
                    </property>
                    <widget class="QWidget" name="advOutRecStandard">
                     <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2418,8 +2499,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>98</width>
-              <height>28</height>
+              <width>742</width>
+              <height>77</height>
              </rect>
             </property>
            </widget>
@@ -2784,8 +2865,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>525</width>
-              <height>383</height>
+              <width>768</width>
+              <height>608</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_16">

--- a/obs/window-basic-preview.cpp
+++ b/obs/window-basic-preview.cpp
@@ -11,7 +11,6 @@
 
 #define HANDLE_RADIUS     4.0f
 #define HANDLE_SEL_RADIUS (HANDLE_RADIUS * 1.5f)
-#define CLAMP_DISTANCE    10.0f
 
 /* TODO: make C++ math classes and clean up code here later */
 
@@ -133,7 +132,7 @@ static inline vec2 GetOBSScreenSize()
 	return size;
 }
 
-vec3 OBSBasicPreview::GetScreenSnapOffset(const vec3 &tl, const vec3 &br)
+vec3 OBSBasicPreview::GetSnapOffset(const vec3 &tl, const vec3 &br)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
 	vec2 screenSize = GetOBSScreenSize();
@@ -141,19 +140,50 @@ vec3 OBSBasicPreview::GetScreenSnapOffset(const vec3 &tl, const vec3 &br)
 
 	vec3_zero(&clampOffset);
 
-	const float clampDist = CLAMP_DISTANCE / main->previewScale;
+	const bool snap = config_get_bool(GetGlobalConfig(), "General",
+			"SnappingEnabled");
+	if (snap == false)
+		return clampOffset;
 
-	if (fabsf(tl.x) < clampDist)
+	const bool screenSnap = config_get_bool(GetGlobalConfig(), "General",
+			"ScreenSnapping");
+	const bool centerSnap = config_get_bool(GetGlobalConfig(), "General",
+			"CenterSnapping");
+
+	const float clampDist = config_get_double(GetGlobalConfig(), "General",
+			"SnapDistance") / main->previewScale;
+	const float centerX = br.x - (br.x - tl.x) / 2.0f;
+	const float centerY = br.y - (br.y - tl.y) / 2.0f;
+
+	// Left screen edge.
+	if (screenSnap &&
+	    fabsf(tl.x) < clampDist)
 		clampOffset.x = -tl.x;
-	if (fabsf(clampOffset.x) < EPSILON &&
+	// Right screen edge.
+	if (screenSnap &&
+	    fabsf(clampOffset.x) < EPSILON &&
 	    fabsf(screenSize.x - br.x) < clampDist)
 		clampOffset.x = screenSize.x - br.x;
+	// Horizontal center.
+	if (centerSnap &&
+	    fabsf(screenSize.x - (br.x - tl.x)) > clampDist &&
+	    fabsf(screenSize.x / 2.0f - centerX) < clampDist)
+		clampOffset.x = screenSize.x / 2.0f - centerX;
 
-	if (fabsf(tl.y) < clampDist)
+	// Top screen edge.
+	if (screenSnap &&
+	    fabsf(tl.y) < clampDist)
 		clampOffset.y = -tl.y;
-	if (fabsf(clampOffset.y) < EPSILON &&
+	// Bottom screen edge.
+	if (screenSnap &&
+	    fabsf(clampOffset.y) < EPSILON &&
 	    fabsf(screenSize.y - br.y) < clampDist)
 		clampOffset.y = screenSize.y - br.y;
+	// Vertical center.
+	if (centerSnap &&
+	    fabsf(screenSize.y - (br.y - tl.y)) > clampDist &&
+	    fabsf(screenSize.y / 2.0f - centerY) < clampDist)
+		clampOffset.y = screenSize.y / 2.0f - centerY;
 
 	return clampOffset;
 }
@@ -466,7 +496,7 @@ void OBSBasicPreview::SnapItemMovement(vec2 &offset)
 	data.br.x += offset.x;
 	data.br.y += offset.y;
 
-	vec3 snapOffset = GetScreenSnapOffset(data.tl, data.br);
+	vec3 snapOffset = GetSnapOffset(data.tl, data.br);
 	offset.x += snapOffset.x;
 	offset.y += snapOffset.y;
 }
@@ -587,7 +617,7 @@ void OBSBasicPreview::SnapStretchingToScreen(vec3 &tl, vec3 &br)
 	vec3_max(&boundingBR, &boundingBR, &newBL);
 	vec3_max(&boundingBR, &boundingBR, &newBR);
 
-	vec3 offset = GetScreenSnapOffset(boundingTL, boundingBR);
+	vec3 offset = GetSnapOffset(boundingTL, boundingBR);
 	vec3_add(&offset, &offset, &newTL);
 	vec3_transform(&offset, &offset, &screenToItem);
 	vec3_sub(&offset, &offset, &tl);

--- a/obs/window-basic-preview.hpp
+++ b/obs/window-basic-preview.hpp
@@ -52,7 +52,7 @@ private:
 	static void DoSelect(const vec2 &pos);
 	static void DoCtrlSelect(const vec2 &pos);
 
-	static vec3 GetScreenSnapOffset(const vec3 &tl, const vec3 &br);
+	static vec3 GetSnapOffset(const vec3 &tl, const vec3 &br);
 
 	void GetStretchHandleData(const vec2 &pos);
 

--- a/obs/window-basic-settings.cpp
+++ b/obs/window-basic-settings.cpp
@@ -265,6 +265,10 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->theme, 		     COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->snappingEnabled,      CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->screenSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->centerSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->snapDistance,         SCROLL_CHANGED, GENERAL_CHANGED);
 	HookWidget(ui->outputMode,           COMBO_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->streamType,           COMBO_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->simpleOutputPath,     EDIT_CHANGED,   OUTPUTS_CHANGED);
@@ -759,6 +763,23 @@ void OBSBasicSettings::LoadGeneralSettings()
 
 	LoadLanguageList();
 	LoadThemeList();
+
+	bool snappingEnabled = config_get_bool(GetGlobalConfig(),
+			"General", "SnappingEnabled");
+	ui->snappingEnabled->setChecked(snappingEnabled);
+
+	bool screenSnapping = config_get_bool(GetGlobalConfig(),
+			"General", "ScreenSnapping");
+	ui->screenSnapping->setChecked(screenSnapping);
+
+	bool centerSnapping = config_get_bool(GetGlobalConfig(),
+			"General", "CenterSnapping");
+	ui->centerSnapping->setChecked(centerSnapping);
+
+	double snapDistance = config_get_double(GetGlobalConfig(),
+			"General", "SnapDistance");
+	ui->snapDistance->setValue(snapDistance);
+
 
 	bool warnBeforeStreamStart = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "WarnBeforeStartingStream");
@@ -2019,6 +2040,19 @@ void OBSBasicSettings::SaveGeneralSettings()
 				  theme.c_str());
 		App()->SetTheme(theme);
 	}
+
+	config_set_bool(GetGlobalConfig(), "General",
+			"SnappingEnabled",
+			ui->snappingEnabled->isChecked());
+	config_set_bool(GetGlobalConfig(), "General",
+			"ScreenSnapping",
+			ui->screenSnapping->isChecked());
+	config_set_bool(GetGlobalConfig(), "General",
+			"CenterSnapping",
+			ui->centerSnapping->isChecked());
+	config_set_double(GetGlobalConfig(), "General",
+			"SnapDistance",
+			ui->snapDistance->value());
 
 	config_set_bool(GetGlobalConfig(), "BasicWindow",
 			"WarnBeforeStartingStream",


### PR DESCRIPTION
Adds center (horizontal & vertical) snapping for sources in the preview pane.

It's possible my math isn't quite correct in all cases.


~~Ideally, I'd like to add options to adjust snapping so that people can enable/disable/adjust the clamp size, but that is a bit more complex. :P~~
Edit: done!