### PR TITLE
linux-capture: Add OBS_SOURCE_DO_NOT_DUPLICATE to window capture sources

### DIFF
--- a/plugins/linux-capture/xcomposite-main.cpp
+++ b/plugins/linux-capture/xcomposite-main.cpp
@@ -70,7 +70,8 @@ extern "C" void xcomposite_load(void)
 
 	sinfo.id = "xcomposite_input";
 	sinfo.output_flags = OBS_SOURCE_VIDEO |
-	                     OBS_SOURCE_CUSTOM_DRAW;
+	                     OBS_SOURCE_CUSTOM_DRAW |
+	                     OBS_SOURCE_DO_NOT_DUPLICATE;
 
 	sinfo.get_name       = xcompcap_getname;
 	sinfo.create         = xcompcap_create;


### PR DESCRIPTION
It seems that it is not possible to create multiple OpenGL textures
for the same window. When sources are duplicated in studio mode this
causes window capture sources to become black. The
OBS_SOURCE_DO_NOT_DUPLICATE flag prevents that this happens.