### PR TITLE
VS 2015 Fix

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -27,6 +27,11 @@ static struct func_hook reset;
 static struct func_hook reset_ex;
 
 struct d3d9_data {
+	explicit d3d9_data()
+	{
+			
+	}
+	
 	HMODULE                d3d9;
 	IDirect3DDevice9       *device; /* do not release */
 	uint32_t               cx;
@@ -62,7 +67,7 @@ struct d3d9_data {
 	};
 };
 
-static struct d3d9_data data = {};
+static struct d3d9_data data;
 
 static void d3d9_free()
 {


### PR DESCRIPTION
This is a fix for the C1001 error is VS 2015, as seen here: https://obsproject.com/forum/threads/one-build-error-c1001-using-visual-studio-2015.47766/
I don't believe this impacts anything else, please correct me if I'm wrong