### PR TITLE
Fix a string in Russian locale

### DIFF
--- a/UI/data/locale/ru-RU.ini
+++ b/UI/data/locale/ru-RU.ini
@@ -333,7 +333,7 @@ Basic.Settings.General.CenterSnapping="Привязка к центру по г�
 Basic.Settings.General.SourceSnapping="Привязка к другим источникам"
 Basic.Settings.General.SnapDistance="Чувствительность привязки"
 Basic.Settings.General.RecordWhenStreaming="Автоматическая запись при стриме"
-Basic.Settings.General.KeepRecordingWhenStreamStops="Сохранить запись, когда стрим остановится"
+Basic.Settings.General.KeepRecordingWhenStreamStops="Продолжить запись, когда стрим остановится"
 
 Basic.Settings.Stream="Вещание"
 Basic.Settings.Stream.StreamType="Тип вещания"


### PR DESCRIPTION
Fixed "Keep Recording when stream stops" string in Russian. It was "Save recording", now it's "Continue recording". English "keep" is a two words in russian with different meanings.
This option confused me when I opened settings for the first time