### PR TITLE
Prevent random_file call when file list empty

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -243,7 +243,7 @@ static void ss_update(void *data, obs_data_t *settings)
 	obs_transition_set_scale_type(ss->transition,
 			OBS_TRANSITION_SCALE_ASPECT);
 
-	if (ss->randomize && files.num)
+	if (ss->randomize && ss->files.num)
 		ss->cur_item = random_file(ss);
 	if (new_tr)
 		obs_source_add_active_child(ss->source, new_tr);

--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -243,7 +243,7 @@ static void ss_update(void *data, obs_data_t *settings)
 	obs_transition_set_scale_type(ss->transition,
 			OBS_TRANSITION_SCALE_ASPECT);
 
-	if (ss->randomize)
+	if (ss->randomize && files.num)
 		ss->cur_item = random_file(ss);
 	if (new_tr)
 		obs_source_add_active_child(ss->source, new_tr);


### PR DESCRIPTION
Fast workaround to prevent integer division by zero in random_file when add new source.
This resolves second crash from https://obsproject.com/forum/threads/image-diasshow-slideshow.47739/#post-216961