### PR TITLE
obs-transitions: Don't use inefficient branching in slide_transition.effect

### DIFF
--- a/plugins/obs-transitions/data/slide_transition.effect
+++ b/plugins/obs-transitions/data/slide_transition.effect
@@ -28,11 +28,12 @@ float4 PSSlide(VertData v_in) : TARGET
 {
 	float2 tex_a_uv = v_in.uv + tex_a_dir;
 	float2 tex_b_uv = v_in.uv - tex_b_dir;
-
-	return (tex_a_uv.x - saturate(tex_a_uv.x) != 0.0) ||
-	       (tex_a_uv.y - saturate(tex_a_uv.y) != 0.0)
-		   ? tex_b.Sample(textureSampler, tex_b_uv)
-		   : tex_a.Sample(textureSampler, tex_a_uv);
+	
+	float4 tex_a_sample = tex_a.Sample(textureSampler, tex_a_uv);
+	float4 tex_b_sample = tex_b.Sample(textureSampler, tex_b_uv);
+	
+	float val = saturate(abs((tex_a_uv.x - saturate(tex_a_uv.x)) + (tex_a_uv.y - saturate(tex_a_uv.y))) * 65535);
+	return lerp(tex_a_sample, tex_b_sample, val);
 }
 
 technique Slide


### PR DESCRIPTION
Currently the code has two issues:

* it uses branching, which is slow on a GPU,
* it samples inside the branch, which can cause cache misses in the shading unit.

The second one is easy to fix by moving the sampling before the branch. The first one needs some mathematical magic that converts a condition into a simple 0..1 value for the lerp command. This patch does essentially that, elimination branching and the occasional cache miss.

If you do not know how badly this can hurt performance, I recommend reading about in depth GPU programming. AMDs GPUOpen blog posts give a lot of insight into the internal workings of GPU programing.