### PR TITLE
hack to get vlc udp media streaming to work on Windows

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.c
+++ b/plugins/vlc-video/vlc-video-plugin.c
@@ -16,6 +16,8 @@ LIBVLC_EVENT_ATTACH libvlc_event_attach_;
 
 /* libvlc media */
 LIBVLC_MEDIA_NEW_PATH libvlc_media_new_path_;
+LIBVLC_MEDIA_NEW_LOCATION libvlc_media_new_location_;
+LIBVLC_MEDIA_ADD_OPTION libvlc_media_add_option_;
 LIBVLC_MEDIA_RELEASE libvlc_media_release_;
 LIBVLC_MEDIA_RELEASE libvlc_media_retain_;
 
@@ -76,6 +78,8 @@ static bool load_vlc_funcs(void)
 
 	/* libvlc media */
 	LOAD_VLC_FUNC(libvlc_media_new_path);
+	LOAD_VLC_FUNC(libvlc_media_new_location);
+	LOAD_VLC_FUNC(libvlc_media_add_option);
 	LOAD_VLC_FUNC(libvlc_media_release);
 	LOAD_VLC_FUNC(libvlc_media_retain);
 

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -1,16 +1,16 @@
 #include <obs-module.h>
-#include <libvlc.h>
+#include <vlc/libvlc.h>
 
 #ifdef _MSC_VER
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 
-#include <libvlc_media.h>
-#include <libvlc_events.h>
-#include <libvlc_media_list.h>
-#include <libvlc_media_player.h>
-#include <libvlc_media_list_player.h>
+#include <vlc/libvlc_media.h>
+#include <vlc/libvlc_events.h>
+#include <vlc/libvlc_media_list.h>
+#include <vlc/libvlc_media_player.h>
+#include <vlc/libvlc_media_list_player.h>
 
 extern libvlc_instance_t *libvlc;
 extern uint64_t time_start;
@@ -29,6 +29,9 @@ typedef int (*LIBVLC_EVENT_ATTACH)(libvlc_event_manager_t *p_event_manager,
 /* libvlc media */
 typedef libvlc_media_t *(*LIBVLC_MEDIA_NEW_PATH)(
 		libvlc_instance_t *p_instance, const char *path);
+typedef libvlc_media_t *(*LIBVLC_MEDIA_NEW_LOCATION)(
+		libvlc_instance_t *p_instance, const char *location);
+typedef void (*LIBVLC_MEDIA_ADD_OPTION)(libvlc_media_t *p_md, const char *options);
 typedef void (*LIBVLC_MEDIA_RETAIN)(libvlc_media_t *p_md);
 typedef void (*LIBVLC_MEDIA_RELEASE)(libvlc_media_t *p_md);
 
@@ -119,6 +122,8 @@ extern LIBVLC_EVENT_ATTACH libvlc_event_attach_;
 
 /* libvlc media */
 extern LIBVLC_MEDIA_NEW_PATH libvlc_media_new_path_;
+extern LIBVLC_MEDIA_NEW_LOCATION libvlc_media_new_location_;
+extern LIBVLC_MEDIA_ADD_OPTION libvlc_media_add_option_;
 extern LIBVLC_MEDIA_RELEASE libvlc_media_release_;
 extern LIBVLC_MEDIA_RETAIN libvlc_media_retain_;
 

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -76,7 +76,7 @@ static libvlc_media_t *get_media(struct darray *array, const char *path)
 
 static inline libvlc_media_t *create_media_from_file(const char *file)
 {
-	return libvlc_media_new_path_(libvlc, file);
+	return libvlc_media_new_location_(libvlc, file);
 }
 
 static void free_files(struct darray *array)
@@ -303,7 +303,7 @@ static unsigned vlcs_video_format(void **p_data, char *chroma, unsigned *width,
 
 	new_format = convert_vlc_video_format(chroma, &new_range);
 
-	libvlc_video_get_size_(c->media_player, 0, width, height);
+	//int res = libvlc_video_get_size_(c->media_player, 0, width, height);
 
 	/* don't allocate a new frame if format/width/height hasn't changed */
 	if (c->frame.format != new_format ||
@@ -387,7 +387,7 @@ static void add_file(struct vlc_source *c, struct darray *array,
 
 	dstr_copy(&new_path, path);
 #ifdef _WIN32
-	dstr_replace(&new_path, "/", "\\");
+	//dstr_replace(&new_path, "/", "\\");
 #endif
 	path = new_path.array;
 
@@ -399,6 +399,8 @@ static void add_file(struct vlc_source *c, struct darray *array,
 		new_media = create_media_from_file(path);
 
 	if (new_media) {
+		libvlc_media_add_option_(new_media, ":network-caching=100");
+
 		data.path = new_path.array;
 		data.media = new_media;
 		da_push_back(new_files, &data);


### PR DESCRIPTION
Some changes that should be properly included to support reading video streams with VLC into obs-studio. Right now it's hacked to work for me. (Time runs out too fast)