### PR TITLE
rtmp-services: Add Asian Livecoding.tv server and increase video bitrate

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 38,
+	"version": 39,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 38
+			"version": 39
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -326,10 +326,14 @@
                 {
                     "name": "EU",
                     "url": "rtmp://eumedia1.livecoding.tv/livecodingtv"
+                },
+                {
+                    "name": "Asia Pacific",
+                    "url": "rtmp://apmedia1.livecoding.tv/livecodingtv"
                 }
             ],
             "recommended": {
-                "max video bitrate": 1300
+                "max video bitrate": 2300
             }
         },
         {


### PR DESCRIPTION
The new streaming cluster is up and running and there's now an ingest server for the Asia-Pacific area.

The new streaming infrastructure allows streams with up to 2500kbps (total), therefore I increased the max video bitrate from 1300 to 2300 - this leaves enough room for audio up to 192kbps to stay below the maximum bitrate.

BTW: Their support told me that if you stream from the US to e.g. the EU server, the server will reject it. They apparently ensure that you stream to the geographically closest server and disallow streaming to others.