### PR TITLE
image-source: Reload file when timestamp has changed

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -207,7 +207,7 @@ static void image_source_tick(void *data, float seconds)
 		time_t t = get_modified_timestamp(context->file);
 		context->update_time_elapsed = 0.0f;
 
-		if (context->file_timestamp < t) {
+		if (context->file_timestamp != t) {
 			image_source_load(context);
 		}
 	}


### PR DESCRIPTION
This commit fixes the issue outlined in the following thread:
https://obsproject.com/forum/threads/check-for-file-changes-on-images.50045/

When the image source file was replaced by an outside process, it would only reload when the file's new timestamp was newer than the file's previous timestamp.  If you're copying image files onto a common file name (for example, "C:\obs-stuff\image.jpg"), and you have an Image Source targeting that common file name, then this could cause the image source to get stuck on the image that has the newest timestamp.  This fixes that behavior.  Now an image source will reload any time the file's new timestamp is different than its previous timestamp.

I've built and tested this change on Windows 10 64-bit.  I welcome additional testing or feedback.