### PR TITLE
CMake: Fix warn on empty QTDIR/DepsPath vars on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,13 @@ cmake_minimum_required(VERSION 2.8.12)
 project(obs-studio)
 
 if(WIN32)
-	if (QTDIR OR DEFINED ENV{QTDIR} OR DEFINED ENV{QTDIR32} OR DEFINED ENV{QTDIR64})
+	if (QTDIR OR QTDIR32 OR QTDIR64 OR DEFINED ENV{QTDIR} OR DEFINED ENV{QTDIR32} OR DEFINED ENV{QTDIR64})
 		# Qt path set by user or env var
 	else()
 		set(QTDIR "" CACHE PATH "Path to Qt (e.g. C:/Qt/5.7/msvc2015_64)")
 		message(WARNING "QTDIR variable is missing.  Please set this variable to specify path to Qt (e.g. C:/Qt/5.7/msvc2015_64)")
 	endif()
-	if (DepsPath OR DEFINED ENV{DepsPath} OR DEFINED ENV{DepsPath32} OR DEFINED ENV{DepsPath64})
+	if (DepsPath OR DepsPath32 OR DepsPath64 OR DEFINED ENV{DepsPath} OR DEFINED ENV{DepsPath32} OR DEFINED ENV{DepsPath64})
 		# Dependencies path set by user or env var
 	else()
 		set(DepsPath "" CACHE PATH "Path to compiled dependencies (e.g. D:/dependencies/win64)")


### PR DESCRIPTION
This is a follow-up to commit 2680321 (PR #608). That commit checked environment variables for QTDIR(32/64) and DepsPath(32/64), but only checked for unsuffixed CMake vars. If you defined suffixed vars (e.g., QTDIR64 and DepsPath64) in CMake, you would still receive a warning that QTDir or DepsPath were empty. This commit/PR adds checks for arch-suffixed CMake vars.

Tested on Windows 10 Pro 64-bit Version 1607 (OS Build 14393.351) with CMake (cmake-gui) 3.6.2.  As always, feedback or reviews are appreciated and welcome.