### PR TITLE
Display license in MSI installer

### DIFF
--- a/cmake/Modules/ObsCpack.cmake
+++ b/cmake/Modules/ObsCpack.cmake
@@ -8,6 +8,7 @@ endif()
 set(CPACK_PACKAGE_NAME "OBS")
 set(CPACK_PACKAGE_VENDOR "obsproject.com")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OBS - Live video and audio streaming and recording software")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/UI/data/license/gplv2.txt")
 
 set(CPACK_PACKAGE_VERSION_MAJOR "0")
 set(CPACK_PACKAGE_VERSION_MINOR "0")


### PR DESCRIPTION
This change puts the GPL license text in the MSI installer, as it is with the NSIS installer.
