### PR TITLE
changed max delay for the async-delay filter to 120s

### DIFF
--- a/plugins/obs-filters/async-delay-filter.c
+++ b/plugins/obs-filters/async-delay-filter.c
@@ -115,7 +115,7 @@ static obs_properties_t *async_delay_filter_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_int(props, SETTING_DELAY_MS, TEXT_DELAY_MS,
-			0, 6000, 1);
+			0, 120000, 1);
 
 	UNUSED_PARAMETER(data);
 	return props;


### PR DESCRIPTION
I had a lot of problems with only 6s maximum delay, i had to sync some remote screen captures over network and the delay was around 12s. Yes 120s use a lot of RAM, but the gui should not stop me from getting my sources in sync