### PR TITLE
Allow to install architecture independent data outside of prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 include(ObsHelpers)
 include(ObsCpack)
+include(GNUInstallDirs)
 
 if(MSVC AND NOT EXISTS "${CMAKE_BINARY_DIR}/ALL_BUILD.vcxproj.user")
 	file(GENERATE

--- a/obs/CMakeLists.txt
+++ b/obs/CMakeLists.txt
@@ -228,7 +228,7 @@ install_obs_core(obs)
 install_obs_data(obs data obs-studio)
 
 if (UNIX AND UNIX_STRUCTURE AND NOT APPLE)
-	install(FILES dist/obs.desktop DESTINATION share/applications)
+	install(FILES dist/obs.desktop DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/applications)
 	install(FILES forms/images/obs.png
-		DESTINATION share/icons/hicolor/256x256/apps)
+		DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/256x256/apps)
 endif()


### PR DESCRIPTION
This allows installing the architecture independent data outside
the prefix, for example on a multiarch layout where the prefix
is /usr/{host-triplet}.