### PR TITLE
UI: Add option to stop output after specified time

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -532,6 +532,9 @@ Basic.Settings.Advanced.StreamDelay.Preserve="Preserve cutoff point (increase de
 Basic.Settings.Advanced.StreamDelay.MemoryUsage="Estimated Memory Usage: %1 MB"
 Basic.Settings.Advanced.Network="Network"
 Basic.Settings.Advanced.Network.BindToIP="Bind to IP"
+Basic.Settings.Advanced.Timers="Timers"
+Basic.Settings.Advanced.Timers.Streaming="Stop streaming after (seconds)"
+Basic.Settings.Advanced.Timers.Recording="Stop recording after (seconds)"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -3305,6 +3305,90 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QGroupBox" name="timerGroupBox">
+                  <property name="title">
+                   <string>Basic.Settings.Advanced.Timers</string>
+                  </property>
+                  <layout class="QFormLayout" name="timerLayout">
+                   <property name="fieldGrowthPolicy">
+                    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                   </property>
+                   <item row="0" column="1">
+                    <widget class="QCheckBox" name="streamTimerEnable">
+                     <property name="text">
+                      <string>Enable</string>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QSpinBox" name="streamingTimer">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="minimum">
+                      <number>1</number>
+                     </property>
+                     <property name="maximum">
+                      <number>100000</number>
+                     </property>
+                     <property name="value">
+                      <number>60</number>
+                     </property>
+                     </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="streamTimerLabel">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.Timers.Streaming</string>
+                     </property>
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QCheckBox" name="recordTimerEnable">
+                     <property name="text">
+                      <string>Enable</string>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QSpinBox" name="recordingTimer">
+                    <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="minimum">
+                      <number>1</number>
+                     </property>
+                     <property name="maximum">
+                      <number>100000</number>
+                     </property>
+                     <property name="value">
+                      <number>60</number>
+                     </property>
+                    </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="recordTimerLabel">
+                      <property name="text">
+                       <string>Basic.Settings.Advanced.Timers.Recording</string>
+                      </property>
+                      <property name="enabled">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QLabel" name="advancedMsg">
                   <property name="styleSheet">
                    <string notr="true">color: rgb(255, 0, 4);</string>
@@ -3790,6 +3874,70 @@
     <hint type="destinationlabel">
      <x>404</x>
      <y>271</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>streamTimerEnable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>streamingTimer</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>recordTimerEnable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>recordingTimer</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>streamTimerEnable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>streamTimerLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>recordTimerEnable</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>recordTimerLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>250</x>
+     <y>39</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>250</x>
+     <y>39</y>
     </hint>
    </hints>
   </connection>

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -20,6 +20,7 @@
 #include <QBuffer>
 #include <QAction>
 #include <QSystemTrayIcon>
+#include <QTimer>
 #include <obs.hpp>
 #include <vector>
 #include <memory>
@@ -143,6 +144,9 @@ private:
 	QAction       *showHide;
 	QAction       *showPreview;
 	QAction       *exit;
+
+	QTimer        *stopStreamingTimer;
+	QTimer        *stopRecordingTimer;
 
 	void          DrawBackdrop(float cx, float cy);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -376,6 +376,10 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->reconnectMaxRetries,  SCROLL_CHANGED, ADV_CHANGED);
 	HookWidget(ui->processPriority,      COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->bindToIP,             COMBO_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->streamTimerEnable,    CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->recordTimerEnable,    CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->streamingTimer,       SCROLL_CHANGED, ADV_CHANGED);
+	HookWidget(ui->recordingTimer,       SCROLL_CHANGED, ADV_CHANGED);
 
 #ifdef _WIN32
 	uint32_t winVer = GetWindowsVersion();
@@ -1842,6 +1846,14 @@ void OBSBasicSettings::LoadAdvancedSettings()
 			"OverwriteIfExists");
 	const char *bindIP = config_get_string(main->Config(), "Output",
 			"BindIP");
+	int streamSec = config_get_int(main->Config(), "Output",
+			"StreamTimer");
+	int recordSec = config_get_int(main->Config(), "Output",
+			"RecordTimer");
+	bool enableStreamTimer = config_get_bool(main->Config(), "Output",
+			"StreamTimerEnable");
+	bool enableRecordTimer = config_get_bool(main->Config(), "Output",
+			"RecordTimerEnable");
 
 	loading = true;
 
@@ -1863,6 +1875,11 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	SetComboByValue(ui->colorRange, videoColorRange);
 
 	SetComboByValue(ui->bindToIP, bindIP);
+
+	ui->streamTimerEnable->setChecked(enableStreamTimer);
+	ui->recordTimerEnable->setChecked(enableRecordTimer);
+	ui->streamingTimer->setValue(streamSec);
+	ui->recordingTimer->setValue(recordSec);
 
 	if (video_output_active(obs_get_video())) {
 		ui->advancedVideoContainer->setEnabled(false);
@@ -2363,6 +2380,10 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveSpinBox(ui->reconnectRetryDelay, "Output", "RetryDelay");
 	SaveSpinBox(ui->reconnectMaxRetries, "Output", "MaxRetries");
 	SaveComboData(ui->bindToIP, "Output", "BindIP");
+	SaveCheckBox(ui->streamTimerEnable, "Output", "StreamTimerEnable");
+	SaveCheckBox(ui->recordTimerEnable, "Output", "RecordTimerEnable");
+	SaveSpinBox(ui->streamingTimer, "Output", "StreamTimer");
+	SaveSpinBox(ui->recordingTimer, "Output", "RecordTimer");
 }
 
 static inline const char *OutputModeFromIdx(int idx)


### PR DESCRIPTION
This adds an optional timer to the streaming and recording outputs. After this time is elapsed the outputs are stopped.