### PR TITLE
rtmp-services: Add Nood as a service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 22,
+	"version": 23,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 22
+			"version": 23
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -515,6 +515,39 @@
                     "url": "rtmp://sa.restream.io/live"
                 }
             ]
+        },
+        {
+            "name": "Nood",
+            "servers": [
+              {
+                  "name": "EU Central: Frankfurt, Germany",
+                  "url": "rtmp://broadcast-frf.nood.tv"
+              },
+              {
+                  "name": "EU North: Amsterdam, Netherlands",
+                  "url": "rtmp://broadcast-ams.nood.tv"
+              },
+              {
+                  "name": "EU West: Stockholm, Sweden",
+                  "url": "rtmp://broadcast-arn.nood.tv"
+              },
+              {
+                  "name": "US East: Washington, DC",
+                  "url": "rtmp://broadcast-dca.nood.tv"
+              },
+              {
+                  "name": "US West: Los Angeles, CA",
+                  "url": "rtmp://broadcast-oxr.nood.tv"
+              },
+              {
+                  "name": "Australia: Sydney",
+                  "url": "rtmp://broadcast-syd.nood.tv"
+              },
+              {
+                  "name": "Asia: Hong Kong, China",
+                  "url": "rtmp://broadcast-hhp.nood.tv"
+              }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Nood is a Live video streaming platform and community for adults
see: https://www.nood.tv

We are still in beta but we already using obs-studio :+1: 

Thanks for obs-studio :tada: 