### PR TITLE
added restart when "endless" stream gets into trouble

### DIFF
--- a/deps/libff/libff/ff-decoder.c
+++ b/deps/libff/libff/ff-decoder.c
@@ -267,8 +267,8 @@ void ff_decoder_refresh(void *opaque)
 			// compute the amount of time until next refresh
 			delay_until_next_wake = decoder->timer_next_wake -
 					(av_gettime() / 1000000.0L);
-			if (delay_until_next_wake < 0.010L) {
-				delay_until_next_wake = 0.010L;
+			if (delay_until_next_wake < 0.001L) {
+				delay_until_next_wake = 0.001L;
 			}
 
 			if (delay_until_next_wake > pts_diff)

--- a/deps/libff/libff/ff-decoder.c
+++ b/deps/libff/libff/ff-decoder.c
@@ -308,6 +308,15 @@ bool ff_decoder_accept(struct ff_decoder *decoder, struct ff_packet *packet)
 	return false;
 }
 
+bool ff_decoder_abort(struct ff_decoder *decoder)
+{
+	if (decoder == NULL)
+		return false;
+
+	packet_queue_abort(&decoder->packet_queue);
+	return true;
+}
+
 double ff_decoder_get_best_effort_pts(struct ff_decoder *decoder,
 		AVFrame *frame)
 {

--- a/deps/libff/libff/ff-decoder.c
+++ b/deps/libff/libff/ff-decoder.c
@@ -308,15 +308,6 @@ bool ff_decoder_accept(struct ff_decoder *decoder, struct ff_packet *packet)
 	return false;
 }
 
-bool ff_decoder_abort(struct ff_decoder *decoder)
-{
-	if (decoder == NULL)
-		return false;
-
-	packet_queue_abort(&decoder->packet_queue);
-	return true;
-}
-
 double ff_decoder_get_best_effort_pts(struct ff_decoder *decoder,
 		AVFrame *frame)
 {

--- a/deps/libff/libff/ff-demuxer.c
+++ b/deps/libff/libff/ff-demuxer.c
@@ -556,16 +556,18 @@ retry:
 		if (current_retry > 1) {
 			av_usleep((current_retry - 1) * 30 * 1000);
 		}
-		if (demuxer->audio_decoder != NULL) {
-			demuxer->audio_decoder->eof = true;
+		if (demuxer->audio_decoder != NULL)
 			ff_decoder_free(demuxer->audio_decoder);
-		}
-		if (demuxer->video_decoder != NULL) {
-			demuxer->video_decoder->eof = true;
+
+		if (demuxer->video_decoder != NULL)
 			ff_decoder_free(demuxer->video_decoder);
-		}
+
+		if (demuxer->format_context != NULL)
+			avformat_close_input(&demuxer->format_context);
+
 		demuxer->audio_decoder = NULL; // avoid any more accesses
 		demuxer->video_decoder = NULL;
+		demuxer->format_context = NULL;
 	}
 
 	if (!open_input(demuxer, &demuxer->format_context)) {

--- a/deps/libff/libff/ff-demuxer.c
+++ b/deps/libff/libff/ff-demuxer.c
@@ -614,7 +614,7 @@ retry:
 				AVIOContext *io_context =
 						demuxer->format_context->pb;
 				if (io_context->error == 0) {
-					av_usleep(20 * 1000); // 100ms
+					av_usleep(100 * 1000); // 100ms
 					continue;
 				} else {
 					if (io_context->eof_reached != 0)


### PR DESCRIPTION
I have a LKV373A V3. I plan to use it with OBS-Studio to capture presentation slides for our user group.

The LKV373A V3 sends a UDP mpeg ts multicast stream. ffplay can play it perfectly. My self build version of obs-studio plays it as well. But I got some glitches.

To prevent the playback to stop during a recording I started to change the code a bit.

* aborting decoder threads and open stream again
* added nobuffer option to get better predictable delay of the stream
* reduced the minimum delay between video frames (allows to better catchup with the stream)

It is still not perfect. Sometimes the video gets screwed and never aligns again.

I am open to suggestions to get this in the official version. I guess we need to add UI Options, but I want to check if you would merge it.