### PR TITLE
Add xcb message poll to empty out the queue

### DIFF
--- a/libobs-opengl/gl-x11.c
+++ b/libobs-opengl/gl-x11.c
@@ -587,7 +587,12 @@ extern void device_present(gs_device_t *device)
 		initialized = true;
 	}
 
-	/* TODO: Handle XCB events. */
+	xcb_connection_t *xcb_conn = XGetXCBConnection(display);
+	xcb_generic_event_t *xcb_event;
+	while((xcb_event = xcb_poll_for_event(xcb_conn))) {
+		/* TODO: Handle XCB events. */
+		free(xcb_event);
+	}
 
 	switch (swap_type) {
 	case SWAP_TYPE_EXT:    glXSwapIntervalEXT(display, window, 0); break;


### PR DESCRIPTION
The xcb message queue is not currently emptied. If errors are generated
by any void requests the message queue will simply fill up and messages
will never be deleted.

Due to a (currently unknown) other problem this happens for me, and
results in OBS using up all memory with a queue that will never be
emptied.

Here we add a poll loop that will empty the xcb message queue and
discard the messages. While this means that errors are still not
handled, OBS wont end up crashing either.

New pull request because I messed up my branches in #674, sorry :(
