### PR TITLE
UI: Split Properties window with a QSplitter

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -70,21 +70,28 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	view = new OBSPropertiesView(settings, source,
 			(PropertiesReloadCallback)obs_source_properties,
 			(PropertiesUpdateCallback)obs_source_update);
-
-	preview->setMinimumSize(20, 20);
+	//view->setMaximumHeight(250);
+	view->setMinimumHeight(150);
+	
+	preview->setMinimumSize(20, 150);
 	preview->setSizePolicy(QSizePolicy(QSizePolicy::Expanding,
 				QSizePolicy::Expanding));
 
+	// Create a QSplitter to keep a unified workflow here.
+	windowSplitter = new QSplitter(Qt::Orientation::Vertical, this);
+	windowSplitter->addWidget(preview);
+	windowSplitter->addWidget(view);
+	windowSplitter->setChildrenCollapsible(false);
+	//windowSplitter->setSizes(QList<int>({ 16777216, 150 }));
+	windowSplitter->setStretchFactor(0, 3);
+	windowSplitter->setStretchFactor(1, 1);
+
 	setLayout(new QVBoxLayout(this));
-	layout()->addWidget(preview);
-	layout()->addWidget(view);
+	layout()->addWidget(windowSplitter);
 	layout()->addWidget(buttonBox);
 	layout()->setAlignment(buttonBox, Qt::AlignRight | Qt::AlignBottom);
-	layout()->setAlignment(view, Qt::AlignBottom);
-	view->setMaximumHeight(250);
-	view->setMinimumHeight(150);
+	
 	view->show();
-
 	installEventFilter(CreateShortcutFilter());
 
 	const char *name = obs_source_get_name(source);

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -20,6 +20,7 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QPointer>
+#include <QSplitter>
 #include "qt-display.hpp"
 #include <obs.hpp>
 
@@ -42,6 +43,7 @@ private:
 	OBSData    oldSettings;
 	OBSPropertiesView *view;
 	QDialogButtonBox *buttonBox;
+	QSplitter *windowSplitter;
 
 	static void SourceRemoved(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);


### PR DESCRIPTION
Changes the Properties UI to use a QSplitter instead of a fixed boundary. This keeps the workflow from the main OBS window.

Video https://www.youtube.com/watch?v=NfKuIJf_1rM&feature=youtu.be