### PR TITLE
Add Kamcord service

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -548,6 +548,40 @@
                   "url": "rtmp://broadcast-hhp.nood.tv/20D2AB/live"
               }
             ]
+        },
+        {
+            "name": "Kamcord",
+            "common": true,
+            "servers": [
+              {
+                  "name": "US East (N. Virginia)",
+                  "url": "rtmp://us-east-1.stream.kamcord.com/live"
+              },
+              {
+                  "name": "Asia Pacific (Seoul)",
+                  "url": "rtmp://ap-northeast-2.stream.kamcord.com/live"
+              },
+              {
+                  "name": "Asia Pacific (Sydney)",
+                  "url": "rtmp://ap-southeast-2.stream.kamcord.com/live"
+              },
+              {
+                  "name": "Asia Pacific (Tokyo)",
+                  "url": "rtmp://ap-northeast-1.stream.kamcord.com/live"
+              },
+              {
+                  "name": "EU (Frankfurt)",
+                  "url": "rtmp://eu-central-1.stream.kamcord.com/live"
+              },
+              {
+                  "name": "South America (Sao Paulo)",
+                  "url": "rtmp://sa-east-1.stream.kamcord.com/live"
+              },
+              {
+                  "name": "US West (N. California)",
+                  "url": "rtmp://us-west-1.stream.kamcord.com/live"
+              }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Just adding default servers for Kamcord's streaming service.

For more info, see https://kamcord.com and https://lat.stream.kamcord.com/region