### PR TITLE
Fix Spanish typos

### DIFF
--- a/plugins/rtmp-services/data/locale/es-ES.ini
+++ b/plugins/rtmp-services/data/locale/es-ES.ini
@@ -1,5 +1,5 @@
 StreamingServices="Servicio de retransmisión"
-CustomStreamingServer="Presonalizar el servidor de retranmisión"
+CustomStreamingServer="Personalizar el servidor de retransmisión"
 Service="Servicio"
 Server="Servidor"
 StreamKey="Clave de retransmisión"


### PR DESCRIPTION
Just a quick fix to typos I saw when using OBS. (I'm a native Spanish speaker).

I see you may be using a tool called Crowdin for translations.. Feel free to redirect me to there if you prefer I go through that.

Thanks!