### PR TITLE
fixup_bundle script fixes

### DIFF
--- a/cmake/osxbundle/fixup_bundle.sh
+++ b/cmake/osxbundle/fixup_bundle.sh
@@ -9,7 +9,9 @@ cd "$1"
 
 function buildlist() {
 	otool -L "$@" | 
-		grep -E "(opt|Users)" |
+		grep -E '^\s+/' |
+		grep -vE '^\s+/System/' |
+		grep -vE '^\s+/usr/lib/' |
 		perl -pe 's|^\s+(/.*)\s\(.*$|$1|' |
 		grep -vE ":$" |
 		sort -u
@@ -34,6 +36,7 @@ for lib in $FOUNDLIBS; do
 
 	INTOOL_CALL+=(-change "$lib" "$LDEST/$libname")
 	cp "$lib" "$DEST/$libname"
+	chmod 644 "$DEST/$libname"
 
 	echo "Fixing up dependency: $libname"
 done


### PR DESCRIPTION
These changes make the fixup script able to copy all non-system dependencies.

On my system, some of the copied libraries are read-only and must be set writable after copying them so install_name_tool is able to modify them.

Without these fixes, the fixup script misses dependencies from /usr/local/ and would conceivable miss any dependencies that are not is the /Users or /opt directory. And with the wrong permissions, install_name_tool gives off a bunch of errors like this :

```
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't open input file: bin/libavcodec.57.dylib for writing (Permission denied)
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't lseek to offset: 0 in file: bin/libavcodec.57.dylib for writing (Bad file descriptor)
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't write new headers in file: bin/libavcodec.57.dylib (Bad file descriptor)
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't close written on input file: bin/libavcodec.57.dylib (Bad file descriptor)
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't open input file: bin/libavdevice.57.dylib for writing (Permission denied)
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: can't lseek to offset: 0 in file: bin/libavdevice.57.dylib for writing (Bad file descriptor)
```
