### PR TITLE
UI: Fix crash in filters dialog caused by access to deleted widget

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -146,8 +146,10 @@ inline OBSSource OBSBasicFilters::GetFilter(int row, bool async)
 
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
-	delete view;
-	view = nullptr;
+	if (view) {
+		view->deleteLater();
+		view = nullptr;
+	}
 
 	OBSSource filter = GetFilter(row, async);
 	if (!filter)


### PR DESCRIPTION
Qt seems to access a deleted widget when it tries to calculate the focus object of the scroll area for the properties widget. This happens when you tab through the filters dialog, it crashes when the properties have been refreshed at least once and you unfocus the last input element of the properties, for example the spin box of the crop filter. Just add a crop filter and hold tab already causes the crash. That causes the following crash:
 ```
Thread 1 "obs" received signal SIGSEGV, Segmentation fault.
0xb7979857 in QWidget::focusWidget (this=0x88a47e8) at kernel/qwidget.cpp:6776
6776	kernel/qwidget.cpp: Datei oder Verzeichnis nicht gefunden.
(gdb) bt
#0  0xb7979857 in QWidget::focusWidget (this=0x88a47e8) at kernel/qwidget.cpp:6776
#1  0xb7b3fa39 in QScrollArea::focusNextPrevChild (this=0x88a47e8, next=true) at widgets/qscrollarea.cpp:422
#2  0xb798cc60 in QWidget::focusNextPrevChild (this=0x8835370, next=true) at kernel/qwidget.cpp:6729
#3  0xb798cc60 in QWidget::focusNextPrevChild (this=0x883a1e0, next=true) at kernel/qwidget.cpp:6729
#4  0xb798cc60 in QWidget::focusNextPrevChild (this=0x88436d0, next=true) at kernel/qwidget.cpp:6729
#5  0xb799366e in QWidget::event (this=0x88436d0, event=0xbfffed60) at kernel/qwidget.cpp:8774
#6  0xb7a5dc4a in QAbstractSpinBox::event (this=0x88436d0, event=0xbfffed60) at widgets/qabstractspinbox.cpp:779
#7  0xb7b04327 in QSpinBox::event (this=0x88436d0, event=0xbfffed60) at widgets/qspinbox.cpp:1320
```

Valgrind reports that this widget has been deleted in by the destructor call of the properties view in the filter dialog:
```
Invalid read of size 4
   at 0x4193854: QWidget::focusWidget() const (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x4359A38: QScrollArea::focusNextPrevChild(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x41A6C5F: QWidget::focusNextPrevChild(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x41A6C5F: QWidget::focusNextPrevChild(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x41A6C5F: QWidget::focusNextPrevChild(bool) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x41AD66D: QWidget::event(QEvent*) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x4277C49: QAbstractSpinBox::event(QEvent*) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
   by 0x431E326: QSpinBox::event(QEvent*) (in /usr/lib/i386-linux-gnu/libQt5Widgets.so.5.6.1)
 Address 0x134ed47c is 4 bytes inside a block of size 84 free'd
   at 0x402E808: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
   by 0x828E05C: OBSPropertiesView::~OBSPropertiesView() (properties-view.hpp:64)
   by 0x81CD466: OBSBasicFilters::UpdatePropertiesView(int, bool) (window-basic-filters.cpp:149)
```

Using `view->deleteLater()` instead of `delete view` fixes this crash.