### PR TITLE
libobs: Fix possible null pointer dereference

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -585,7 +585,8 @@ bool obs_property_button_clicked(obs_property_t *p, void *obj)
 		struct button_data *data = get_type_data(p,
 				OBS_PROPERTY_BUTTON);
 		if (data && data->callback)
-			return data->callback(p->parent, p, context->data);
+			return data->callback(p->parent, p,
+					(context ? context->data : NULL));
 	}
 
 	return false;


### PR DESCRIPTION
OBS crashes when clicking a button in the encoder settings page due to context being nullptr. This fixes that by switching the last parameter to be 0 if context was nullptr.