### PR TITLE
Stop using GetMonitors in WindowPositionValid in UI/obs-app.cpp.

### DIFF
--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -85,7 +85,7 @@ public:
 	~OBSApp();
 
 	void AppInit();
-	bool OBSInit();
+	bool OBSInit(QDesktopWidget *qdw);
 
 	inline QMainWindow *GetMainWindow() const {return mainWindow.data();}
 
@@ -166,7 +166,7 @@ inline const char *Str(const char *lookup) {return App()->GetString(lookup);}
 bool GetFileSafeName(const char *name, std::string &file);
 bool GetClosestUnusedFileName(std::string &path, const char *extension);
 
-bool WindowPositionValid(QRect rect);
+bool WindowPositionValid(QRect rect, QDesktopWidget *qdw);
 
 static inline int GetProfilePath(char *path, size_t size, const char *file)
 {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -116,7 +116,7 @@ static void AddExtraModulePaths()
 
 static QList<QKeySequence> DeleteKeys;
 
-OBSBasic::OBSBasic(QWidget *parent)
+OBSBasic::OBSBasic(QDesktopWidget *qdw, QWidget *parent)
 	: OBSMainWindow  (parent),
 	  ui             (new Ui::OBSBasic)
 {
@@ -137,7 +137,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 		restoreGeometry(byteArray);
 
 		QRect windowGeometry = normalGeometry();
-		if (!WindowPositionValid(windowGeometry)) {
+		if (!WindowPositionValid(windowGeometry, qdw)) {
 			QRect rect = App()->desktop()->availableGeometry();
 			setGeometry(QStyle::alignedRect(
 						Qt::LeftToRight,

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -580,7 +580,7 @@ public slots:
 	void on_actionResetTransform_triggered();
 
 public:
-	explicit OBSBasic(QWidget *parent = 0);
+	explicit OBSBasic(QDesktopWidget *qdw, QWidget *parent = 0);
 	virtual ~OBSBasic();
 
 	virtual void OBSInit() override;


### PR DESCRIPTION
This change is a start to removing GetMonitors and replacing it with Qt
library functionality.

Hi, I was playing around a bit with the code for obs-studio. I found that the OS specific calls for GetMonitors appear to be implementable with Qt5. This change is a first cut in that direction.

After this change, there are still some uses of the OS specific GetMonitors implmentations. The remaining uses should also be possible to remove. Here's a list for your info:

```
$ git grep GetMonitors
UI/platform-osx.mm:void GetMonitors(vector<MonitorInfo> &monitors)
UI/platform-windows.cpp:void GetMonitors(vector<MonitorInfo> &monitors)
UI/platform-x11.cpp:void GetMonitors(vector<MonitorInfo> &monitors)
UI/platform.hpp:void GetMonitors(std::vector<MonitorInfo> &monitors);
UI/window-basic-main.cpp:       GetMonitors(monitors);
UI/window-basic-main.cpp:       GetMonitors(monitors);
UI/window-basic-settings.cpp:   GetMonitors(monitors);
UI/window-projector.cpp:        GetMonitors(monitors);
```

Also, changing OBSApp to inherit from QGuiApplication instead of just QApplication will allow even  better constructs to be used.

I wanted to post this sooner rather than later to get your input, so what do you think?