### PR TITLE
UI: Enable HiDPI scaling.

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1309,6 +1309,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	QCoreApplication::addLibraryPath(".");
 
+	QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
 	OBSApp program(argc, argv, profilerNameStore.get());
 	try {
 		program.AppInit();


### PR DESCRIPTION
This makes the app much more usable on hidpi screen devices like the
surface.


![obs1](https://cloud.githubusercontent.com/assets/207897/18978685/b652afa8-868a-11e6-92a3-7f22bff41ab7.PNG)
![obs2](https://cloud.githubusercontent.com/assets/207897/18978686/b6560fb8-868a-11e6-9a3c-1d3cd35ce5f2.PNG)