### PR TITLE
UI: Fix fullscreen projector on Linux

### DIFF
--- a/obs/window-projector.cpp
+++ b/obs/window-projector.cpp
@@ -9,7 +9,8 @@
 
 OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_)
 	: OBSQTDisplay                 (widget,
-	                                Qt::Window | Qt::FramelessWindowHint),
+	                                Qt::Window | Qt::FramelessWindowHint |
+					Qt::X11BypassWindowManagerHint),
 	  source                       (source_),
 	  removedSignal                (obs_source_get_signal_handler(source),
 	                                "remove", OBSSourceRemoved, this)


### PR DESCRIPTION
This fixes a issue on Linux, at least on Ubuntu anyways, where the title bar and unity launcher is shown when the fullscreen projector is active.