### PR TITLE
UI: Set projector to be 'Always on Top'

### DIFF
--- a/obs/window-projector.cpp
+++ b/obs/window-projector.cpp
@@ -9,7 +9,8 @@
 
 OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_)
 	: OBSQTDisplay                 (widget,
-	                                Qt::Window | Qt::FramelessWindowHint),
+	                                Qt::Window | Qt::FramelessWindowHint |
+					Qt::WindowStaysOnTopHint),
 	  source                       (source_),
 	  removedSignal                (obs_source_get_signal_handler(source),
 	                                "remove", OBSSourceRemoved, this)


### PR DESCRIPTION
This solves an issue when dragging windows across monitors. It now makes sure no windows appear above the projector, and this makes the projector seamless, especially when the cursor is hidden.