### PR TITLE
UI: Add raw text and text file to drag&drop support

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -11,6 +11,10 @@
 
 using namespace std;
 
+static const char *textExtensions[] = {
+	"txt", "log", nullptr
+};
+
 static const char *imageExtensions[] = {
 	"bmp", "tga", "png", "jpg", "jpeg", "gif", nullptr
 };
@@ -32,6 +36,7 @@ static const char *mediaExtensions[] = {
 	nullptr
 };
 
+
 static string GenerateSourceName(const char *base)
 {
 	string name;
@@ -52,19 +57,31 @@ static string GenerateSourceName(const char *base)
 	}
 }
 
-void OBSBasic::AddDropSource(const char *file, bool image)
+void OBSBasic::AddDropSource(const char *data, DropType image)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
 	obs_data_t *settings = obs_data_create();
 	obs_source_t *source = nullptr;
 	const char *type = nullptr;
 
-	if (image) {
-		obs_data_set_string(settings, "file", file);
-		type = "image_source";
-	} else {
-		obs_data_set_string(settings, "local_file", file);
-		type = "ffmpeg_source";
+	switch (image) {
+		case DropType_RawText:
+			obs_data_set_string(settings, "text", data);
+			type = "text_gdiplus";
+			break;
+		case DropType_Text:
+			obs_data_set_bool(settings, "read_from_file", true);
+			obs_data_set_string(settings, "file", data);
+			type = "text_gdiplus";
+			break;
+		case DropType_Image:
+			obs_data_set_string(settings, "file", data);
+			type = "image_source";
+			break;
+		case DropType_Media:
+			obs_data_set_string(settings, "local_file", data);
+			type = "ffmpeg_source";
+			break;
 	}
 
 	const char *name = obs_source_get_display_name(type);
@@ -113,10 +130,26 @@ void OBSBasic::dropEvent(QDropEvent *event)
 			const char *suffix = suffixArray.constData();
 			bool found = false;
 
-			const char **cmp = imageExtensions;
+			const char **cmp;
+
+			cmp = textExtensions;
 			while (*cmp) {
 				if (strcmp(*cmp, suffix) == 0) {
-					AddDropSource(QT_TO_UTF8(file), true);
+					AddDropSource(QT_TO_UTF8(file), DropType_Text);
+					found = true;
+					break;
+				}
+
+				cmp++;
+			}
+
+			if (found)
+				continue;
+
+			cmp = imageExtensions;
+			while (*cmp) {
+				if (strcmp(*cmp, suffix) == 0) {
+					AddDropSource(QT_TO_UTF8(file), DropType_Image);
 					found = true;
 					break;
 				}
@@ -130,13 +163,15 @@ void OBSBasic::dropEvent(QDropEvent *event)
 			cmp = mediaExtensions;
 			while (*cmp) {
 				if (strcmp(*cmp, suffix) == 0) {
-					AddDropSource(QT_TO_UTF8(file), false);
+					AddDropSource(QT_TO_UTF8(file), DropType_Media);
 					break;
 				}
 
 				cmp++;
 			}
 		}
+	} else if (mimeData->hasText()) {
+		AddDropSource(QT_TO_UTF8(mimeData->text()), DropType_RawText);
 	}
 }
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -95,6 +95,13 @@ class OBSBasic : public OBSMainWindow {
 		Right
 	};
 
+	enum DropType {
+		DropType_RawText,
+		DropType_Text,
+		DropType_Image,
+		DropType_Media
+	};
+
 private:
 	obs_frontend_callbacks *api = nullptr;
 
@@ -299,7 +306,7 @@ private:
 	inline void OnActivate();
 	inline void OnDeactivate();
 
-	void AddDropSource(const char *file, bool image);
+	void AddDropSource(const char *file, DropType image);
 	void dragEnterEvent(QDragEnterEvent *event) override;
 	void dragLeaveEvent(QDragLeaveEvent *event) override;
 	void dragMoveEvent(QDragMoveEvent *event) override;


### PR DESCRIPTION
This adds raw text (drag and drop from anywhere as text) and text file (.txt, .log) support to obs studio.