### PR TITLE
Fix build error on debian

### DIFF
--- a/cmake/Modules/FindFFmpeg.cmake
+++ b/cmake/Modules/FindFFmpeg.cmake
@@ -49,6 +49,8 @@ function(find_ffmpeg_library component header)
 			${DepsPath${_lib_suffix}}
 			${DepsPath}
 			${PC_FFMPEG_${component}_INCLUDE_DIRS}
+		PATHS
+			/usr/include /usr/local/include /opt/local/include /sw/include
 		PATH_SUFFIXES ffmpeg libav include)
 
 	find_library(FFMPEG_${component}_LIBRARY
@@ -64,6 +66,8 @@ function(find_ffmpeg_library component header)
 			${DepsPath${_lib_suffix}}
 			${DepsPath}
 			${PC_FFMPEG_${component}_LIBRARY_DIRS}
+		PATHS
+			/usr/lib /usr/local/lib /opt/local/lib /sw/lib
 		PATH_SUFFIXES
 			lib${_lib_suffix} lib
 			libs${_lib_suffix} libs


### PR DESCRIPTION
Altough ffmpeg is installed, OBS currently fails to build on debian (tested on Debian Jessie 8.6). This is due to multiple undefined references to `av_*` functions because it looks for `libavcodec.a` in `/usr/local/lib/../lib` only and not `/usr/lib`.

To fix this problem, I specified in `FindFFmpeg.cmake` the various directories where to look for the said library.