### PR TITLE
UI: Fix full screen projector on screens that have reserved areas

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -141,7 +141,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 		QRect windowGeometry = normalGeometry();
 		if (!WindowPositionValid(windowGeometry)) {
-			QRect rect = App()->desktop()->availableGeometry();
+			QRect rect = App()->desktop()->geometry();
 			setGeometry(QStyle::alignedRect(
 						Qt::LeftToRight,
 						Qt::AlignCenter,
@@ -2774,7 +2774,7 @@ static void AddProjectorMenuMonitors(QMenu *parent, QObject *target,
 	QAction *action;
 	QList<QScreen*> screens = QGuiApplication::screens();
 	for (int i = 0; i < screens.size(); i++) {
-		QRect screenGeometry = screens[i]->availableGeometry();
+		QRect screenGeometry = screens[i]->geometry();
 		QString str = QString("%1 %2: %3x%4 @ %5,%6").
 			arg(QTStr("Display"),
 			    QString::number(i),

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1101,7 +1101,7 @@ void OBSBasicSettings::LoadResolutionLists()
 	ui->baseResolution->clear();
 
 	for (QScreen* screen: QGuiApplication::screens()) {
-		QSize as = screen->availableSize();
+		QSize as = screen->size();
 		string res = ResString(as.width(), as.height());
 		ui->baseResolution->addItem(res.c_str());
 	}

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -50,7 +50,7 @@ OBSProjector::~OBSProjector()
 void OBSProjector::Init(int monitor)
 {
 	QScreen *screen = QGuiApplication::screens()[monitor];
-	setGeometry(screen->availableGeometry());
+	setGeometry(screen->geometry());
 
 	bool alwaysOnTop = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "ProjectorAlwaysOnTop");


### PR DESCRIPTION
QScreen::availableGeometry() does not return the full screen size on X11
if areas of the screen are reserved by the window manager. In this case
the full screen projector does not cover the whole screen. Using
QScreen::geometry() instead fixes this issue.

This fixes the bug introduced by #647.