### PR TITLE
OSX Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+os: osx
+env:
+  matrix:
+  - CMAKE_PREFIX_PATH=/usr/local/opt/qt5/lib/cmake
+  global:
+  # AWS S3 creds
+  # access key
+  - secure: "MfhOg+84yb4ZHB2tM8PIPFQX2Y+WLN0I0iiAgyLC4KaHPUoNOyloe9yk6OjV7Lj7SZWqTlQUsqHa8S9mOUswGIody1Ydglo4RvyGOKCd8I6b2ri/jE8qHVuD9sO+sNlIxq4YqqG/qReTsbSs2YEgLneZUCYLCk/fihl8L6eVuSc="
+  # secret
+  - secure: "JRQVU2zgC3hY6CEY+Crmh/upp93En0BzKaLcsuBT538johNlK7m5hn3m2UOw63seLvBvVaKKWUDj9N986a3DwcXxWPMyF/9ctXgNWy39WzaVWxrbVR5nQB1fdiRp5YEgkoVN+gEm3OVF7sV5AGzh5/8CvEdRCoTLIGgMGHxW9mc="
+language: cpp
+before_install: "./CI/install-dependencies-osx.sh"
+before_script: "./CI/before-script-osx.sh"
+script: cd ./build && make -j4 && cd -
+before_deploy: "./CI/before-deploy-osx.sh"
+deploy:
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY
+  secret_access_key: $AWS_SECRET_KEY
+  skip_cleanup: true
+  local_dir: nightly
+  bucket: obs-nightly
+  region: us-west-2
+  acl: public_read
+  on:
+    condition: "$TRAVIS_EVENT_TYPE = cron"

--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -1,0 +1,7 @@
+export GIT_HASH=$(git rev-parse --short HEAD)
+export FILE_DATE=$(date +%Y-%m-%d.%H:%M:%S)
+export FILENAME=$FILE_DATE-$GIT_HASH-osx.zip
+mkdir nightly
+cd ./build/rundir/RelWithDebInfo
+zip -r -X $FILENAME .
+mv ./$FILENAME ../../../nightly

--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -1,0 +1,3 @@
+mkdir build
+cd build
+cmake ..

--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -1,0 +1,2 @@
+brew update
+brew install ffmpeg x264 qt5


### PR DESCRIPTION
This builds a basic OBS build for OSX. If the build is called from a travis cron task the build is uploaded to an S3 bucket.
 
Super simple (crappy) file list of the build artifacts, I'll improve this later.
https://obs-nightly.s3-us-west-2.amazonaws.com/index.html

The secure variables will need to be set for the travis repo, I'll need to sync up with someone with repo access to get that done.

We also need to send an email to travis to enable cron: https://docs.travis-ci.com/user/cron-jobs/

Someone will also need to login to https://travis-ci.org/ and enable builds for obs-studio.
