### PR TITLE
rtmp-services: Add Boomstream service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 27,
+	"version": 28,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 27
+			"version": 28
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -608,6 +608,15 @@
                 "max video bitrate": 3500,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Boomstream",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://live.boomstream.com/live"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Boomstream is an Online Video Platform.
https://boomstream.com/

We suggest using OBS for our customers.