### PR TITLE
obs-ffmpeg: Readded setting the profile for nvenc

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -159,7 +159,7 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 
 	nvenc_video_info(enc, &info);
 	av_opt_set_int(enc->context->priv_data, "cbr", false, 0);
-
+	av_opt_set(enc->context->priv_data, "profile", profile, 0);
 	av_opt_set(enc->context->priv_data, "preset", preset, 0);
 
 	if (astrcmpi(rc, "cqp") == 0) {


### PR DESCRIPTION
This should fix https://obsproject.com/mantis/view.php?id=621

Originally this line was removed in 0157d025644fb8a5fa6230690843b83eea8b2a69, I think by accident?