### PR TITLE
UI: Add Portable Mode indicator to title bar and log

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -858,6 +858,9 @@ bool OBSApp::OBSInit()
 		if (!StartupOBS(locale.c_str(), GetProfilerNameStore()))
 			return false;
 
+		blog(LOG_INFO, "Portable mode: %s",
+			portable_mode ? "true" : "false");
+
 		mainWindow = new OBSBasic();
 
 		mainWindow->setAttribute(Qt::WA_DeleteOnClose, true);
@@ -907,6 +910,11 @@ string OBSApp::GetVersionString() const
 #endif
 
 	return ver.str();
+}
+
+bool OBSApp::IsPortableMode()
+{
+	return portable_mode;
 }
 
 #ifdef __APPLE__

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -117,6 +117,7 @@ public:
 	const char *GetCurrentLog() const;
 
 	std::string GetVersionString() const;
+	bool IsPortableMode();
 
 	const char *InputAudioSource() const;
 	const char *OutputAudioSource() const;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4459,6 +4459,9 @@ void OBSBasic::UpdateTitleBar()
 		name << "Studio ";
 
 	name << App()->GetVersionString();
+	if (App()->IsPortableMode())
+		name << " - Portable Mode";
+
 	name << " - " << Str("TitleBar.Profile") << ": " << profile;
 	name << " - " << Str("TitleBar.Scenes") << ": " << sceneCollection;
 


### PR DESCRIPTION
It's difficult to rely on end users to tell us if they're actually running in Portable Mode or not.  Often times they just don't know if they correctly engaged it.  This PR makes it so that they don't have to know - the logs will speak for them.  Additionally, it also shows "Portable Mode" in the title bar of the main OBS Studio window so that it's more readily apparently to the user that they have actually engaged Portable Mode.

As always, feedback or reviews are appreciated.