### PR TITLE
libobs: Set core signal handlers to NULL after destroying

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -820,6 +820,8 @@ void obs_shutdown(void)
 	obs_free_graphics();
 	proc_handler_destroy(obs->procs);
 	signal_handler_destroy(obs->signals);
+	obs->procs = NULL;
+	obs->signals = NULL;
 
 	module = obs->first_module;
 	while (module) {


### PR DESCRIPTION
Fixes https://obsproject.com/mantis/view.php?id=595