### PR TITLE
test: Fix compiler warnings about incompatible pointer type

### DIFF
--- a/test/test-input/test-filter.c
+++ b/test/test-input/test-filter.c
@@ -5,8 +5,9 @@ struct test_filter {
 	gs_effect_t *whatever;
 };
 
-static const char *filter_getname(void)
+static const char *filter_getname(void *unused)
 {
+	UNUSED_PARAMETER(unused);
 	return "Test";
 }
 

--- a/test/test-input/test-random.c
+++ b/test/test-input/test-random.c
@@ -10,8 +10,9 @@ struct random_tex {
 	bool         initialized;
 };
 
-static const char *random_getname(void)
+static const char *random_getname(void *unused)
 {
+	UNUSED_PARAMETER(unused);
 	return "20x20 Random Pixel Texture Source (Test)";
 }
 

--- a/test/test-input/test-sinewave.c
+++ b/test/test-input/test-sinewave.c
@@ -58,8 +58,9 @@ static void *sinewave_thread(void *pdata)
 
 /* ------------------------------------------------------------------------- */
 
-static const char *sinewave_getname(void)
+static const char *sinewave_getname(void *unused)
 {
+	UNUSED_PARAMETER(unused);
 	return "Sinewave Sound Source (Test)";
 }
 


### PR DESCRIPTION
Method definitions for test plugins have not been updated after API change.