### PR TITLE
deps/libff: Fix that inputs are not closed when a demuxer is freed

### DIFF
--- a/deps/libff/libff/ff-demuxer.c
+++ b/deps/libff/libff/ff-demuxer.c
@@ -94,7 +94,7 @@ void ff_demuxer_free(struct ff_demuxer *demuxer)
 		ff_decoder_free(demuxer->video_decoder);
 
 	if (demuxer->format_context)
-		avformat_free_context(demuxer->format_context);
+		avformat_close_input(&demuxer->format_context);
 
 	av_free(demuxer);
 }


### PR DESCRIPTION
avformat_free_context() only frees the memory used by an AVFormatContext
but it does not close the opened media file. This causes a leaked file
descriptor every time a media source frees a demuxer. Using
avformat_close_input() instead frees the context and closes the media
file.

Should fix https://obsproject.com/mantis/view.php?id=477