### PR TITLE
Button property click handlers should receive settings data

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1672,7 +1672,7 @@ void WidgetInfo::EditableListChanged()
 
 void WidgetInfo::ButtonClicked()
 {
-	if (obs_property_button_clicked(property, view->obj)) {
+	if (obs_property_button_clicked(property, view->obj, view->settings)) {
 		QMetaObject::invokeMethod(view, "RefreshProperties",
 				Qt::QueuedConnection);
 	}

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -578,7 +578,7 @@ bool obs_property_modified(obs_property_t *p, obs_data_t *settings)
 	return false;
 }
 
-bool obs_property_button_clicked(obs_property_t *p, void *obj)
+bool obs_property_button_clicked(obs_property_t *p, void *obj, obs_data_t *settings)
 {
 	struct obs_context_data *context = obj;
 	if (p) {
@@ -586,7 +586,7 @@ bool obs_property_button_clicked(obs_property_t *p, void *obj)
 				OBS_PROPERTY_BUTTON);
 		if (data && data->callback)
 			return data->callback(p->parent, p,
-					(context ? context->data : NULL));
+					(context ? context->data : NULL), settings);
 	}
 
 	return false;

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -137,7 +137,7 @@ EXPORT void obs_properties_apply_settings(obs_properties_t *props,
  * otherwise return false.
  */
 typedef bool (*obs_property_clicked_t)(obs_properties_t *props,
-		obs_property_t *property, void *data);
+		obs_property_t *property, void *data, obs_data_t *settings);
 
 EXPORT obs_property_t *obs_properties_add_bool(obs_properties_t *props,
 		const char *name, const char *description);
@@ -228,7 +228,7 @@ EXPORT void obs_property_set_modified_callback(obs_property_t *p,
 		obs_property_modified_t modified);
 
 EXPORT bool obs_property_modified(obs_property_t *p, obs_data_t *settings);
-EXPORT bool obs_property_button_clicked(obs_property_t *p, void *obj);
+EXPORT bool obs_property_button_clicked(obs_property_t *p, void *obj, obs_data_t *settings);
 
 EXPORT void obs_property_set_visible(obs_property_t *p, bool visible);
 EXPORT void obs_property_set_enabled(obs_property_t *p, bool enabled);

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -903,7 +903,7 @@ static void show_syphon_license_internal(void)
 }
 
 static bool show_syphon_license(obs_properties_t *props, obs_property_t *prop,
-		void *data)
+		void *data, obs_data_t *settings)
 {
 	UNUSED_PARAMETER(props);
 	UNUSED_PARAMETER(prop);

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1305,7 +1305,7 @@ static bool DeviceSelectionChanged(obs_properties_t *props, obs_property_t *p,
 }
 
 static bool VideoConfigClicked(obs_properties_t *props, obs_property_t *p,
-		void *data)
+		void *data, obs_data_t *settings)
 {
 	DShowInput *input = reinterpret_cast<DShowInput*>(data);
 	input->QueueAction(Action::ConfigVideo);
@@ -1327,7 +1327,7 @@ static bool VideoConfigClicked(obs_properties_t *props, obs_property_t *p,
 }*/
 
 static bool CrossbarConfigClicked(obs_properties_t *props, obs_property_t *p,
-		void *data)
+		void *data, obs_data_t *settings)
 {
 	DShowInput *input = reinterpret_cast<DShowInput*>(data);
 	input->QueueAction(Action::ConfigCrossbar1);
@@ -1698,7 +1698,7 @@ static bool CustomAudioClicked(obs_properties_t *props, obs_property_t *p,
 }
 
 static bool ActivateClicked(obs_properties_t *, obs_property_t *p,
-		void *data)
+		void *data, obs_data_t *settings)
 {
 	DShowInput *input = reinterpret_cast<DShowInput*>(data);
 


### PR DESCRIPTION
This makes click handlers receive settings data, much like other properties do in their "modified" callback.