### PR TITLE
rtmp-services: Update Facebook Live

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -472,9 +472,9 @@
                 }
             ],
             "recommended": {
-                "keyint": 1,
+                "keyint": 2,
                 "profile": "main",
-                "max video bitrate": 2000,
+                "max video bitrate": 2500,
                 "max audio bitrate": 160
             }
         },


### PR DESCRIPTION
As commented on: https://github.com/jp9000/obs-studio/commit/cab28190337255a85bbc7b244f2821f3adebeb5f#commitcomment-17482672
And according to: https://www.facebook.com/facebookmedia/get-started/live 
Key Intervall of 1 key frame per 2 second's and max video bitrate of 2500.