### PR TITLE
libobs: Fix missing call to profile_end() when encoding fails

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -796,7 +796,7 @@ static inline void do_encode(struct obs_encoder *encoder,
 		full_stop(encoder);
 		blog(LOG_ERROR, "Error encoding with encoder '%s'",
 				encoder->context.name);
-		return;
+		goto error;
 	}
 
 	if (received) {
@@ -822,6 +822,7 @@ static inline void do_encode(struct obs_encoder *encoder,
 		pthread_mutex_unlock(&encoder->callbacks_mutex);
 	}
 
+error:
 	profile_end(do_encode_name);
 }
 


### PR DESCRIPTION
The do_encode() method does not call profile_end() when encoding fails
which causes an error message about mismatching names being logged.

Example log:
> Error encoding with encoder 'simple_h264_stream'
> Called profile end with mismatching name: start("do_encode"[000007FEEABD9B80]) <-> end("receive_video"[000007FEEABD9B90])