### PR TITLE
Add Windows bitness (32/64-bit) to log file

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -172,13 +172,27 @@ static void log_available_memory(void)
 			note);
 }
 
+static bool is_64_bit_windows(void)
+{
+#if defined(_WIN64)
+	return true;
+#elif defined(_WIN32)
+	BOOL b64 = false;
+	return IsWow64Process(GetCurrentProcess(), &b64) && b64;
+#endif
+}
+
 static void log_windows_version(void)
 {
 	struct win_version_info ver;
 	get_win_ver(&ver);
 
-	blog(LOG_INFO, "Windows Version: %d.%d Build %d (revision: %d)",
-			ver.major, ver.minor, ver.build, ver.revis);
+	bool b64 = is_64_bit_windows();
+	const char *windows_bitness = b64 ? "64" : "32";
+
+	blog(LOG_INFO, "Windows Version: %d.%d Build %d (revision: %d; %s-bit)",
+			ver.major, ver.minor, ver.build, ver.revis,
+			windows_bitness);
 }
 
 static void log_admin_status(void)


### PR DESCRIPTION
This commit/PR adds the Windows OS bitness (32-bit or 64-bit) to the log file.

I've read the CONTRIBUTING doc and the [Linux kernel coding style document](https://www.kernel.org/doc/Documentation/CodingStyle), and I've tried my best to conform to those.  However, I'm not great at C, so there may be better ways to achieve this.  I'm open to feedback.