### PR TITLE
Added configuration for Coderwall

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -608,6 +608,18 @@
                 "max video bitrate": 3500,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Coderwall",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://live.coderwall.com/coderwall"
+                }
+            ],
+            "recommended": {
+                "max video bitrate": 1500
+            }
         }
     ]
 }


### PR DESCRIPTION
Coderwall is bringing their live streaming support out of beta (currently at http://coderwall.com/live). Added the server configuration to make it easier to begin live streaming.