### PR TITLE
UI: Add option to automatically record while streaming

### DIFF
--- a/obs/data/locale/en-US.ini
+++ b/obs/data/locale/en-US.ini
@@ -360,6 +360,8 @@ Basic.Settings.General.ScreenSnapping="Snap Sources to edge of screen"
 Basic.Settings.General.CenterSnapping="Snap Sources to horizontal and vertical center"
 Basic.Settings.General.SourceSnapping="Snap Sources to other sources"
 Basic.Settings.General.SnapDistance="Snap Sensitivity"
+Basic.Settings.General.RecordWhenStreaming="Automatically record when streaming"
+Basic.Settings.General.KeepRecordingWhenStreamStops="Keep recording if stream stops"
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"

--- a/obs/forms/OBSBasicSettings.ui
+++ b/obs/forms/OBSBasicSettings.ui
@@ -185,14 +185,28 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0" colspan="2">
+         <item row="5" column="1">
+           <widget class="QCheckBox" name="recordWhenStreaming">
+           <property name="text">
+            <string>Basic.Settings.General.RecordWhenStreaming</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QCheckBox" name="keepRecordStreamStops">
+           <property name="text">
+            <string>Basic.Settings.General.KeepRecordingWhenStreamStops</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0" colspan="2">
           <widget class="Line" name="line_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
-         <item row="6" column="0" colspan="2">
+         <item row="8" column="0" colspan="2">
           <widget class="QGroupBox" name="groupBox_10">
            <property name="enabled">
             <bool>true</bool>

--- a/obs/obs-app.cpp
+++ b/obs/obs-app.cpp
@@ -354,6 +354,10 @@ bool OBSApp::InitGlobalConfigDefaults()
 			"CenterSnapping", false);
 	config_set_default_double(globalConfig, "BasicWindow",
 			"SnapDistance", 10.0);
+	config_set_default_bool(globalConfig, "BasicWindow",
+			"RecordWhenStreaming", false);
+	config_set_default_bool(globalConfig, "BasicWindow",
+			"KeepRecordingWhenStreamStops", false);
 
 #ifdef __APPLE__
 	config_set_default_bool(globalConfig, "Video", "DisableOSXVSync", true);

--- a/obs/window-basic-main.cpp
+++ b/obs/window-basic-main.cpp
@@ -3419,6 +3419,12 @@ void OBSBasic::StreamingStart()
 		App()->IncrementSleepInhibition();
 	}
 
+	bool record_stream = config_get_bool(GetGlobalConfig(), "BasicWindow",
+		"RecordWhenStreaming");
+
+	if (record_stream)        
+		StartRecording();
+        
 	blog(LOG_INFO, STREAMING_START);
 }
 
@@ -3472,6 +3478,12 @@ void OBSBasic::StreamingStop(int code)
 		startStreamMenu->deleteLater();
 		startStreamMenu = nullptr;
 	}
+
+	bool keep_recording = config_get_bool(GetGlobalConfig(), "BasicWindow",
+		"KeepRecordingWhenStreamStops");
+
+	if (!keep_recording)        
+		StopRecording();
 }
 
 void OBSBasic::StartRecording()

--- a/obs/window-basic-settings.cpp
+++ b/obs/window-basic-settings.cpp
@@ -271,6 +271,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->theme, 		     COMBO_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStart,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->recordWhenStreaming,  CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->keepRecordStreamStops,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->snappingEnabled,      CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->screenSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->centerSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
@@ -794,6 +796,14 @@ void OBSBasicSettings::LoadGeneralSettings()
 	LoadLanguageList();
 	LoadThemeList();
 
+	bool recordWhenStreaming = config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "RecordWhenStreaming");
+	ui->recordWhenStreaming->setChecked(recordWhenStreaming);
+
+	bool keepRecordStreamStops = config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "KeepRecordingWhenStreamStops");
+	ui->keepRecordStreamStops->setChecked(keepRecordStreamStops);
+
 	bool snappingEnabled = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SnappingEnabled");
 	ui->snappingEnabled->setChecked(snappingEnabled);
@@ -813,7 +823,6 @@ void OBSBasicSettings::LoadGeneralSettings()
 	double snapDistance = config_get_double(GetGlobalConfig(),
 			"BasicWindow", "SnapDistance");
 	ui->snapDistance->setValue(snapDistance);
-
 
 	bool warnBeforeStreamStart = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "WarnBeforeStartingStream");
@@ -2129,6 +2138,16 @@ void OBSBasicSettings::SaveGeneralSettings()
 				  theme.c_str());
 		App()->SetTheme(theme);
 	}
+        
+	if (WidgetChanged(ui->recordWhenStreaming))
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"RecordWhenStreaming",
+				ui->recordWhenStreaming->isChecked());
+
+	if (WidgetChanged(ui->keepRecordStreamStops))
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"KeepRecordingWhenStreamStops",
+				ui->keepRecordStreamStops->isChecked());
 
 	if (WidgetChanged(ui->snappingEnabled))
 		config_set_bool(GetGlobalConfig(), "BasicWindow",


### PR DESCRIPTION
Trying this for a second time. I think I have finally figured out how github all works. This option is added to the general settings. When the streaming button is pushed, recording will also automatically happen. Also when streaming is stopped, recording is also stopped.