### PR TITLE
fix a crash bug.

### DIFF
--- a/deps/libff/libff/ff-demuxer.c
+++ b/deps/libff/libff/ff-demuxer.c
@@ -342,15 +342,15 @@ void ff_demuxer_reset(struct ff_demuxer *demuxer)
 	packet.clock = clock;
 
 	if (demuxer->audio_decoder != NULL) {
+		ff_clock_retain(clock);
 		packet_queue_put(&demuxer->audio_decoder->packet_queue,
 				&packet);
-		ff_clock_retain(clock);
 	}
 
 	if (demuxer->video_decoder != NULL) {
+		ff_clock_retain(clock);
 		packet_queue_put(&demuxer->video_decoder->packet_queue,
 				&packet);
-		ff_clock_retain(clock);
 	}
 }
 


### PR DESCRIPTION
how to crash:
1. use recent ffmpeg shared libraries.
2. add a ffmpeg_source, a small static picture (e.g. jpeg) with loop
3. after a while of high cpu usage, it crashed. Seems reproduced more easily on faster computer