### PR TITLE
UI: Fix visibility of control elements in CRF mode.

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -130,11 +130,9 @@ static bool use_bufsize_modified(obs_properties_t *ppts, obs_property_t *p,
 		obs_data_t *settings)
 {
 	bool use_bufsize = obs_data_get_bool(settings, "use_bufsize");
-	const char *rc = obs_data_get_string(settings, "rate_control");
-	bool rc_crf = astrcmpi(rc, "CRF") == 0;
-
+	
+	//"buffer_size" UI is visible if "use_bufsize" is checked/enabled
 	p = obs_properties_get(ppts, "buffer_size");
-	obs_property_set_visible(p, use_bufsize && !rc_crf);
 	return true;
 }
 
@@ -148,11 +146,12 @@ static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,
 	p = obs_properties_get(ppts, "crf");
 	obs_property_set_visible(p, !abr);
 
+	//hide UI elements if "rate_control" is CRF
 	p = obs_properties_get(ppts, "bitrate");
 	obs_property_set_visible(p, !rc_crf);
 	p = obs_properties_get(ppts, "use_bufsize");
 	obs_property_set_visible(p, !rc_crf);
-	p = obs_properties_get(ppts, "buffse_size");
+	p = obs_properties_get(ppts, "buffer_size");
 	obs_property_set_visible(p, !rc_crf);
 	return true;
 }

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -143,7 +143,8 @@ static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,
 	const char *rc = obs_data_get_string(settings, "rate_control");
 	bool abr = astrcmpi(rc, "CBR") == 0 || astrcmpi(rc, "ABR") == 0;
 	bool rc_crf = astrcmpi(rc, "CRF") == 0;
-
+	
+	//hide CRF value input field at CBR & ABR mode
 	p = obs_properties_get(ppts, "crf");
 	obs_property_set_visible(p, !abr);
 

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -133,6 +133,7 @@ static bool use_bufsize_modified(obs_properties_t *ppts, obs_property_t *p,
 	
 	//"buffer_size" UI is visible if "use_bufsize" is checked/enabled
 	p = obs_properties_get(ppts, "buffer_size");
+	obs_property_set_visible(p, use_bufsize);
 	return true;
 }
 


### PR DESCRIPTION
Fix visibility of the "Buffer Size" field, when CRF control rate method selected and "Use Custom Buffer Size" UI was checked/enabled earlier.

Issue caused by typo.

Also, removes unnecessary stuff from _use_bufsize_modified_.