### PR TITLE
Increase MAX_BUFFERING_TICKS to Increase Max Audio Buffer Size

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -24,7 +24,7 @@ struct ts_info {
 };
 
 #define DEBUG_AUDIO 0
-#define MAX_BUFFERING_TICKS 4500
+#define MAX_BUFFERING_TICKS 450
 
 static void push_audio_tree(obs_source_t *parent, obs_source_t *source, void *p)
 {

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -24,7 +24,7 @@ struct ts_info {
 };
 
 #define DEBUG_AUDIO 0
-#define MAX_BUFFERING_TICKS 45
+#define MAX_BUFFERING_TICKS 4500
 
 static void push_audio_tree(obs_source_t *parent, obs_source_t *source, void *p)
 {


### PR DESCRIPTION
**More Info:** https://obsproject.com/forum/threads/max_buffering_ticks-artificial-limit-to-audio-sync-offset.54867/

**Relevant Previous Commits:**
https://github.com/jp9000/obs-studio/commit/c1dd156db8b15d2f54a1953c6f403230b2b7ef23
https://github.com/jp9000/obs-studio/commit/31496ec3639aef24394f9faefce693a154e75a50

**Examples of Commit Change in Action:**
Video Showing Issue: https://youtu.be/2NE3-uDlAFI
Video Showing Resolution: https://youtu.be/bMZ8Md8uvy0

**Summary tldr:** A hardcoded #define value of 45 here means that there is only a maximum of 960ms (@48khz) available to the audio buffer. The audio buffer can handle more (since the Dec 2015 audio rewrite) but it is hardcoded to be less than a second. It was set to 80, but was reduced to its current value 45 in Feb. Values near this limit will cause audio stutters, growing in severity until the audio source cuts out completely.

**Why:** Audio processing outside of OBS adds a delay to the audio before it reaches OBS, and OBS requires an audio buffer large enough to "undo" this delay. For example, I am intending to use Audition for microphone audio processing (noise reduction, normalization, etc), and each of these processing effects adds to the overall delay. More effects equals more delay, and a complex enough pipeline could rather easily cross the current 960ms threshold, especially if these programs are given large buffers themselves in order to help prevent any unintended audio artifacts from slow processing.

**Ideal:** Ideally the audio buffer wouldn't be #define limited. Some sort of (substantially higher) maximum is of course fine, but a better alternative might be to have the setting be listed in the OBS settings window or adv-audio panel. This pull request isn't perfect, but it increases the buffer limit to a value that works for me and (theoretically) others in all but the most complex of audio pipeline situations.