### PR TITLE
UI: Use Qt api for translation.

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -272,11 +272,11 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 	edit->setToolTip(toolTip);
 
 	auto revert = new QPushButton;
-	revert->setText(QTStr("Revert"));
+	revert->setText(tr("Revert"));
 	revert->setEnabled(false);
 
 	auto clear = new QPushButton;
-	clear->setText(QTStr("Clear"));
+	clear->setText(tr("Clear"));
 	clear->setEnabled(!obs_key_combination_is_empty(combo));
 
 	QObject::connect(edit, &OBSHotkeyEdit::KeyChanged,

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -52,17 +52,29 @@ class OBSTranslator : public QTranslator {
 	Q_OBJECT
 
 public:
+	bool Init(const char *lang);
+
 	virtual bool isEmpty() const override {return false;}
 
-	virtual QString translate(const char *context, const char *sourceText,
-			const char *disambiguation, int n) const override;
+	virtual QString translate(
+	                const char *context, const char *sourceText,
+	                const char *disambiguation = Q_NULLPTR,
+	                int n = -1) const override;
+
+	inline std::string GetLocale() const
+	{
+		return locale;
+	}
+
+private:
+	std::string     locale;
+	TextLookup      textLookup;
 };
 
 class OBSApp : public QApplication {
 	Q_OBJECT
 
 private:
-	std::string                    locale;
 	std::string		       theme;
 	ConfigFile                     globalConfig;
 	TextLookup                     textLookup;
@@ -72,6 +84,7 @@ private:
 
 	os_inhibit_t                   *sleepInhibitor = nullptr;
 	int                            sleepInhibitRefs = 0;
+	OBSTranslator                  translator;
 
 	std::deque<obs_frontend_translate_ui_cb> translatorHooks;
 
@@ -93,7 +106,7 @@ public:
 
 	inline const char *GetLocale() const
 	{
-		return locale.c_str();
+		return translator.GetLocale().c_str();
 	}
 
 	inline const char *GetTheme() const {return theme.c_str();}
@@ -103,7 +116,7 @@ public:
 
 	inline const char *GetString(const char *lookupVal) const
 	{
-		return textLookup.GetString(lookupVal);
+		return qPrintable(translator.translate("", lookupVal));
 	}
 
 	bool TranslateString(const char *lookupVal, const char **out) const;
@@ -161,8 +174,6 @@ inline OBSApp *App() {return static_cast<OBSApp*>(qApp);}
 inline config_t *GetGlobalConfig() {return App()->GlobalConfig();}
 
 std::vector<std::pair<std::string, std::string>> GetLocaleNames();
-inline const char *Str(const char *lookup) {return App()->GetString(lookup);}
-#define QTStr(lookupVal) QString::fromUtf8(Str(lookupVal))
 
 bool GetFileSafeName(const char *name, std::string &file);
 bool GetClosestUnusedFileName(std::string &path, const char *extension);

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -101,8 +101,6 @@ void OBSPropertiesView::ReloadProperties()
 	RefreshProperties();
 }
 
-#define NO_PROPERTIES_STRING QTStr("Basic.PropertiesWindow.NoProperties")
-
 void OBSPropertiesView::RefreshProperties()
 {
 	int h, v;
@@ -144,7 +142,7 @@ void OBSPropertiesView::RefreshProperties()
 	}
 
 	if (hasNoProperties) {
-		QLabel *noPropertiesLabel = new QLabel(NO_PROPERTIES_STRING);
+		QLabel *noPropertiesLabel = new QLabel(tr("Basic.PropertiesWindow.NoProperties"));
 		layout->addWidget(noPropertiesLabel);
 	}
 }
@@ -247,7 +245,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 		QLineEdit *edit = new QLineEdit();
 		QPushButton *show = new QPushButton();
 
-		show->setText(QTStr("Show"));
+		show->setText(tr("Show"));
 		show->setCheckable(true);
 		edit->setText(QT_UTF8(val));
 		edit->setEchoMode(QLineEdit::Password);
@@ -260,7 +258,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 				info, &WidgetInfo::TogglePasswordText);
 		connect(show, &QAbstractButton::toggled, [=](bool hide)
 		{
-			show->setText(hide ? QTStr("Hide") : QTStr("Show"));
+			show->setText(hide ? tr("Hide") : tr("Show"));
 		});
 		children.emplace_back(info);
 
@@ -289,7 +287,7 @@ void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout,
 	const char  *val       = obs_data_get_string(settings, name);
 	QLayout     *subLayout = new QHBoxLayout();
 	QLineEdit   *edit      = new QLineEdit();
-	QPushButton *button    = new QPushButton(QTStr("Browse"));
+	QPushButton *button    = new QPushButton(tr("Browse"));
 
 	edit->setText(QT_UTF8(val));
 	edit->setReadOnly(true);
@@ -507,7 +505,7 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 		if (id != -1 && id != idx) {
 			QString actual   = combo->itemText(id);
 			QString selected = combo->itemText(idx);
-			QString combined = QTStr(
+			QString combined = tr(
 				"Basic.PropertiesWindow.AutoSelectFormat");
 			combo->setItemText(idx,
 					combined.arg(selected).arg(actual));
@@ -609,7 +607,7 @@ void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout,
 	long long   val         = obs_data_get_int(settings, name);
 	QColor      color       = color_from_int(val);
 
-	button->setText(QTStr("Basic.PropertiesWindow.SelectColor"));
+	button->setText(tr("Basic.PropertiesWindow.SelectColor"));
 	button->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
 	colorLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
@@ -674,7 +672,7 @@ void OBSPropertiesView::AddFont(obs_property_t *prop, QFormLayout *layout,
 	font = fontLabel->font();
 	MakeQFont(font_obj, font, true);
 
-	button->setText(QTStr("Basic.PropertiesWindow.SelectFont"));
+	button->setText(tr("Basic.PropertiesWindow.SelectFont"));
 	button->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
 	fontLabel->setFrameStyle(QFrame::Sunken | QFrame::Panel);
@@ -950,7 +948,7 @@ static QWidget *CreateRationalFPS(OBSFrameRatePropertyWidget *fpsProps,
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->setSpacing(4);
 
-	auto str = QTStr("Basic.PropertiesView.FPS.ValidFPSRanges");
+	auto str = QObject::tr("Basic.PropertiesView.FPS.ValidFPSRanges");
 	auto rlabel = new QLabel{str};
 
 	auto combo = fpsProps->fpsRange = new QComboBox{};
@@ -985,8 +983,8 @@ static QWidget *CreateRationalFPS(OBSFrameRatePropertyWidget *fpsProps,
 		den_edit->setValue(current_fps->denominator);
 	}
 
-	layout->addRow(QTStr("Basic.Settings.Video.Numerator"), num_edit);
-	layout->addRow(QTStr("Basic.Settings.Video.Denominator"), den_edit);
+	layout->addRow(QObject::tr("Basic.Settings.Video.Numerator"), num_edit);
+	layout->addRow(QObject::tr("Basic.Settings.Video.Denominator"), den_edit);
 
 	widget->setLayout(layout);
 
@@ -1005,9 +1003,9 @@ static OBSFrameRatePropertyWidget *CreateFrameRateWidget(obs_property_t *prop,
 	swap(widget->fps_ranges, fps_ranges);
 
 	auto combo = widget->modeSelect = new QComboBox{};
-	combo->addItem(QTStr("Basic.PropertiesView.FPS.Simple"),
+	combo->addItem(QObject::tr("Basic.PropertiesView.FPS.Simple"),
 			QVariant::fromValue(frame_rate_tag::simple()));
-	combo->addItem(QTStr("Basic.PropertiesView.FPS.Rational"),
+	combo->addItem(QObject::tr("Basic.PropertiesView.FPS.Rational"),
 			QVariant::fromValue(frame_rate_tag::rational()));
 
 	combo->setToolTip(QT_UTF8(obs_property_long_description(prop)));
@@ -1073,7 +1071,7 @@ static OBSFrameRatePropertyWidget *CreateFrameRateWidget(obs_property_t *prop,
 
 	auto fps_label = widget->currentFPS = new QLabel{"FPS: 22"};
 	auto time_label = widget->timePerFrame =
-		new QLabel{"Frame Interval: 0.123 ms"};
+		new QLabel{"Frame Interval: 0.123 ms"};
 	auto min_label = widget->minLabel = new QLabel{"Min FPS: 1/1"};
 	auto max_label = widget->maxLabel = new QLabel{"Max FPS: 2/1"};
 
@@ -1181,7 +1179,7 @@ static void UpdateFPSLabels(OBSFrameRatePropertyWidget *w)
 
 	w->currentFPS->setText(QString("FPS: %1")
 			.arg(convert_to_fps(*valid_fps)));
-	w->timePerFrame->setText(QString("Frame Interval: %1 ms")
+	w->timePerFrame->setText(QString("Frame Interval: %1 ms")
 			.arg(convert_to_frame_interval(*valid_fps) * 1000));
 }
 
@@ -1741,7 +1739,7 @@ class EditableItemDialog : public QDialog {
 			curPath = default_path;
 
 		QString path = QFileDialog::getOpenFileName(
-				App()->GetMainWindow(), QTStr("Browse"),
+				App()->GetMainWindow(), tr("Browse"),
 				curPath, filter);
 		if (path.isEmpty())
 			return;
@@ -1767,7 +1765,7 @@ public:
 
 		if (browse) {
 			QPushButton *browseButton =
-				new QPushButton(QTStr("Browse"));
+				new QPushButton(tr("Browse"));
 			topLayout->addWidget(browseButton);
 			topLayout->setAlignment(browseButton, Qt::AlignVCenter);
 
@@ -1810,18 +1808,18 @@ void WidgetInfo::EditListAdd()
 
 	QAction *action;
 
-	action = new QAction(QTStr("Basic.PropertiesWindow.AddFiles"), this);
+	action = new QAction(tr("Basic.PropertiesWindow.AddFiles"), this);
 	connect(action, &QAction::triggered,
 			this, &WidgetInfo::EditListAddFiles);
 	popup.addAction(action);
 
-	action = new QAction(QTStr("Basic.PropertiesWindow.AddDir"), this);
+	action = new QAction(tr("Basic.PropertiesWindow.AddDir"), this);
 	connect(action, &QAction::triggered,
 			this, &WidgetInfo::EditListAddDir);
 	popup.addAction(action);
 
 	if (type == OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS) {
-		action = new QAction(QTStr("Basic.PropertiesWindow.AddURL"),
+		action = new QAction(tr("Basic.PropertiesWindow.AddURL"),
 				this);
 		connect(action, &QAction::triggered,
 				this, &WidgetInfo::EditListAddText);
@@ -1837,7 +1835,7 @@ void WidgetInfo::EditListAddText()
 	const char *desc = obs_property_description(property);
 
 	EditableItemDialog dialog(widget->window(), QString(), false);
-	auto title = QTStr("Basic.PropertiesWindow.AddEditableListEntry").arg(
+	auto title = tr("Basic.PropertiesWindow.AddEditableListEntry").arg(
 			QT_UTF8(desc));
 	dialog.setWindowTitle(title);
 	if (dialog.exec() == QDialog::Rejected)
@@ -1859,7 +1857,7 @@ void WidgetInfo::EditListAddFiles()
 	const char *default_path =
 		obs_property_editable_list_default_path(property);
 
-	QString title = QTStr("Basic.PropertiesWindow.AddEditableListFiles")
+	QString title = tr("Basic.PropertiesWindow.AddEditableListFiles")
 		.arg(QT_UTF8(desc));
 
 	QStringList files = QFileDialog::getOpenFileNames(
@@ -1880,7 +1878,7 @@ void WidgetInfo::EditListAddDir()
 	const char *default_path =
 		obs_property_editable_list_default_path(property);
 
-	QString title = QTStr("Basic.PropertiesWindow.AddEditableListDir")
+	QString title = tr("Basic.PropertiesWindow.AddEditableListDir")
 		.arg(QT_UTF8(desc));
 
 	QString dir = QFileDialog::getExistingDirectory(
@@ -1919,7 +1917,7 @@ void WidgetInfo::EditListEdit()
 
 	if (type == OBS_EDITABLE_LIST_TYPE_FILES) {
 		QString path = QFileDialog::getOpenFileName(
-				App()->GetMainWindow(), QTStr("Browse"),
+				App()->GetMainWindow(), tr("Browse"),
 				item->text(), QT_UTF8(filter));
 		if (path.isEmpty())
 			return;
@@ -1931,7 +1929,7 @@ void WidgetInfo::EditListEdit()
 
 	EditableItemDialog dialog(widget->window(), item->text(),
 			type != OBS_EDITABLE_LIST_TYPE_STRINGS, filter);
-	auto title = QTStr("Basic.PropertiesWindow.EditEditableListEntry").arg(
+	auto title = tr("Basic.PropertiesWindow.EditEditableListEntry").arg(
 			QT_UTF8(desc));
 	dialog.setWindowTitle(title);
 	if (dialog.exec() == QDialog::Rejected)

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -24,22 +24,22 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 
 	mainLayout = new QGridLayout;
 	mainLayout->setContentsMargins(0, 0, 0, 0);
-	label = new QLabel(QTStr("Basic.AdvAudio.Name"));
+	label = new QLabel(tr("Basic.AdvAudio.Name"));
 	label->setAlignment(Qt::AlignHCenter);
 	mainLayout->addWidget(label, 0, 0);
-	label = new QLabel(QTStr("Basic.AdvAudio.Volume"));
+	label = new QLabel(tr("Basic.AdvAudio.Volume"));
 	label->setAlignment(Qt::AlignHCenter);
 	mainLayout->addWidget(label, 0, 1);
-	label = new QLabel(QTStr("Basic.AdvAudio.Mono"));
+	label = new QLabel(tr("Basic.AdvAudio.Mono"));
 	label->setAlignment(Qt::AlignHCenter);
 	mainLayout->addWidget(label, 0, 2);
-	label = new QLabel(QTStr("Basic.AdvAudio.Panning"));
+	label = new QLabel(tr("Basic.AdvAudio.Panning"));
 	label->setAlignment(Qt::AlignHCenter);
 	mainLayout->addWidget(label, 0, 3);
-	label = new QLabel(QTStr("Basic.AdvAudio.SyncOffset"));
+	label = new QLabel(tr("Basic.AdvAudio.SyncOffset"));
 	label->setAlignment(Qt::AlignHCenter);
 	mainLayout->addWidget(label, 0, 4);
-	label = new QLabel(QTStr("Basic.AdvAudio.AudioTracks"));
+	label = new QLabel(tr("Basic.AdvAudio.AudioTracks"));
 	label->setAlignment(Qt::AlignHCenter);
 	mainLayout->addWidget(label, 0, 5);
 
@@ -70,7 +70,7 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	obs_enum_sources(EnumSources, this);
 
 	resize(1000, 340);
-	setWindowTitle(QTStr("Basic.AdvAudio"));
+	setWindowTitle(tr("Basic.AdvAudio"));
 	setSizeGripEnabled(true);
 	setWindowModality(Qt::NonModal);
 	setAttribute(Qt::WA_DeleteOnClose, true);

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -68,7 +68,7 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 			new VisibilityItemDelegate(ui->effectFilters));
 
 	const char *name = obs_source_get_name(source);
-	setWindowTitle(QTStr("Basic.Filters.Title").arg(QT_UTF8(name)));
+	setWindowTitle(tr("Basic.Filters.Title").arg(QT_UTF8(name)));
 
 	installEventFilter(CreateShortcutFilter());
 
@@ -101,7 +101,7 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 	}
 
 	if (audioOnly || (audio && !async))
-		ui->asyncLabel->setText(QTStr("Basic.Filters.AudioFilters"));
+		ui->asyncLabel->setText(tr("Basic.Filters.AudioFilters"));
 
 	auto addDrawCallback = [this] ()
 	{
@@ -325,7 +325,7 @@ QMenu *OBSBasicFilters::CreateAddFilterPopupMenu(bool async)
 	bool foundValues = false;
 	size_t idx = 0;
 
-	QMenu *popup = new QMenu(QTStr("Add"), this);
+	QMenu *popup = new QMenu(tr("Add"), this);
 	while (obs_enum_filter_types(idx++, &type)) {
 		const char *name = obs_source_get_display_name(type);
 		uint32_t filterFlags = obs_get_source_output_flags(type);
@@ -357,16 +357,16 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		string name = obs_source_get_display_name(id);
 
 		bool success = NameDialog::AskForName(this,
-				QTStr("Basic.Filters.AddFilter.Title"),
-				QTStr("Basic.FIlters.AddFilter.Text"), name,
+				tr("Basic.Filters.AddFilter.Title"),
+				tr("Basic.FIlters.AddFilter.Text"), name,
 				QT_UTF8(name.c_str()));
 		if (!success)
 			return;
 
 		if (name.empty()) {
 			QMessageBox::information(this,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					tr("NoNameEntered.Title"),
+					tr("NoNameEntered.Text"));
 			AddNewFilter(id);
 			return;
 		}
@@ -375,8 +375,8 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 				name.c_str());
 		if (existing_filter) {
 			QMessageBox::information(this,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					tr("NameExists.Title"),
+					tr("NameExists.Text"));
 			obs_source_release(existing_filter);
 			AddNewFilter(id);
 			return;
@@ -457,7 +457,7 @@ void OBSBasicFilters::SourceRemoved(void *data, calldata_t *params)
 void OBSBasicFilters::SourceRenamed(void *data, calldata_t *params)
 {
 	const char *name = calldata_string(params, "new_name");
-	QString title = QTStr("Basic.Filters.Title").arg(QT_UTF8(name));
+	QString title = tr("Basic.Filters.Title").arg(QT_UTF8(name));
 
 	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(data),
 	                "setWindowTitle", Q_ARG(QString, title));
@@ -499,16 +499,16 @@ static bool QueryRemove(QWidget *parent, obs_source_t *source)
 {
 	const char *name  = obs_source_get_name(source);
 
-	QString text = QTStr("ConfirmRemove.Text");
+	QString text = QObject::tr("ConfirmRemove.Text");
 	text.replace("$1", QT_UTF8(name));
 
 	QMessageBox remove_source(parent);
 	remove_source.setText(text);
-	QAbstractButton *Yes = remove_source.addButton(QTStr("Yes"),
+	QAbstractButton *Yes = remove_source.addButton(QObject::tr("Yes"),
 			QMessageBox::YesRole);
-	remove_source.addButton(QTStr("No"), QMessageBox::NoRole);
+	remove_source.addButton(QObject::tr("No"), QMessageBox::NoRole);
 	remove_source.setIcon(QMessageBox::Question);
-	remove_source.setWindowTitle(QTStr("ConfirmRemove.Title"));
+	remove_source.setWindowTitle(QObject::tr("ConfirmRemove.Title"));
 	remove_source.exec();
 
 	return Yes == remove_source.clickedButton();
@@ -615,8 +615,8 @@ void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 			SLOT(on_removeEffectFilter_clicked());
 
 		popup.addSeparator();
-		popup.addAction(QTStr("Rename"), this, renameSlot);
-		popup.addAction(QTStr("Remove"), this, removeSlot);
+		popup.addAction(tr("Rename"), this, renameSlot);
+		popup.addAction(tr("Remove"), this, removeSlot);
 	}
 
 	popup.exec(QCursor::pos());
@@ -678,14 +678,14 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 
 		if (foundFilter) {
 			QMessageBox::information(window(),
-				QTStr("NameExists.Title"),
-				QTStr("NameExists.Text"));
+				tr("NameExists.Title"),
+				tr("NameExists.Text"));
 			obs_source_release(foundFilter);
 
 		} else if (name.empty()) {
 			QMessageBox::information(window(),
-				QTStr("NoNameEntered.Title"),
-				QTStr("NoNameEntered.Text"));
+				tr("NoNameEntered.Title"),
+				tr("NoNameEntered.Text"));
 		}
 	} else {
 		const char *sourceName = obs_source_get_name(source);

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -57,7 +57,7 @@ OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
 	obs_data_release(settings);
 
 	const char *name = obs_source_get_name(source);
-	setWindowTitle(QTStr("Basic.InteractionWindow").arg(QT_UTF8(name)));
+	setWindowTitle(tr("Basic.InteractionWindow").arg(QT_UTF8(name)));
 
 	auto addDrawCallback = [this] ()
 	{
@@ -122,7 +122,7 @@ void OBSBasicInteraction::SourceRemoved(void *data, calldata_t *params)
 void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)
 {
 	const char *name = calldata_string(params, "new_name");
-	QString title = QTStr("Basic.InteractionWindow").arg(QT_UTF8(name));
+	QString title = tr("Basic.InteractionWindow").arg(QT_UTF8(name));
 
 	QMetaObject::invokeMethod(static_cast<OBSBasicProperties*>(data),
 	                "setWindowTitle", Q_ARG(QString, title));

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -670,10 +670,10 @@ bool SimpleOutput::StartRecording()
 	if (!dir) {
 		if (main->isVisible())
 			QMessageBox::information(main,
-					QTStr("Output.BadPath.Title"),
-					QTStr("Output.BadPath.Text"));
+					tr("Output.BadPath.Title"),
+					tr("Output.BadPath.Text"));
 		else
-			main->SysTrayNotify(QTStr("Output.BadPath.Text"),
+			main->SysTrayNotify(tr("Output.BadPath.Text"),
 					QSystemTrayIcon::Warning);
 		return false;
 	}
@@ -1217,10 +1217,10 @@ bool AdvancedOutput::StartRecording()
 		if (!dir) {
 			if (main->isVisible())
 				QMessageBox::information(main,
-						QTStr("Output.BadPath.Title"),
-						QTStr("Output.BadPath.Text"));
+						tr("Output.BadPath.Title"),
+						tr("Output.BadPath.Text"));
 			else
-				main->SysTrayNotify(QTStr("Output.BadPath.Text"),
+				main->SysTrayNotify(tr("Output.BadPath.Text"),
 						QSystemTrayIcon::Warning);
 			return false;
 		}

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -3,6 +3,9 @@
 class OBSBasic;
 
 struct BasicOutputHandler {
+	Q_DECLARE_TR_FUNCTIONS(BasicOutputHandler)
+
+public:
 	OBSOutput              fileOutput;
 	OBSOutput              streamOutput;
 	bool                   streamingActive = false;

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -102,14 +102,14 @@ static bool GetProfileName(QWidget *parent, std::string &name,
 		}
 		if (name.empty()) {
 			QMessageBox::information(parent,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					QObject::tr("NoNameEntered.Title"),
+					QObject::tr("NoNameEntered.Text"));
 			continue;
 		}
 		if (ProfileExists(name.c_str())) {
 			QMessageBox::information(parent,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					QObject::tr("NameExists.Title"),
+					QObject::tr("NameExists.Text"));
 			continue;
 		}
 		break;
@@ -180,8 +180,8 @@ static bool CopyProfile(const char *fromPartial, const char *to)
 	return true;
 }
 
-bool OBSBasic::AddProfile(bool create_new, const char *title, const char *text,
-		const char *init_text)
+bool OBSBasic::AddProfile(bool create_new, const char *title,
+		const char *text, const char *init_text)
 {
 	std::string newName;
 	std::string newDir;
@@ -346,12 +346,18 @@ void OBSBasic::ResetProfileData()
 
 void OBSBasic::on_actionNewProfile_triggered()
 {
-	AddProfile(true, Str("AddProfile.Title"), Str("AddProfile.Text"));
+	AddProfile(
+			true,
+			QT_TO_UTF8(tr("AddProfile.Title")),
+			QT_TO_UTF8(tr("AddProfile.Text")));
 }
 
 void OBSBasic::on_actionDupProfile_triggered()
 {
-	AddProfile(false, Str("AddProfile.Title"), Str("AddProfile.Text"));
+	AddProfile(
+			false,
+			QT_TO_UTF8(tr("AddProfile.Title")),
+			QT_TO_UTF8(tr("AddProfile.Text")));
 }
 
 void OBSBasic::on_actionRenameProfile_triggered()
@@ -362,8 +368,10 @@ void OBSBasic::on_actionRenameProfile_triggered()
 			"Basic", "Profile");
 
 	/* Duplicate and delete in case there are any issues in the process */
-	bool success = AddProfile(false, Str("RenameProfile.Title"),
-			Str("AddProfile.Text"), curName.c_str());
+	bool success = AddProfile(
+			false,
+			QT_TO_UTF8(tr("RenameProfile.Title")),
+			QT_TO_UTF8(tr("AddProfile.Text")), curName.c_str());
 	if (success) {
 		DeleteProfile(curName.c_str(), curDir.c_str());
 		RefreshProfiles();
@@ -403,11 +411,11 @@ void OBSBasic::on_actionRemoveProfile_triggered()
 	if (newPath.empty())
 		return;
 
-	QString text = QTStr("ConfirmRemove.Text");
+	QString text = tr("ConfirmRemove.Text");
 	text.replace("$1", QT_UTF8(oldName.c_str()));
 
 	QMessageBox::StandardButton button = QMessageBox::question(this,
-			QTStr("ConfirmRemove.Title"), text);
+			tr("ConfirmRemove.Title"), text);
 	if (button == QMessageBox::No)
 		return;
 

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -91,18 +91,18 @@ static bool GetSceneCollectionName(QWidget *parent, std::string &name,
 		std::string &file, const char *oldName = nullptr)
 {
 	bool rename = oldName != nullptr;
-	const char *title;
-	const char *text;
+	QString title;
+	QString text;
 	char path[512];
 	size_t len;
 	int ret;
 
 	if (rename) {
-		title = Str("Basic.Main.RenameSceneCollection.Title");
-		text  = Str("Basic.Main.AddSceneCollection.Text");
+		title = QObject::tr("Basic.Main.RenameSceneCollection.Title");
+		text  = QObject::tr("Basic.Main.AddSceneCollection.Text");
 	} else {
-		title = Str("Basic.Main.AddSceneCollection.Title");
-		text  = Str("Basic.Main.AddSceneCollection.Text");
+		title = QObject::tr("Basic.Main.AddSceneCollection.Title");
+		text  = QObject::tr("Basic.Main.AddSceneCollection.Text");
 	}
 
 	for (;;) {
@@ -113,14 +113,14 @@ static bool GetSceneCollectionName(QWidget *parent, std::string &name,
 		}
 		if (name.empty()) {
 			QMessageBox::information(parent,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					QObject::tr("NoNameEntered.Title"),
+					QObject::tr("NoNameEntered.Text"));
 			continue;
 		}
 		if (SceneCollectionExists(name.c_str())) {
 			QMessageBox::information(parent,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					QObject::tr("NameExists.Title"),
+					QObject::tr("NameExists.Text"));
 			continue;
 		}
 		break;
@@ -306,11 +306,11 @@ void OBSBasic::on_actionRemoveSceneCollection_triggered()
 	if (newPath.empty())
 		return;
 
-	QString text = QTStr("ConfirmRemove.Text");
+	QString text = tr("ConfirmRemove.Text");
 	text.replace("$1", QT_UTF8(oldName.c_str()));
 
 	QMessageBox::StandardButton button = QMessageBox::question(this,
-			QTStr("ConfirmRemove.Title"), text);
+			tr("ConfirmRemove.Title"), text);
 	if (button == QMessageBox::No)
 		return;
 

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -76,7 +76,7 @@ void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 	QString hotkeyName;
 
 	dstr_printf(hotkeyId, "OBSBasic.QuickTransition.%d", qt->id);
-	hotkeyName = QTStr("QuickTransitions.HotkeyName")
+	hotkeyName = tr("QuickTransitions.HotkeyName")
 		.arg(MakeQuickTransitionText(qt));
 
 	auto quickTransition = [] (void *data, obs_hotkey_id, obs_hotkey_t*,
@@ -356,15 +356,15 @@ void OBSBasic::AddTransition()
 	}
 
 	bool accepted = NameDialog::AskForName(this,
-			QTStr("TransitionNameDlg.Title"),
-			QTStr("TransitionNameDlg.Text"),
+			tr("TransitionNameDlg.Title"),
+			tr("TransitionNameDlg.Text"),
 			name, placeHolderText);
 
 	if (accepted) {
 		if (name.empty()) {
 			QMessageBox::information(this,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					tr("NoNameEntered.Title"),
+					tr("NoNameEntered.Text"));
 			AddTransition();
 			return;
 		}
@@ -372,8 +372,8 @@ void OBSBasic::AddTransition()
 		source = FindTransition(name.c_str());
 		if (source) {
 			QMessageBox::information(this,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					tr("NameExists.Title"),
+					tr("NameExists.Text"));
 
 			AddTransition();
 			return;
@@ -456,15 +456,15 @@ void OBSBasic::RenameTransition()
 	obs_source_t *source = nullptr;
 
 	bool accepted = NameDialog::AskForName(this,
-			QTStr("TransitionNameDlg.Title"),
-			QTStr("TransitionNameDlg.Text"),
+			tr("TransitionNameDlg.Title"),
+			tr("TransitionNameDlg.Text"),
 			name, placeHolderText);
 
 	if (accepted) {
 		if (name.empty()) {
 			QMessageBox::information(this,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					tr("NoNameEntered.Title"),
+					tr("NoNameEntered.Text"));
 			RenameTransition();
 			return;
 		}
@@ -472,8 +472,8 @@ void OBSBasic::RenameTransition()
 		source = FindTransition(name.c_str());
 		if (source) {
 			QMessageBox::information(this,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					tr("NameExists.Title"),
+					tr("NameExists.Text"));
 
 			RenameTransition();
 			return;
@@ -499,12 +499,12 @@ void OBSBasic::on_transitionProps_clicked()
 
 	QMenu menu(this);
 
-	QAction *action = new QAction(QTStr("Rename"), &menu);
+	QAction *action = new QAction(tr("Rename"), &menu);
 	connect(action, SIGNAL(triggered()), this, SLOT(RenameTransition()));
 	action->setProperty("transition", QVariant::fromValue(source));
 	menu.addAction(action);
 
-	action = new QAction(QTStr("Properties"), &menu);
+	action = new QAction(tr("Properties"), &menu);
 	connect(action, &QAction::triggered, properties);
 	menu.addAction(action);
 
@@ -634,7 +634,7 @@ void OBSBasic::CreateProgramOptions()
 	QHBoxLayout *mainButtonLayout = new QHBoxLayout();
 	mainButtonLayout->setSpacing(2);
 
-	QPushButton *transitionButton = new QPushButton(QTStr("Transition"));
+	QPushButton *transitionButton = new QPushButton(tr("Transition"));
 	QHBoxLayout *quickTransitions = new QHBoxLayout();
 	quickTransitions->setSpacing(2);
 
@@ -643,7 +643,7 @@ void OBSBasic::CreateProgramOptions()
 	addQuickTransition->setProperty("themeID", "addIconSmall");
 	addQuickTransition->setFlat(true);
 
-	QLabel *quickTransitionsLabel = new QLabel(QTStr("QuickTransitions"));
+	QLabel *quickTransitionsLabel = new QLabel(tr("QuickTransitions"));
 
 	quickTransitions->addWidget(quickTransitionsLabel);
 	quickTransitions->addWidget(addQuickTransition);
@@ -693,23 +693,23 @@ void OBSBasic::CreateProgramOptions()
 					&menu, menu.actionGeometry(act));
 		};
 
-		action = menu.addAction(QTStr("QuickTransitions.DuplicateScene"));
-		action->setToolTip(QTStr("QuickTransitions.DuplicateSceneTT"));
+		action = menu.addAction(tr("QuickTransitions.DuplicateScene"));
+		action->setToolTip(tr("QuickTransitions.DuplicateSceneTT"));
 		action->setCheckable(true);
 		action->setChecked(sceneDuplicationMode);
 		connect(action, &QAction::triggered, toggleSceneDuplication);
 		connect(action, &QAction::hovered, showToolTip);
 
-		action = menu.addAction(QTStr("QuickTransitions.EditProperties"));
-		action->setToolTip(QTStr("QuickTransitions.EditPropertiesTT"));
+		action = menu.addAction(tr("QuickTransitions.EditProperties"));
+		action->setToolTip(tr("QuickTransitions.EditPropertiesTT"));
 		action->setCheckable(true);
 		action->setChecked(editPropertiesMode);
 		action->setEnabled(sceneDuplicationMode);
 		connect(action, &QAction::triggered, toggleEditProperties);
 		connect(action, &QAction::hovered, showToolTip);
 
-		action = menu.addAction(QTStr("QuickTransitions.SwapScenes"));
-		action->setToolTip(QTStr("QuickTransitions.SwapScenesTT"));
+		action = menu.addAction(tr("QuickTransitions.SwapScenes"));
+		action->setToolTip(tr("QuickTransitions.SwapScenesTT"));
 		action->setCheckable(true);
 		action->setChecked(swapScenesMode);
 		connect(action, &QAction::triggered, toggleSwapScenesMode);
@@ -740,7 +740,7 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 	QAction *action;
 
 	if (qt) {
-		action = menu->addAction(QTStr("Remove"));
+		action = menu->addAction(tr("Remove"));
 		action->setProperty("id", qt->id);
 		connect(action, &QAction::triggered,
 				this, &OBSBasic::QuickTransitionRemoveClicked);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -27,6 +27,7 @@
 #include <QDesktopWidget>
 #include <QRect>
 #include <QScreen>
+#include <QStringList>
 
 #include <util/dstr.h>
 #include <util/util.hpp>
@@ -269,11 +270,11 @@ static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 	vector<OBSSource> audioSources;
 	audioSources.reserve(5);
 
-	SaveAudioDevice(DESKTOP_AUDIO_1, 1, saveData, audioSources);
-	SaveAudioDevice(DESKTOP_AUDIO_2, 2, saveData, audioSources);
-	SaveAudioDevice(AUX_AUDIO_1,     3, saveData, audioSources);
-	SaveAudioDevice(AUX_AUDIO_2,     4, saveData, audioSources);
-	SaveAudioDevice(AUX_AUDIO_3,     5, saveData, audioSources);
+	SaveAudioDevice(QT_TO_UTF8(DESKTOP_AUDIO_1), 1, saveData, audioSources);
+	SaveAudioDevice(QT_TO_UTF8(DESKTOP_AUDIO_2), 2, saveData, audioSources);
+	SaveAudioDevice(QT_TO_UTF8(AUX_AUDIO_1),     3, saveData, audioSources);
+	SaveAudioDevice(QT_TO_UTF8(AUX_AUDIO_2),     4, saveData, audioSources);
+	SaveAudioDevice(QT_TO_UTF8(AUX_AUDIO_3),     5, saveData, audioSources);
 
 	auto FilterAudioSources = [&](obs_source_t *source)
 	{
@@ -432,10 +433,10 @@ void OBSBasic::CreateFirstRunSources()
 
 	if (hasDesktopAudio)
 		ResetAudioDevice(App()->OutputAudioSource(), "default",
-				Str("Basic.DesktopDevice1"), 1);
+				QT_TO_UTF8(tr("Basic.DesktopDevice1")), 1);
 	if (hasInputAudio)
 		ResetAudioDevice(App()->InputAudioSource(), "default",
-				Str("Basic.AuxDevice1"), 3);
+				QT_TO_UTF8(tr("Basic.AuxDevice1")), 3);
 }
 
 void OBSBasic::CreateDefaultScene(bool firstStart)
@@ -448,7 +449,8 @@ void OBSBasic::CreateDefaultScene(bool firstStart)
 	ui->transitionDuration->setValue(300);
 	SetTransition(fadeTransition);
 
-	obs_scene_t  *scene  = obs_scene_create(Str("Basic.Scene"));
+	obs_scene_t  *scene  = obs_scene_create(
+			qPrintable(QObject::tr("Basic.Scene")));
 
 	if (firstStart)
 		CreateFirstRunSources();
@@ -594,11 +596,11 @@ void OBSBasic::Load(const char *file)
 	if (!name || !*name)
 		name = curSceneCollection;
 
-	LoadAudioDevice(DESKTOP_AUDIO_1, 1, data);
-	LoadAudioDevice(DESKTOP_AUDIO_2, 2, data);
-	LoadAudioDevice(AUX_AUDIO_1,     3, data);
-	LoadAudioDevice(AUX_AUDIO_2,     4, data);
-	LoadAudioDevice(AUX_AUDIO_3,     5, data);
+	LoadAudioDevice(QT_TO_UTF8(DESKTOP_AUDIO_1), 1, data);
+	LoadAudioDevice(QT_TO_UTF8(DESKTOP_AUDIO_2), 2, data);
+	LoadAudioDevice(QT_TO_UTF8(AUX_AUDIO_1),     3, data);
+	LoadAudioDevice(QT_TO_UTF8(AUX_AUDIO_2),     4, data);
+	LoadAudioDevice(QT_TO_UTF8(AUX_AUDIO_3),     5, data);
 
 	obs_load_sources(sources, OBSBasic::SourceLoaded, this);
 
@@ -1212,51 +1214,55 @@ void OBSBasic::InitHotkeys()
 	ProfileScope("OBSBasic::InitHotkeys");
 
 	struct obs_hotkeys_translations t = {};
-	t.insert                       = Str("Hotkeys.Insert");
-	t.del                          = Str("Hotkeys.Delete");
-	t.home                         = Str("Hotkeys.Home");
-	t.end                          = Str("Hotkeys.End");
-	t.page_up                      = Str("Hotkeys.PageUp");
-	t.page_down                    = Str("Hotkeys.PageDown");
-	t.num_lock                     = Str("Hotkeys.NumLock");
-	t.scroll_lock                  = Str("Hotkeys.ScrollLock");
-	t.caps_lock                    = Str("Hotkeys.CapsLock");
-	t.backspace                    = Str("Hotkeys.Backspace");
-	t.tab                          = Str("Hotkeys.Tab");
-	t.print                        = Str("Hotkeys.Print");
-	t.pause                        = Str("Hotkeys.Pause");
-	t.left                         = Str("Hotkeys.Left");
-	t.right                        = Str("Hotkeys.Right");
-	t.up                           = Str("Hotkeys.Up");
-	t.down                         = Str("Hotkeys.Down");
+	t.insert                       = QT_TO_UTF8(tr("Hotkeys.Insert"));
+	t.del                          = QT_TO_UTF8(tr("Hotkeys.Delete"));
+	t.home                         = QT_TO_UTF8(tr("Hotkeys.Home"));
+	t.end                          = QT_TO_UTF8(tr("Hotkeys.End"));
+	t.page_up                      = QT_TO_UTF8(tr("Hotkeys.PageUp"));
+	t.page_down                    = QT_TO_UTF8(tr("Hotkeys.PageDown"));
+	t.num_lock                     = QT_TO_UTF8(tr("Hotkeys.NumLock"));
+	t.scroll_lock                  = QT_TO_UTF8(tr("Hotkeys.ScrollLock"));
+	t.caps_lock                    = QT_TO_UTF8(tr("Hotkeys.CapsLock"));
+	t.backspace                    = QT_TO_UTF8(tr("Hotkeys.Backspace"));
+	t.tab                          = QT_TO_UTF8(tr("Hotkeys.Tab"));
+	t.print                        = QT_TO_UTF8(tr("Hotkeys.Print"));
+	t.pause                        = QT_TO_UTF8(tr("Hotkeys.Pause"));
+	t.left                         = QT_TO_UTF8(tr("Hotkeys.Left"));
+	t.right                        = QT_TO_UTF8(tr("Hotkeys.Right"));
+	t.up                           = QT_TO_UTF8(tr("Hotkeys.Up"));
+	t.down                         = QT_TO_UTF8(tr("Hotkeys.Down"));
 #ifdef _WIN32
-	t.meta                         = Str("Hotkeys.Windows");
+	t.meta                         = QT_TO_UTF8(tr("Hotkeys.Windows"));
 #else
-	t.meta                         = Str("Hotkeys.Super");
+	t.meta                         = QT_TO_UTF8(tr("Hotkeys.Super"));
 #endif
-	t.menu                         = Str("Hotkeys.Menu");
-	t.space                        = Str("Hotkeys.Space");
-	t.numpad_num                   = Str("Hotkeys.NumpadNum");
-	t.numpad_multiply              = Str("Hotkeys.NumpadMultiply");
-	t.numpad_divide                = Str("Hotkeys.NumpadDivide");
-	t.numpad_plus                  = Str("Hotkeys.NumpadAdd");
-	t.numpad_minus                 = Str("Hotkeys.NumpadSubtract");
-	t.numpad_decimal               = Str("Hotkeys.NumpadDecimal");
-	t.apple_keypad_num             = Str("Hotkeys.AppleKeypadNum");
-	t.apple_keypad_multiply        = Str("Hotkeys.AppleKeypadMultiply");
-	t.apple_keypad_divide          = Str("Hotkeys.AppleKeypadDivide");
-	t.apple_keypad_plus            = Str("Hotkeys.AppleKeypadAdd");
-	t.apple_keypad_minus           = Str("Hotkeys.AppleKeypadSubtract");
-	t.apple_keypad_decimal         = Str("Hotkeys.AppleKeypadDecimal");
-	t.apple_keypad_equal           = Str("Hotkeys.AppleKeypadEqual");
-	t.mouse_num                    = Str("Hotkeys.MouseButton");
+	t.menu                         = QT_TO_UTF8(tr("Hotkeys.Menu"));
+	t.space                        = QT_TO_UTF8(tr("Hotkeys.Space"));
+	t.numpad_num                   = QT_TO_UTF8(tr("Hotkeys.NumpadNum"));
+	t.numpad_multiply              = QT_TO_UTF8(tr("Hotkeys.NumpadMultiply"));
+	t.numpad_divide                = QT_TO_UTF8(tr("Hotkeys.NumpadDivide"));
+	t.numpad_plus                  = QT_TO_UTF8(tr("Hotkeys.NumpadAdd"));
+	t.numpad_minus                 = QT_TO_UTF8(tr("Hotkeys.NumpadSubtract"));
+	t.numpad_decimal               = QT_TO_UTF8(tr("Hotkeys.NumpadDecimal"));
+	t.apple_keypad_num             = QT_TO_UTF8(tr("Hotkeys.AppleKeypadNum"));
+	t.apple_keypad_multiply        = QT_TO_UTF8(tr("Hotkeys.AppleKeypadMultiply"));
+	t.apple_keypad_divide          = QT_TO_UTF8(tr("Hotkeys.AppleKeypadDivide"));
+	t.apple_keypad_plus            = QT_TO_UTF8(tr("Hotkeys.AppleKeypadAdd"));
+	t.apple_keypad_minus           = QT_TO_UTF8(tr("Hotkeys.AppleKeypadSubtract"));
+	t.apple_keypad_decimal         = QT_TO_UTF8(tr("Hotkeys.AppleKeypadDecimal"));
+	t.apple_keypad_equal           = QT_TO_UTF8(tr("Hotkeys.AppleKeypadEqual"));
+	t.mouse_num                    = QT_TO_UTF8(tr("Hotkeys.MouseButton"));
 	obs_hotkeys_set_translations(&t);
 
-	obs_hotkeys_set_audio_hotkeys_translations(Str("Mute"), Str("Unmute"),
-			Str("Push-to-mute"), Str("Push-to-talk"));
+	obs_hotkeys_set_audio_hotkeys_translations(
+			QT_TO_UTF8(tr("Mute")),
+			QT_TO_UTF8(tr("Unmute")),
+			QT_TO_UTF8(tr("Push-to-mute")),
+			QT_TO_UTF8(tr("Push-to-talk")));
 
 	obs_hotkeys_set_sceneitem_hotkeys_translations(
-			Str("SceneItemShow"), Str("SceneItemHide"));
+			QT_TO_UTF8(tr("SceneItemShow")),
+			QT_TO_UTF8(tr("SceneItemHide")));
 
 	obs_hotkey_enable_callback_rerouting(true);
 	obs_hotkey_set_callback_routing_func(OBSBasic::HotkeyTriggered, this);
@@ -1329,9 +1335,9 @@ void OBSBasic::CreateHotkeys()
 
 	streamingHotkeys = obs_hotkey_pair_register_frontend(
 			"OBSBasic.StartStreaming",
-			Str("Basic.Hotkeys.StartStreaming"),
+			QT_TO_UTF8(tr("Basic.Hotkeys.StartStreaming")),
 			"OBSBasic.StopStreaming",
-			Str("Basic.Hotkeys.StopStreaming"),
+			QT_TO_UTF8(tr("Basic.Hotkeys.StopStreaming")),
 			MAKE_CALLBACK(!basic.outputHandler->StreamingActive(),
 				basic.StartStreaming),
 			MAKE_CALLBACK(basic.outputHandler->StreamingActive(),
@@ -1350,16 +1356,16 @@ void OBSBasic::CreateHotkeys()
 
 	forceStreamingStopHotkey = obs_hotkey_register_frontend(
 			"OBSBasic.ForceStopStreaming",
-			Str("Basic.Main.ForceStopStreaming"),
+			QT_TO_UTF8(tr("Basic.Main.ForceStopStreaming")),
 			cb, this);
 	LoadHotkey(forceStreamingStopHotkey,
 			"OBSBasic.ForceStopStreaming");
 
 	recordingHotkeys = obs_hotkey_pair_register_frontend(
 			"OBSBasic.StartRecording",
-			Str("Basic.Hotkeys.StartRecording"),
+			QT_TO_UTF8(tr("Basic.Hotkeys.StartRecording")),
 			"OBSBasic.StopRecording",
-			Str("Basic.Hotkeys.StopRecording"),
+			QT_TO_UTF8(tr("Basic.Hotkeys.StopRecording")),
 			MAKE_CALLBACK(!basic.outputHandler->RecordingActive(),
 				basic.StartRecording),
 			MAKE_CALLBACK(basic.outputHandler->RecordingActive(),
@@ -1380,7 +1386,7 @@ void OBSBasic::CreateHotkeys()
 
 	togglePreviewProgramHotkey = obs_hotkey_register_frontend(
 			"OBSBasic.TogglePreviewProgram",
-			Str("Basic.TogglePreviewProgramMode"),
+			QT_TO_UTF8(tr("Basic.TogglePreviewProgramMode")),
 			togglePreviewProgram, this);
 	LoadHotkey(togglePreviewProgramHotkey, "OBSBasic.TogglePreviewProgram");
 
@@ -1395,7 +1401,7 @@ void OBSBasic::CreateHotkeys()
 
 	transitionHotkey = obs_hotkey_register_frontend(
 			"OBSBasic.Transition",
-			Str("Transition"), transition, this);
+			QT_TO_UTF8(tr("Transition")), transition, this);
 	LoadHotkey(transitionHotkey, "OBSBasic.Transition");
 }
 
@@ -1635,7 +1641,7 @@ void OBSBasic::AddScene(OBSSource source)
 	ui->scenes->addItem(item);
 
 	obs_hotkey_register_source(source, "OBSBasic.SelectScene",
-			Str("Basic.Hotkeys.SelectScene"),
+			QT_TO_UTF8(tr("Basic.Hotkeys.SelectScene")),
 			[](void *data,
 				obs_hotkey_id, obs_hotkey_t*, bool pressed)
 	{
@@ -1856,8 +1862,8 @@ void OBSBasic::VolControlContextMenu()
 {
 	VolControl *vol = reinterpret_cast<VolControl*>(sender());
 
-	QAction filtersAction(QTStr("Filters"), this);
-	QAction propertiesAction(QTStr("Properties"), this);
+	QAction filtersAction(tr("Filters"), this);
+	QAction propertiesAction(tr("Properties"), this);
 
 	connect(&filtersAction, &QAction::triggered,
 			this, &OBSBasic::GetAudioSourceFilters,
@@ -1903,16 +1909,16 @@ bool OBSBasic::QueryRemoveSource(obs_source_t *source)
 {
 	const char *name  = obs_source_get_name(source);
 
-	QString text = QTStr("ConfirmRemove.Text");
+	QString text = tr("ConfirmRemove.Text");
 	text.replace("$1", QT_UTF8(name));
 
 	QMessageBox remove_source(this);
 	remove_source.setText(text);
-	QAbstractButton *Yes = remove_source.addButton(QTStr("Yes"),
+	QAbstractButton *Yes = remove_source.addButton(tr("Yes"),
 			QMessageBox::YesRole);
-	remove_source.addButton(QTStr("No"), QMessageBox::NoRole);
+	remove_source.addButton(tr("No"), QMessageBox::NoRole);
 	remove_source.setIcon(QMessageBox::Question);
-	remove_source.setWindowTitle(QTStr("ConfirmRemove.Title"));
+	remove_source.setWindowTitle(tr("ConfirmRemove.Title"));
 	remove_source.exec();
 
 	return Yes == remove_source.clickedButton();
@@ -2005,7 +2011,7 @@ void OBSBasic::updateFileFinished(const QString &text, const QString &error)
 				major, minor, patch);
 
 		if (version > LIBOBS_API_VER) {
-			QString     str = QTStr("UpdateAvailable.Text");
+			QString     str = tr("UpdateAvailable.Text");
 			QMessageBox messageBox(this);
 
 			str = str.arg(QString::number(major),
@@ -2013,7 +2019,7 @@ void OBSBasic::updateFileFinished(const QString &text, const QString &error)
 			              QString::number(patch),
 			              download);
 
-			messageBox.setWindowTitle(QTStr("UpdateAvailable"));
+			messageBox.setWindowTitle(tr("UpdateAvailable"));
 			messageBox.setTextFormat(Qt::RichText);
 			messageBox.setText(str);
 			messageBox.setInformativeText(QT_UTF8(description));
@@ -2054,8 +2060,8 @@ void OBSBasic::DuplicateSelectedScene()
 	for (;;) {
 		string name;
 		bool accepted = NameDialog::AskForName(this,
-				QTStr("Basic.Main.AddSceneDlg.Title"),
-				QTStr("Basic.Main.AddSceneDlg.Text"),
+				tr("Basic.Main.AddSceneDlg.Title"),
+				tr("Basic.Main.AddSceneDlg.Text"),
 				name,
 				placeHolderText);
 		if (!accepted)
@@ -2063,16 +2069,16 @@ void OBSBasic::DuplicateSelectedScene()
 
 		if (name.empty()) {
 			QMessageBox::information(this,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					tr("NoNameEntered.Title"),
+					tr("NoNameEntered.Text"));
 			continue;
 		}
 
 		obs_source_t *source = obs_get_source_by_name(name.c_str());
 		if (source) {
 			QMessageBox::information(this,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					tr("NameExists.Title"),
+					tr("NameExists.Text"));
 
 			obs_source_release(source);
 			continue;
@@ -2645,8 +2651,8 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 		SetShowing(true);
 
 		QMessageBox::StandardButton button = QMessageBox::question(
-				this, QTStr("ConfirmExit.Title"),
-				QTStr("ConfirmExit.Text"));
+				this, tr("ConfirmExit.Title"),
+				tr("ConfirmExit.Text"));
 
 		if (button == QMessageBox::No) {
 			event->ignore();
@@ -2776,7 +2782,7 @@ static void AddProjectorMenuMonitors(QMenu *parent, QObject *target,
 	for (int i = 0; i < screens.size(); i++) {
 		QRect screenGeometry = screens[i]->geometry();
 		QString str = QString("%1 %2: %3x%4 @ %5,%6").
-			arg(QTStr("Display"),
+			arg(QObject::tr("Display"),
 			    QString::number(i),
 			    QString::number((int)screenGeometry.width()),
 			    QString::number((int)screenGeometry.height()),
@@ -2794,39 +2800,39 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 	QPointer<QMenu> sceneProjectorMenu;
 
 	QMenu popup(this);
-	QMenu order(QTStr("Basic.MainMenu.Edit.Order"), this);
-	popup.addAction(QTStr("Add"),
+	QMenu order(tr("Basic.MainMenu.Edit.Order"), this);
+	popup.addAction(tr("Add"),
 			this, SLOT(on_actionAddScene_triggered()));
 
 	if (item) {
 		popup.addSeparator();
-		popup.addAction(QTStr("Duplicate"),
+		popup.addAction(tr("Duplicate"),
 				this, SLOT(DuplicateSelectedScene()));
-		popup.addAction(QTStr("Rename"),
+		popup.addAction(tr("Rename"),
 				this, SLOT(EditSceneName()));
-		popup.addAction(QTStr("Remove"),
+		popup.addAction(tr("Remove"),
 				this, SLOT(RemoveSelectedScene()),
 				DeleteKeys.front());
 		popup.addSeparator();
 
-		order.addAction(QTStr("Basic.MainMenu.Edit.Order.MoveUp"),
+		order.addAction(tr("Basic.MainMenu.Edit.Order.MoveUp"),
 				this, SLOT(on_actionSceneUp_triggered()));
-		order.addAction(QTStr("Basic.MainMenu.Edit.Order.MoveDown"),
+		order.addAction(tr("Basic.MainMenu.Edit.Order.MoveDown"),
 				this, SLOT(on_actionSceneDown_triggered()));
 		order.addSeparator();
-		order.addAction(QTStr("Basic.MainMenu.Edit.Order.MoveToTop"),
+		order.addAction(tr("Basic.MainMenu.Edit.Order.MoveToTop"),
 				this, SLOT(MoveSceneToTop()));
-		order.addAction(QTStr("Basic.MainMenu.Edit.Order.MoveToBottom"),
+		order.addAction(tr("Basic.MainMenu.Edit.Order.MoveToBottom"),
 				this, SLOT(MoveSceneToBottom()));
 		popup.addMenu(&order);
 
 		popup.addSeparator();
-		sceneProjectorMenu = new QMenu(QTStr("SceneProjector"));
+		sceneProjectorMenu = new QMenu(tr("SceneProjector"));
 		AddProjectorMenuMonitors(sceneProjectorMenu, this,
 				SLOT(OpenSceneProjector()));
 		popup.addMenu(sceneProjectorMenu);
 		popup.addSeparator();
-		popup.addAction(QTStr("Filters"), this,
+		popup.addAction(tr("Filters"), this,
 				SLOT(OpenSceneFilters()));
 	}
 
@@ -2836,7 +2842,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 void OBSBasic::on_actionAddScene_triggered()
 {
 	string name;
-	QString format{QTStr("Basic.Main.DefaultSceneName.Text")};
+	QString format{tr("Basic.Main.DefaultSceneName.Text")};
 
 	int i = 1;
 	QString placeHolderText = format.arg(i);
@@ -2847,16 +2853,16 @@ void OBSBasic::on_actionAddScene_triggered()
 	}
 
 	bool accepted = NameDialog::AskForName(this,
-			QTStr("Basic.Main.AddSceneDlg.Title"),
-			QTStr("Basic.Main.AddSceneDlg.Text"),
+			tr("Basic.Main.AddSceneDlg.Title"),
+			tr("Basic.Main.AddSceneDlg.Text"),
 			name,
 			placeHolderText);
 
 	if (accepted) {
 		if (name.empty()) {
 			QMessageBox::information(this,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					tr("NoNameEntered.Title"),
+					tr("NoNameEntered.Text"));
 			on_actionAddScene_triggered();
 			return;
 		}
@@ -2864,8 +2870,8 @@ void OBSBasic::on_actionAddScene_triggered()
 		obs_source_t *source = obs_get_source_by_name(name.c_str());
 		if (source) {
 			QMessageBox::information(this,
-					QTStr("NameExists.Title"),
-					QTStr("NameExists.Text"));
+					tr("NameExists.Title"),
+					tr("NameExists.Text"));
 
 			obs_source_release(source);
 			on_actionAddScene_triggered();
@@ -2994,7 +3000,7 @@ void OBSBasic::SetDeinterlacingOrder()
 
 QMenu *OBSBasic::AddDeinterlacingMenu(obs_source_t *source)
 {
-	QMenu *menu = new QMenu(QTStr("Deinterlacing"));
+	QMenu *menu = new QMenu(tr("Deinterlacing"));
 	obs_deinterlace_mode deinterlaceMode =
 		obs_source_get_deinterlace_mode(source);
 	obs_deinterlace_field_order deinterlaceOrder =
@@ -3002,7 +3008,7 @@ QMenu *OBSBasic::AddDeinterlacingMenu(obs_source_t *source)
 	QAction *action;
 
 #define ADD_MODE(name, mode) \
-	action = menu->addAction(QTStr("" name), this, \
+	action = menu->addAction(tr("" name), this, \
 				SLOT(SetDeinterlacingMode())); \
 	action->setProperty("mode", (int)mode); \
 	action->setCheckable(true); \
@@ -3022,7 +3028,7 @@ QMenu *OBSBasic::AddDeinterlacingMenu(obs_source_t *source)
 	menu->addSeparator();
 
 #define ADD_ORDER(name, order) \
-	action = menu->addAction(QTStr("Deinterlacing." name), this, \
+	action = menu->addAction(tr("Deinterlacing." name), this, \
 				SLOT(SetDeinterlacingOrder())); \
 	action->setProperty("order", (int)order); \
 	action->setCheckable(true); \
@@ -3046,12 +3052,12 @@ void OBSBasic::SetScaleFilter()
 
 QMenu *OBSBasic::AddScaleFilteringMenu(obs_sceneitem_t *item)
 {
-	QMenu *menu = new QMenu(QTStr("ScaleFiltering"));
+	QMenu *menu = new QMenu(tr("ScaleFiltering"));
 	obs_scale_type scaleFilter = obs_sceneitem_get_scale_filter(item);
 	QAction *action;
 
 #define ADD_MODE(name, mode) \
-	action = menu->addAction(QTStr("" name), this, \
+	action = menu->addAction(tr("" name), this, \
 				SLOT(SetScaleFilter())); \
 	action->setProperty("mode", (int)mode); \
 	action->setCheckable(true); \
@@ -3075,7 +3081,7 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 
 	if (preview) {
 		QAction *action = popup.addAction(
-				QTStr("Basic.Main.PreviewConextMenu.Enable"),
+				tr("Basic.Main.PreviewConextMenu.Enable"),
 				this, SLOT(TogglePreview()));
 		action->setCheckable(true);
 		action->setChecked(
@@ -3084,12 +3090,12 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 			action->setEnabled(false);
 
 		action = popup.addAction(
-				QTStr("Basic.MainMenu.Edit.LockPreview"),
+				tr("Basic.MainMenu.Edit.LockPreview"),
 				this, SLOT(on_actionLockPreview_triggered()));
 		action->setCheckable(true);
 		action->setChecked(ui->preview->Locked());
 
-		previewProjector = new QMenu(QTStr("PreviewProjector"));
+		previewProjector = new QMenu(tr("PreviewProjector"));
 		AddProjectorMenuMonitors(previewProjector, this,
 				SLOT(OpenPreviewProjector()));
 
@@ -3113,16 +3119,16 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 			OBS_SOURCE_ASYNC_VIDEO;
 		QAction *action;
 
-		popup.addAction(QTStr("Rename"), this,
+		popup.addAction(tr("Rename"), this,
 				SLOT(EditSceneItemName()));
-		popup.addAction(QTStr("Remove"), this,
+		popup.addAction(tr("Remove"), this,
 				SLOT(on_actionRemoveSource_triggered()),
 				DeleteKeys.front());
 		popup.addSeparator();
 		popup.addMenu(ui->orderMenu);
 		popup.addMenu(ui->transformMenu);
 
-		sourceProjector = new QMenu(QTStr("SourceProjector"));
+		sourceProjector = new QMenu(tr("SourceProjector"));
 		AddProjectorMenuMonitors(sourceProjector, this,
 				SLOT(OpenSourceProjector()));
 
@@ -3138,15 +3144,15 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 		popup.addMenu(sourceProjector);
 		popup.addSeparator();
 
-		action = popup.addAction(QTStr("Interact"), this,
+		action = popup.addAction(tr("Interact"), this,
 				SLOT(on_actionInteract_triggered()));
 
 		action->setEnabled(obs_source_get_output_flags(source) &
 				OBS_SOURCE_INTERACTION);
 
-		popup.addAction(QTStr("Filters"), this,
+		popup.addAction(tr("Filters"), this,
 				SLOT(OpenFilters()));
-		popup.addAction(QTStr("Properties"), this,
+		popup.addAction(tr("Properties"), this,
 				SLOT(on_actionSourceProperties_triggered()));
 	}
 
@@ -3188,8 +3194,8 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 	bool foundDeprecated = false;
 	size_t idx = 0;
 
-	QMenu *popup = new QMenu(QTStr("Add"), this);
-	QMenu *deprecated = new QMenu(QTStr("Deprecated"), popup);
+	QMenu *popup = new QMenu(tr("Add"), this);
+	QMenu *deprecated = new QMenu(tr("Deprecated"), popup);
 
 	auto getActionAfter = [] (QMenu *menu, const QString &name)
 	{
@@ -3204,15 +3210,14 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 	};
 
 	auto addSource = [this, getActionAfter] (QMenu *popup,
-			const char *type, const char *name)
+	                const char *type, const QString &name)
 	{
-		QString qname = QT_UTF8(name);
-		QAction *popupItem = new QAction(qname, this);
+		QAction *popupItem = new QAction(name, this);
 		popupItem->setData(QT_UTF8(type));
 		connect(popupItem, SIGNAL(triggered(bool)),
 				this, SLOT(AddSourceFromAction()));
 
-		QAction *after = getActionAfter(popup, qname);
+		QAction *after = getActionAfter(popup, name);
 		popup->insertAction(after, popupItem);
 	};
 
@@ -3229,7 +3234,7 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 		foundValues = true;
 	}
 
-	addSource(popup, "scene", Str("Basic.Scene"));
+	addSource(popup, "scene", QObject::tr("Basic.Scene"));
 
 	if (!foundDeprecated) {
 		delete deprecated;
@@ -3261,8 +3266,8 @@ void OBSBasic::AddSourcePopupMenu(const QPoint &pos)
 	if (!GetCurrentScene()) {
 		// Tell the user he needs a scene first (help beginners).
 		QMessageBox::information(this,
-				QTStr("Basic.Main.AddSourceHelp.Title"),
-				QTStr("Basic.Main.AddSourceHelp.Text"));
+				tr("Basic.Main.AddSourceHelp.Title"),
+				tr("Basic.Main.AddSourceHelp.Text"));
 		return;
 	}
 
@@ -3296,16 +3301,16 @@ void OBSBasic::on_actionRemoveSource_triggered()
 
 	auto removeMultiple = [this] (size_t count)
 	{
-		QString text = QTStr("ConfirmRemove.TextMultiple")
+		QString text = tr("ConfirmRemove.TextMultiple")
 			.arg(QString::number(count));
 
 		QMessageBox remove_items(this);
 		remove_items.setText(text);
-		QAbstractButton *Yes = remove_items.addButton(QTStr("Yes"),
+		QAbstractButton *Yes = remove_items.addButton(tr("Yes"),
 				QMessageBox::YesRole);
-		remove_items.addButton(QTStr("No"), QMessageBox::NoRole);
+		remove_items.addButton(tr("No"), QMessageBox::NoRole);
 		remove_items.setIcon(QMessageBox::Question);
-		remove_items.setWindowTitle(QTStr("ConfirmRemove.Title"));
+		remove_items.setWindowTitle(tr("ConfirmRemove.Title"));
 		remove_items.exec();
 
 		return Yes == remove_items.clickedButton();
@@ -3496,7 +3501,7 @@ void OBSBasic::logUploadFinished(const QString &text, const QString &error)
 
 	if (text.isEmpty()) {
 		QMessageBox::information(this,
-				QTStr("LogReturnDialog.ErrorUploadingLog"),
+				tr("LogReturnDialog.ErrorUploadingLog"),
 				error);
 		return;
 	}
@@ -3524,12 +3529,12 @@ static void RenameListItem(OBSBasic *parent, QListWidget *listWidget,
 
 		if (foundSource) {
 			QMessageBox::information(parent,
-				QTStr("NameExists.Title"),
-				QTStr("NameExists.Text"));
+				QObject::tr("NameExists.Title"),
+				QObject::tr("NameExists.Text"));
 		} else if (name.empty()) {
 			QMessageBox::information(parent,
-				QTStr("NoNameEntered.Title"),
-				QTStr("NoNameEntered.Text"));
+				QObject::tr("NoNameEntered.Title"),
+				QObject::tr("NoNameEntered.Text"));
 		}
 
 		obs_source_release(foundSource);
@@ -3614,7 +3619,7 @@ void OBSBasic::StartStreaming()
 	SaveProject();
 
 	ui->streamButton->setEnabled(false);
-	ui->streamButton->setText(QTStr("Basic.Main.Connecting"));
+	ui->streamButton->setText(tr("Basic.Main.Connecting"));
 
 	if (sysTrayStream) {
 		sysTrayStream->setEnabled(false);
@@ -3622,7 +3627,7 @@ void OBSBasic::StartStreaming()
 	}
 
 	if (!outputHandler->StartStreaming(service)) {
-		ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
+		ui->streamButton->setText(tr("Basic.Main.StartStreaming"));
 		ui->streamButton->setEnabled(true);
 
 		if (sysTrayStream) {
@@ -3718,7 +3723,7 @@ void OBSBasic::ForceStopStreaming()
 
 void OBSBasic::StreamDelayStarting(int sec)
 {
-	ui->streamButton->setText(QTStr("Basic.Main.StopStreaming"));
+	ui->streamButton->setText(tr("Basic.Main.StopStreaming"));
 	ui->streamButton->setEnabled(true);
 
 	if (sysTrayStream) {
@@ -3730,9 +3735,9 @@ void OBSBasic::StreamDelayStarting(int sec)
 		startStreamMenu->deleteLater();
 
 	startStreamMenu = new QMenu();
-	startStreamMenu->addAction(QTStr("Basic.Main.StopStreaming"),
+	startStreamMenu->addAction(tr("Basic.Main.StopStreaming"),
 			this, SLOT(StopStreaming()));
-	startStreamMenu->addAction(QTStr("Basic.Main.ForceStopStreaming"),
+	startStreamMenu->addAction(tr("Basic.Main.ForceStopStreaming"),
 			this, SLOT(ForceStopStreaming()));
 	ui->streamButton->setMenu(startStreamMenu);
 
@@ -3743,7 +3748,7 @@ void OBSBasic::StreamDelayStarting(int sec)
 
 void OBSBasic::StreamDelayStopping(int sec)
 {
-	ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
+	ui->streamButton->setText(tr("Basic.Main.StartStreaming"));
 	ui->streamButton->setEnabled(true);
 
 	if (sysTrayStream) {
@@ -3755,9 +3760,9 @@ void OBSBasic::StreamDelayStopping(int sec)
 		startStreamMenu->deleteLater();
 
 	startStreamMenu = new QMenu();
-	startStreamMenu->addAction(QTStr("Basic.Main.StartStreaming"),
+	startStreamMenu->addAction(tr("Basic.Main.StartStreaming"),
 			this, SLOT(StartStreaming()));
-	startStreamMenu->addAction(QTStr("Basic.Main.ForceStopStreaming"),
+	startStreamMenu->addAction(tr("Basic.Main.ForceStopStreaming"),
 			this, SLOT(ForceStopStreaming()));
 	ui->streamButton->setMenu(startStreamMenu);
 
@@ -3766,7 +3771,7 @@ void OBSBasic::StreamDelayStopping(int sec)
 
 void OBSBasic::StreamingStart()
 {
-	ui->streamButton->setText(QTStr("Basic.Main.StopStreaming"));
+	ui->streamButton->setText(tr("Basic.Main.StopStreaming"));
 	ui->streamButton->setEnabled(true);
 	ui->statusbar->StreamStarted(outputHandler->streamOutput);
 
@@ -3785,7 +3790,7 @@ void OBSBasic::StreamingStart()
 
 void OBSBasic::StreamStopping()
 {
-	ui->streamButton->setText(QTStr("Basic.Main.StoppingStreaming"));
+	ui->streamButton->setText(tr("Basic.Main.StoppingStreaming"));
 
 	if (sysTrayStream)
 		sysTrayStream->setText(ui->streamButton->text());
@@ -3797,35 +3802,35 @@ void OBSBasic::StreamStopping()
 
 void OBSBasic::StreamingStop(int code)
 {
-	const char *errorMessage;
+	QString errorMessage;
 
 	switch (code) {
 	case OBS_OUTPUT_BAD_PATH:
-		errorMessage = Str("Output.ConnectFail.BadPath");
+		errorMessage = tr("Output.ConnectFail.BadPath");
 		break;
 
 	case OBS_OUTPUT_CONNECT_FAILED:
-		errorMessage = Str("Output.ConnectFail.ConnectFailed");
+		errorMessage = tr("Output.ConnectFail.ConnectFailed");
 		break;
 
 	case OBS_OUTPUT_INVALID_STREAM:
-		errorMessage = Str("Output.ConnectFail.InvalidStream");
+		errorMessage = tr("Output.ConnectFail.InvalidStream");
 		break;
 
 	default:
 	case OBS_OUTPUT_ERROR:
-		errorMessage = Str("Output.ConnectFail.Error");
+		errorMessage = tr("Output.ConnectFail.Error");
 		break;
 
 	case OBS_OUTPUT_DISCONNECTED:
 		/* doesn't happen if output is set to reconnect.  note that
 		 * reconnects are handled in the output, not in the UI */
-		errorMessage = Str("Output.ConnectFail.Disconnected");
+		errorMessage = tr("Output.ConnectFail.Disconnected");
 	}
 
 	ui->statusbar->StreamStopped();
 
-	ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
+	ui->streamButton->setText(tr("Basic.Main.StartStreaming"));
 	ui->streamButton->setEnabled(true);
 
 	if (sysTrayStream) {
@@ -3843,10 +3848,9 @@ void OBSBasic::StreamingStop(int code)
 
 	if (code != OBS_OUTPUT_SUCCESS && isVisible()) {
 		QMessageBox::information(this,
-				QTStr("Output.ConnectFail.Title"),
-				QT_UTF8(errorMessage));
+				tr("Output.ConnectFail.Title"), errorMessage);
 	} else if (code != OBS_OUTPUT_SUCCESS && !isVisible()) {
-		SysTrayNotify(QT_UTF8(errorMessage), QSystemTrayIcon::Warning);
+		SysTrayNotify(errorMessage, QSystemTrayIcon::Warning);
 	}
 
 	if (!startStreamMenu.isNull()) {
@@ -3870,7 +3874,7 @@ void OBSBasic::StartRecording()
 
 void OBSBasic::RecordStopping()
 {
-	ui->recordButton->setText(QTStr("Basic.Main.StoppingRecording"));
+	ui->recordButton->setText(tr("Basic.Main.StoppingRecording"));
 
 	if (sysTrayRecord)
 		sysTrayRecord->setText(ui->recordButton->text());
@@ -3893,7 +3897,7 @@ void OBSBasic::StopRecording()
 void OBSBasic::RecordingStart()
 {
 	ui->statusbar->RecordingStarted(outputHandler->fileOutput);
-	ui->recordButton->setText(QTStr("Basic.Main.StopRecording"));
+	ui->recordButton->setText(tr("Basic.Main.StopRecording"));
 
 	if (sysTrayRecord)
 		sysTrayRecord->setText(ui->recordButton->text());
@@ -3910,7 +3914,7 @@ void OBSBasic::RecordingStart()
 void OBSBasic::RecordingStop(int code)
 {
 	ui->statusbar->RecordingStopped();
-	ui->recordButton->setText(QTStr("Basic.Main.StartRecording"));
+	ui->recordButton->setText(tr("Basic.Main.StartRecording"));
 
 	if (sysTrayRecord)
 		sysTrayRecord->setText(ui->recordButton->text());
@@ -3918,29 +3922,29 @@ void OBSBasic::RecordingStop(int code)
 
 	if (code == OBS_OUTPUT_UNSUPPORTED && isVisible()) {
 		QMessageBox::information(this,
-				QTStr("Output.RecordFail.Title"),
-				QTStr("Output.RecordFail.Unsupported"));
+				tr("Output.RecordFail.Title"),
+				tr("Output.RecordFail.Unsupported"));
 
 	} else if (code == OBS_OUTPUT_NO_SPACE && isVisible()) {
 		QMessageBox::information(this,
-				QTStr("Output.RecordNoSpace.Title"),
-				QTStr("Output.RecordNoSpace.Msg"));
+				tr("Output.RecordNoSpace.Title"),
+				tr("Output.RecordNoSpace.Msg"));
 
 	} else if (code != OBS_OUTPUT_SUCCESS && isVisible()) {
 		QMessageBox::information(this,
-				QTStr("Output.RecordError.Title"),
-				QTStr("Output.RecordError.Msg"));
+				tr("Output.RecordError.Title"),
+				tr("Output.RecordError.Msg"));
 
 	} else if (code == OBS_OUTPUT_UNSUPPORTED && !isVisible()) {
-		SysTrayNotify(QTStr("Output.RecordFail.Unsupported"),
+		SysTrayNotify(tr("Output.RecordFail.Unsupported"),
 			QSystemTrayIcon::Warning);
 
 	} else if (code == OBS_OUTPUT_NO_SPACE && !isVisible()) {
-		SysTrayNotify(QTStr("Output.RecordNoSpace.Msg"),
+		SysTrayNotify(tr("Output.RecordNoSpace.Msg"),
 			QSystemTrayIcon::Warning);
 
 	} else if (code != OBS_OUTPUT_SUCCESS && !isVisible()) {
-		SysTrayNotify(QTStr("Output.RecordError.Msg"),
+		SysTrayNotify(tr("Output.RecordError.Msg"),
 			QSystemTrayIcon::Warning);
 	}
 
@@ -3959,8 +3963,8 @@ void OBSBasic::on_streamButton_clicked()
 		if (confirm && isVisible()) {
 			QMessageBox::StandardButton button =
 				QMessageBox::question(this,
-						QTStr("ConfirmStop.Title"),
-						QTStr("ConfirmStop.Text"));
+						tr("ConfirmStop.Title"),
+						tr("ConfirmStop.Text"));
 
 			if (button == QMessageBox::No)
 				return;
@@ -3974,8 +3978,8 @@ void OBSBasic::on_streamButton_clicked()
 		if (confirm && isVisible()) {
 			QMessageBox::StandardButton button =
 				QMessageBox::question(this,
-						QTStr("ConfirmStart.Title"),
-						QTStr("ConfirmStart.Text"));
+						tr("ConfirmStart.Title"),
+						tr("ConfirmStart.Text"));
 
 			if (button == QMessageBox::No)
 				return;
@@ -4047,12 +4051,12 @@ void OBSBasic::on_previewDisabledLabel_customContextMenuRequested(
 	QPointer<QMenu> previewProjector;
 
 	QAction *action = popup.addAction(
-			QTStr("Basic.Main.PreviewConextMenu.Enable"),
+			tr("Basic.Main.PreviewConextMenu.Enable"),
 			this, SLOT(TogglePreview()));
 	action->setCheckable(true);
 	action->setChecked(obs_display_enabled(ui->preview->GetDisplay()));
 
-	previewProjector = new QMenu(QTStr("PreviewProjector"));
+	previewProjector = new QMenu(tr("PreviewProjector"));
 	AddProjectorMenuMonitors(previewProjector, this,
 			SLOT(OpenPreviewProjector()));
 
@@ -4488,25 +4492,26 @@ void OBSBasic::OpenSceneProjector()
 
 void OBSBasic::UpdateTitleBar()
 {
-	stringstream name;
+	QStringList nameParts;
 
-	const char *profile = config_get_string(App()->GlobalConfig(),
-			"Basic", "Profile");
-	const char *sceneCollection = config_get_string(App()->GlobalConfig(),
-			"Basic", "SceneCollection");
+	QString profile = QString(config_get_string(App()->GlobalConfig(),
+	                          "Basic", "Profile"));
+	QString sceneCollection = QString(
+	                        config_get_string(App()->GlobalConfig(),
+	                        "Basic", "SceneCollection"));
 
-	name << "OBS ";
+	nameParts << "OBS ";
 	if (previewProgramMode)
-		name << "Studio ";
+		nameParts << "Studio ";
 
-	name << App()->GetVersionString();
+	nameParts << QString::fromStdString(App()->GetVersionString());
 	if (App()->IsPortableMode())
-		name << " - Portable Mode";
+		nameParts << " - Portable Mode";
 
-	name << " - " << Str("TitleBar.Profile") << ": " << profile;
-	name << " - " << Str("TitleBar.Scenes") << ": " << sceneCollection;
+	nameParts << " - " << tr("TitleBar.Profile") << ": " << profile;
+	nameParts << " - " << tr("TitleBar.Scenes") << ": " << sceneCollection;
 
-	setWindowTitle(QT_UTF8(name.str().c_str()));
+	setWindowTitle(nameParts.join(""));
 }
 
 int OBSBasic::GetProfilePath(char *path, size_t size, const char *file) const
@@ -4573,7 +4578,7 @@ void OBSBasic::SetShowing(bool showing)
 			saveGeometry().toBase64().constData());
 
 		if (showHide)
-			showHide->setText(QTStr("Basic.SystemTray.Show"));
+			showHide->setText(tr("Basic.SystemTray.Show"));
 		QTimer::singleShot(250, this, SLOT(hide()));
 
 		if (previewEnabled)
@@ -4583,7 +4588,7 @@ void OBSBasic::SetShowing(bool showing)
 
 	} else if (showing && !isVisible()) {
 		if (showHide)
-			showHide->setText(QTStr("Basic.SystemTray.Hide"));
+			showHide->setText(tr("Basic.SystemTray.Hide"));
 		QTimer::singleShot(250, this, SLOT(show()));
 
 		if (previewEnabled)
@@ -4599,13 +4604,13 @@ void OBSBasic::SystemTrayInit()
 			this);
 	trayIcon->setToolTip("OBS Studio");
 
-	showHide = new QAction(QTStr("Basic.SystemTray.Show"),
+	showHide = new QAction(tr("Basic.SystemTray.Show"),
 			trayIcon);
-	sysTrayStream = new QAction(QTStr("Basic.Main.StartStreaming"),
+	sysTrayStream = new QAction(tr("Basic.Main.StartStreaming"),
 			trayIcon);
-	sysTrayRecord = new QAction(QTStr("Basic.Main.StartRecording"),
+	sysTrayRecord = new QAction(tr("Basic.Main.StartRecording"),
 			trayIcon);
-	exit = new QAction(QTStr("Exit"),
+	exit = new QAction(tr("Exit"),
 			trayIcon);
 
 	connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
@@ -4675,7 +4680,7 @@ void OBSBasic::SystemTray(bool firstStarted)
 	}
 
 	if (isVisible())
-		showHide->setText(QTStr("Basic.SystemTray.Hide"));
+		showHide->setText(tr("Basic.SystemTray.Hide"));
 	else
-		showHide->setText(QTStr("Basic.SystemTray.Show"));
+		showHide->setText(tr("Basic.SystemTray.Show"));
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -44,11 +44,11 @@ class QNetworkReply;
 
 #include "ui_OBSBasic.h"
 
-#define DESKTOP_AUDIO_1 Str("DesktopAudioDevice1")
-#define DESKTOP_AUDIO_2 Str("DesktopAudioDevice2")
-#define AUX_AUDIO_1     Str("AuxAudioDevice1")
-#define AUX_AUDIO_2     Str("AuxAudioDevice2")
-#define AUX_AUDIO_3     Str("AuxAudioDevice3")
+#define DESKTOP_AUDIO_1 QObject::tr("DesktopAudioDevice1")
+#define DESKTOP_AUDIO_2 QObject::tr("DesktopAudioDevice2")
+#define AUX_AUDIO_1     QObject::tr("AuxAudioDevice1")
+#define AUX_AUDIO_2     QObject::tr("AuxAudioDevice2")
+#define AUX_AUDIO_3     QObject::tr("AuxAudioDevice3")
 
 #define SIMPLE_ENCODER_X264                    "x264"
 #define SIMPLE_ENCODER_X264_LOWCPU             "x264_lowcpu"

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -94,7 +94,7 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	installEventFilter(CreateShortcutFilter());
 
 	const char *name = obs_source_get_name(source);
-	setWindowTitle(QTStr("Basic.PropertiesWindow").arg(QT_UTF8(name)));
+	setWindowTitle(tr("Basic.PropertiesWindow").arg(QT_UTF8(name)));
 
 	obs_source_inc_showing(source);
 
@@ -136,7 +136,7 @@ void OBSBasicProperties::SourceRemoved(void *data, calldata_t *params)
 void OBSBasicProperties::SourceRenamed(void *data, calldata_t *params)
 {
 	const char *name = calldata_string(params, "new_name");
-	QString title = QTStr("Basic.PropertiesWindow").arg(QT_UTF8(name));
+	QString title = tr("Basic.PropertiesWindow").arg(QT_UTF8(name));
 
 	QMetaObject::invokeMethod(static_cast<OBSBasicProperties*>(data),
 	                "setWindowTitle", Q_ARG(QString, title));
@@ -266,8 +266,8 @@ bool OBSBasicProperties::ConfirmQuit()
 	QMessageBox::StandardButton button;
 
 	button = QMessageBox::question(this,
-			QTStr("Basic.PropertiesWindow.ConfirmTitle"),
-			QTStr("Basic.PropertiesWindow.Confirm"),
+			tr("Basic.PropertiesWindow.ConfirmTitle"),
+			tr("Basic.PropertiesWindow.Confirm"),
 			QMessageBox::Save | QMessageBox::Discard |
 			QMessageBox::Cancel);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -383,7 +383,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	uint32_t winVer = GetWindowsVersion();
 	if (winVer > 0 && winVer < 0x602) {
 		toggleAero = new QCheckBox(
-				QTStr("Basic.Settings.Video.DisableAero"),
+				tr("Basic.Settings.Video.DisableAero"),
 				this);
 		QFormLayout *videoLayout =
 			reinterpret_cast<QFormLayout*>(ui->videoPage->layout());
@@ -409,7 +409,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #undef PROCESS_PRIORITY
 
 	for (ProcessPriority pri : processPriorities)
-		ui->processPriority->addItem(QTStr(pri.name), pri.val);
+		ui->processPriority->addItem(tr(pri.name), pri.val);
 
 #else
 	delete ui->rendererLabel;
@@ -619,15 +619,15 @@ void OBSBasicSettings::LoadServiceTypes()
 	SetComboByValue(ui->streamType, type);
 }
 
-#define TEXT_USE_STREAM_ENC \
-	QTStr("Basic.Settings.Output.Adv.Recording.UseStreamEncoder")
-
 void OBSBasicSettings::LoadEncoderTypes()
 {
 	const char    *type;
 	size_t        idx = 0;
 
-	ui->advOutRecEncoder->addItem(TEXT_USE_STREAM_ENC, "none");
+	ui->advOutRecEncoder->addItem(
+			tr("Basic.Settings.Output.Adv.Recording."
+			   "UseStreamEncoder"),
+			"none");
 
 	while (obs_enum_encoder_types(idx++, &type)) {
 		const char *name = obs_encoder_get_display_name(type);
@@ -647,21 +647,18 @@ void OBSBasicSettings::LoadEncoderTypes()
 	}
 }
 
-#define CS_PARTIAL_STR QTStr("Basic.Settings.Advanced.Video.ColorRange.Partial")
-#define CS_FULL_STR    QTStr("Basic.Settings.Advanced.Video.ColorRange.Full")
-
 void OBSBasicSettings::LoadColorRanges()
 {
-	ui->colorRange->addItem(CS_PARTIAL_STR, "Partial");
-	ui->colorRange->addItem(CS_FULL_STR, "Full");
+	ui->colorRange->addItem(
+			tr("Basic.Settings.Advanced.Video.ColorRange.Partial"),
+			"Partial");
+	ui->colorRange->addItem(
+			tr("Basic.Settings.Advanced.Video.ColorRange.Full"),
+			"Full");
 }
 
-#define AV_FORMAT_DEFAULT_STR \
-	QTStr("Basic.Settings.Output.Adv.FFmpeg.FormatDefault")
-#define AUDIO_STR \
-	QTStr("Basic.Settings.Output.Adv.FFmpeg.FormatAudio")
-#define VIDEO_STR \
-	QTStr("Basic.Settings.Output.Adv.FFmpeg.FormatVideo")
+#define AUDIO_STR tr("Basic.Settings.Output.Adv.FFmpeg.FormatAudio")
+#define VIDEO_STR tr("Basic.Settings.Output.Adv.FFmpeg.FormatVideo")
 
 void OBSBasicSettings::LoadFormats()
 {
@@ -691,7 +688,9 @@ void OBSBasicSettings::LoadFormats()
 
 	ui->advOutFFFormat->model()->sort(0);
 
-	ui->advOutFFFormat->insertItem(0, AV_FORMAT_DEFAULT_STR);
+	ui->advOutFFFormat->insertItem(
+			0,
+			tr("Basic.Settings.Output.Adv.FFmpeg.FormatDefault"));
 
 	ui->advOutFFFormat->blockSignals(false);
 }
@@ -709,9 +708,6 @@ static void AddCodec(QComboBox *combo, const ff_codec_desc *codec_desc)
 	combo->addItem(itemText, qVariantFromValue(cd));
 }
 
-#define AV_ENCODER_DEFAULT_STR \
-	QTStr("Basic.Settings.Output.Adv.FFmpeg.AVEncoderDefault")
-
 static void AddDefaultCodec(QComboBox *combo, const ff_format_desc *formatDesc,
 		ff_codec_type codecType)
 {
@@ -721,12 +717,14 @@ static void AddDefaultCodec(QComboBox *combo, const ff_format_desc *formatDesc,
 	if (existingIdx >= 0)
 		combo->removeItem(existingIdx);
 
-	combo->addItem(QString("%1 (%2)").arg(cd.name, AV_ENCODER_DEFAULT_STR),
+	QString defEncoderStr = QObject::tr(
+			"Basic.Settings.Output.Adv.FFmpeg.AVEncoderDefault");
+	combo->addItem(QString("%1 (%2)").arg(cd.name, defEncoderStr),
 			qVariantFromValue(cd));
 }
 
 #define AV_ENCODER_DISABLE_STR \
-	QTStr("Basic.Settings.Output.Adv.FFmpeg.AVEncoderDisable")
+	tr("Basic.Settings.Output.Adv.FFmpeg.AVEncoderDisable")
 
 void OBSBasicSettings::ReloadCodecs(const ff_format_desc *formatDesc)
 {
@@ -1071,13 +1069,13 @@ void OBSBasicSettings::ResetDownscales(uint32_t cx, uint32_t cy)
 void OBSBasicSettings::LoadDownscaleFilters()
 {
 	ui->downscaleFilter->addItem(
-			QTStr("Basic.Settings.Video.DownscaleFilter.Bilinear"),
+			tr("Basic.Settings.Video.DownscaleFilter.Bilinear"),
 			QT_UTF8("bilinear"));
 	ui->downscaleFilter->addItem(
-			QTStr("Basic.Settings.Video.DownscaleFilter.Bicubic"),
+			tr("Basic.Settings.Video.DownscaleFilter.Bicubic"),
 			QT_UTF8("bicubic"));
 	ui->downscaleFilter->addItem(
-			QTStr("Basic.Settings.Video.DownscaleFilter.Lanczos"),
+			tr("Basic.Settings.Video.DownscaleFilter.Lanczos"),
 			QT_UTF8("lanczos"));
 
 	const char *scaleType = config_get_string(main->Config(),
@@ -1162,7 +1160,7 @@ void OBSBasicSettings::LoadVideoSettings()
 	if (video_output_active(obs_get_video())) {
 		ui->videoPage->setEnabled(false);
 		ui->videoMsg->setText(
-				QTStr("Basic.Settings.Video.CurrentlyActive"));
+				tr("Basic.Settings.Video.CurrentlyActive"));
 	}
 
 	LoadResolutionLists();
@@ -1268,13 +1266,13 @@ void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 	ui->advOutRescale->setEnabled(rescale);
 	ui->advOutRescale->setCurrentText(rescaleRes);
 
-	QStringList specList = QTStr("FilenameFormatting.completer").split(
+	QStringList specList = tr("FilenameFormatting.completer").split(
 				QRegularExpression("\n"));
 	QCompleter *specCompleter = new QCompleter(specList);
 	specCompleter->setCaseSensitivity(Qt::CaseSensitive);
 	specCompleter->setFilterMode(Qt::MatchContains);
 	ui->filenameFormatting->setCompleter(specCompleter);
-	ui->filenameFormatting->setToolTip(QTStr("FilenameFormatting.TT"));
+	ui->filenameFormatting->setToolTip(tr("FilenameFormatting.TT"));
 
 	switch (trackIndex) {
 	case 1: ui->advOutTrack1->setChecked(true); break;
@@ -1607,7 +1605,7 @@ void OBSBasicSettings::LoadListValues(QComboBox *widget, obs_property_t *prop,
 			deviceId = obs_data_get_string(settings, "device_id");
 	}
 
-	widget->addItem(QTStr("Disabled"), "disabled");
+	widget->addItem(tr("Disabled"), "disabled");
 
 	for (size_t i = 0; i < count; i++) {
 		const char *name = obs_property_list_item_name(prop, i);
@@ -1622,7 +1620,7 @@ void OBSBasicSettings::LoadListValues(QComboBox *widget, obs_property_t *prop,
 			widget->setCurrentIndex(idx);
 		} else {
 			widget->insertItem(0,
-					QTStr("Basic.Settings.Audio."
+					tr("Basic.Settings.Audio."
 						"UnknownAudioDevice"),
 					var);
 			widget->setCurrentIndex(0);
@@ -1677,10 +1675,10 @@ void OBSBasicSettings::LoadAudioSources()
 	widget->setLayout(layout);
 	ui->audioSourceScrollArea->setWidget(widget);
 
-	const char *enablePtm = Str("Basic.Settings.Audio.EnablePushToMute");
-	const char *ptmDelay  = Str("Basic.Settings.Audio.PushToMuteDelay");
-	const char *enablePtt = Str("Basic.Settings.Audio.EnablePushToTalk");
-	const char *pttDelay  = Str("Basic.Settings.Audio.PushToTalkDelay");
+	QString enablePtm = tr("Basic.Settings.Audio.EnablePushToMute");
+	QString ptmDelay  = tr("Basic.Settings.Audio.PushToMuteDelay");
+	QString enablePtt = tr("Basic.Settings.Audio.EnablePushToTalk");
+	QString pttDelay  = tr("Basic.Settings.Audio.PushToTalkDelay");
 	auto AddSource = [&](obs_source_t *source)
 	{
 		if (!(obs_source_get_output_flags(source) & OBS_SOURCE_AUDIO))
@@ -2148,7 +2146,7 @@ void OBSBasicSettings::LoadHotkeySettings(obs_hotkey_id ignoreKey)
 		if (label2->pairPartner)
 			continue;
 
-		QString tt = QTStr("Basic.Settings.Hotkeys.Pair");
+		QString tt = tr("Basic.Settings.Hotkeys.Pair");
 		auto name1 = label1->text();
 		auto name2 = label2->text();
 
@@ -2589,7 +2587,7 @@ void OBSBasicSettings::SaveAudioSettings()
 				input ? App()->InputAudioSource()
 				      : App()->OutputAudioSource(),
 				QT_TO_UTF8(GetComboData(combo)),
-				Str(name), index);
+				QT_TO_UTF8(tr(name)), index);
 	};
 
 	UpdateAudioDevice(false, ui->desktopAudioDevice1,
@@ -2693,8 +2691,8 @@ bool OBSBasicSettings::QueryChanges()
 	QMessageBox::StandardButton button;
 
 	button = QMessageBox::question(this,
-			QTStr("Basic.Settings.ConfirmTitle"),
-			QTStr("Basic.Settings.Confirm"),
+			tr("Basic.Settings.ConfirmTitle"),
+			tr("Basic.Settings.Confirm"),
 			QMessageBox::Yes | QMessageBox::No |
 			QMessageBox::Cancel);
 
@@ -2787,7 +2785,7 @@ void OBSBasicSettings::on_streamType_currentIndexChanged(int idx)
 void OBSBasicSettings::on_simpleOutputBrowse_clicked()
 {
 	QString dir = QFileDialog::getExistingDirectory(this,
-			QTStr("Basic.Settings.Output.SelectDirectory"),
+			tr("Basic.Settings.Output.SelectDirectory"),
 			ui->simpleOutputPath->text(),
 			QFileDialog::ShowDirsOnly |
 			QFileDialog::DontResolveSymlinks);
@@ -2800,7 +2798,7 @@ void OBSBasicSettings::on_simpleOutputBrowse_clicked()
 void OBSBasicSettings::on_advOutRecPathBrowse_clicked()
 {
 	QString dir = QFileDialog::getExistingDirectory(this,
-			QTStr("Basic.Settings.Output.SelectDirectory"),
+			tr("Basic.Settings.Output.SelectDirectory"),
 			ui->advOutRecPath->text(),
 			QFileDialog::ShowDirsOnly |
 			QFileDialog::DontResolveSymlinks);
@@ -2813,7 +2811,7 @@ void OBSBasicSettings::on_advOutRecPathBrowse_clicked()
 void OBSBasicSettings::on_advOutFFPathBrowse_clicked()
 {
 	QString dir = QFileDialog::getExistingDirectory(this,
-			QTStr("Basic.Settings.Output.SelectDirectory"),
+			tr("Basic.Settings.Output.SelectDirectory"),
 			ui->advOutRecPath->text(),
 			QFileDialog::ShowDirsOnly |
 			QFileDialog::DontResolveSymlinks);
@@ -2862,9 +2860,6 @@ void OBSBasicSettings::on_advOutRecEncoder_currentIndexChanged(int idx)
 	}
 }
 
-#define DEFAULT_CONTAINER_STR \
-	QTStr("Basic.Settings.Output.Adv.FFmpeg.FormatDescDef")
-
 void OBSBasicSettings::on_advOutFFFormat_currentIndexChanged(int idx)
 {
 	const QVariant itemDataVariant = ui->advOutFFFormat->itemData(idx);
@@ -2891,7 +2886,9 @@ void OBSBasicSettings::on_advOutFFFormat_currentIndexChanged(int idx)
 				defaultVideoCodecDesc.id);
 	} else {
 		ReloadCodecs(nullptr);
-		ui->advOutFFFormatDesc->setText(DEFAULT_CONTAINER_STR);
+		ui->advOutFFFormatDesc->setText(
+				"Basic.Settings.Output.Adv.FFmpeg."
+				"FormatDescDef");
 	}
 }
 
@@ -2928,7 +2925,7 @@ void OBSBasicSettings::on_colorFormat_currentIndexChanged(const QString &text)
 		ui->advancedMsg2->setText(QString());
 	else
 		ui->advancedMsg2->setText(
-				QTStr("Basic.Settings.Advanced.FormatWarning"));
+				tr("Basic.Settings.Advanced.FormatWarning"));
 }
 
 #define INVALID_RES_STR "Basic.Settings.Video.InvalidResolution"
@@ -2942,7 +2939,7 @@ static bool ValidResolutions(Ui::OBSBasicSettings *ui)
 	if (!ConvertResText(QT_TO_UTF8(baseRes), cx, cy) ||
 	    !ConvertResText(QT_TO_UTF8(outputRes), cx, cy)) {
 
-		ui->videoMsg->setText(QTStr(INVALID_RES_STR));
+		ui->videoMsg->setText(QObject::tr(INVALID_RES_STR));
 		return false;
 	}
 
@@ -3036,7 +3033,7 @@ void OBSBasicSettings::AudioChangedRestart()
 {
 	if (!loading) {
 		audioChanged = true;
-		ui->audioMsg->setText(QTStr("Basic.Settings.ProgramRestart"));
+		ui->audioMsg->setText(tr("Basic.Settings.ProgramRestart"));
 		sender()->setProperty("changed", QVariant(true));
 		EnableApplyButton(true);
 	}
@@ -3051,7 +3048,7 @@ void OBSBasicSettings::VideoChangedRestart()
 {
 	if (!loading) {
 		videoChanged = true;
-		ui->videoMsg->setText(QTStr("Basic.Settings.ProgramRestart"));
+		ui->videoMsg->setText(tr("Basic.Settings.ProgramRestart"));
 		sender()->setProperty("changed", QVariant(true));
 		EnableApplyButton(true);
 	}
@@ -3062,7 +3059,7 @@ void OBSBasicSettings::AdvancedChangedRestart()
 	if (!loading) {
 		advancedChanged = true;
 		ui->advancedMsg->setText(
-				QTStr("Basic.Settings.ProgramRestart"));
+				tr("Basic.Settings.ProgramRestart"));
 		sender()->setProperty("changed", QVariant(true));
 		EnableApplyButton(true);
 	}
@@ -3133,11 +3130,11 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 	const char *objectName = nullptr;
 
 	if (tracks == 0) {
-		msg = QTStr("OutputWarnings.NoTracksSelected");
+		msg = tr("OutputWarnings.NoTracksSelected");
 		objectName = "errorLabel";
 
 	} else if (tracks > 1) {
-		msg = QTStr("OutputWarnings.MultiTrackRecording");
+		msg = tr("OutputWarnings.MultiTrackRecording");
 		objectName = "warningLabel";
 	}
 
@@ -3156,7 +3153,8 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 
 static inline QString MakeMemorySizeString(int bitrate, int seconds)
 {
-	QString str = QTStr("Basic.Settings.Advanced.StreamDelay.MemoryUsage");
+	QString str = QObject::tr(
+			"Basic.Settings.Advanced.StreamDelay.MemoryUsage");
 	int megabytes = bitrate * seconds / 1000 / 8;
 
 	return str.arg(QString::number(megabytes));
@@ -3222,10 +3220,10 @@ void OBSBasicSettings::FillSimpleRecordingValues()
 {
 #define ADD_QUALITY(str) \
 	ui->simpleOutRecQuality->addItem( \
-			QTStr("Basic.Settings.Output.Simple.RecordingQuality." \
+			tr("Basic.Settings.Output.Simple.RecordingQuality." \
 				str), \
-			QString(str));
-#define ENCODER_STR(str) QTStr("Basic.Settings.Output.Simple.Encoder." str)
+			str);
+#define ENCODER_STR(str) tr("Basic.Settings.Output.Simple.Encoder." str)
 
 	ADD_QUALITY("Stream");
 	ADD_QUALITY("Small");
@@ -3359,7 +3357,7 @@ void OBSBasicSettings::SimpleStreamingEncoderChanged()
 }
 
 #define SIMPLE_OUTPUT_WARNING(str) \
-	QTStr("Basic.Settings.Output.Simple.Warn." str)
+	tr("Basic.Settings.Output.Simple.Warn." str)
 
 void OBSBasicSettings::SimpleRecordingEncoderChanged()
 {

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -123,8 +123,8 @@ bool AddNew(QWidget *parent, const char *id, const char *name,
 	obs_source_t *source = obs_get_source_by_name(name);
 	if (source) {
 		QMessageBox::information(parent,
-				QTStr("NameExists.Title"),
-				QTStr("NameExists.Text"));
+				QObject::tr("NameExists.Title"),
+				QObject::tr("NameExists.Text"));
 
 	} else {
 		source = obs_source_create(id, name, NULL, nullptr);
@@ -159,8 +159,8 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 	} else {
 		if (ui->sourceName->text().isEmpty()) {
 			QMessageBox::information(this,
-					QTStr("NoNameEntered.Title"),
-					QTStr("NoNameEntered.Text"));
+					tr("NoNameEntered.Title"),
+					tr("NoNameEntered.Text"));
 			return;
 		}
 
@@ -177,11 +177,12 @@ void OBSBasicSourceSelect::on_buttonBox_rejected()
 	done(DialogCode::Rejected);
 }
 
-static inline const char *GetSourceDisplayName(const char *id)
+static inline QString GetSourceDisplayName(const char *id)
 {
-	if (strcmp(id, "scene") == 0)
-		return Str("Basic.Scene");
-	return obs_source_get_display_name(id);
+	if (strcmp(id, "scene") == 0) {
+		return QObject::tr("Basic.Scene");
+	}
+	return QString(obs_source_get_display_name(id));
 }
 
 Q_DECLARE_METATYPE(OBSScene);
@@ -201,7 +202,7 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_)
 
 	ui->sourceList->setAttribute(Qt::WA_MacShowFocusRect, false);
 
-	QString placeHolderText{QT_UTF8(GetSourceDisplayName(id))};
+	QString placeHolderText = GetSourceDisplayName(id);
 
 	QString text{placeHolderText};
 	int i = 1;

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -82,19 +82,19 @@ void OBSBasicStatusBar::UpdateDelayMsg()
 
 	if (delaySecTotal) {
 		if (delaySecStarting && !delaySecStopping) {
-			msg = QTStr("Basic.StatusBar.DelayStartingIn");
+			msg = tr("Basic.StatusBar.DelayStartingIn");
 			msg = msg.arg(QString::number(delaySecStarting));
 
 		} else if (!delaySecStarting && delaySecStopping) {
-			msg = QTStr("Basic.StatusBar.DelayStoppingIn");
+			msg = tr("Basic.StatusBar.DelayStoppingIn");
 			msg = msg.arg(QString::number(delaySecStopping));
 
 		} else if (delaySecStarting && delaySecStopping) {
-			msg = QTStr("Basic.StatusBar.DelayStartingStoppingIn");
+			msg = tr("Basic.StatusBar.DelayStartingStoppingIn");
 			msg = msg.arg(QString::number(delaySecStopping),
 					QString::number(delaySecStarting));
 		} else {
-			msg = QTStr("Basic.StatusBar.Delay");
+			msg = tr("Basic.StatusBar.Delay");
 			msg = msg.arg(QString::number(delaySecTotal));
 		}
 	}
@@ -168,14 +168,14 @@ void OBSBasicStatusBar::UpdateSessionTime()
 	sessionTime->setMinimumWidth(sessionTime->width());
 
 	if (reconnectTimeout > 0) {
-		QString msg = QTStr("Basic.StatusBar.Reconnecting")
+		QString msg = tr("Basic.StatusBar.Reconnecting")
 			.arg(QString::number(retries),
 					QString::number(reconnectTimeout));
 		showMessage(msg);
 		reconnectTimeout--;
 
 	} else if (retries > 0) {
-		QString msg = QTStr("Basic.StatusBar.AttemptingReconnect");
+		QString msg = tr("Basic.StatusBar.AttemptingReconnect");
 		showMessage(msg.arg(QString::number(retries)));
 	}
 
@@ -200,7 +200,7 @@ void OBSBasicStatusBar::UpdateDroppedFrames()
 	if (!totalFrames)
 		return;
 
-	QString text = QTStr("DroppedFrames");
+	QString text = tr("DroppedFrames");
 	text = text.arg(QString::number(totalDropped),
 			QString::number(percent, 'f', 1));
 	droppedFrames->setText(text);
@@ -232,7 +232,7 @@ void OBSBasicStatusBar::Reconnect(int seconds)
 
 	if (!retries)
 		main->SysTrayNotify(
-				QTStr("Basic.SystemTray.Message.Reconnecting"),
+				tr("Basic.SystemTray.Message.Reconnecting"),
 				QSystemTrayIcon::Warning);
 
 	reconnectTimeout = seconds;
@@ -260,7 +260,7 @@ void OBSBasicStatusBar::ReconnectSuccess()
 {
 	OBSBasic *main = qobject_cast<OBSBasic*>(parent());
 
-	QString msg = QTStr("Basic.StatusBar.ReconnectSuccessful");
+	QString msg = tr("Basic.StatusBar.ReconnectSuccessful");
 	showMessage(msg, 4000);
 	main->SysTrayNotify(msg, QSystemTrayIcon::Information);
 	ReconnectClear();
@@ -289,9 +289,9 @@ void OBSBasicStatusBar::UpdateStatusBar()
 	double percentage = double(skipped) / double(total) * 100.0;
 
 	if (diff > 10 && percentage >= 0.1f) {
-		showMessage(QTStr("HighResourceUsage"), 4000);
+		showMessage(tr("HighResourceUsage"), 4000);
 		if (!main->isVisible() && overloadedNotify) {
-			main->SysTrayNotify(QTStr("HighResourceUsage"),
+			main->SysTrayNotify(tr("HighResourceUsage"),
 					QSystemTrayIcon::Warning);
 			overloadedNotify = false;
 		}

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -122,7 +122,7 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 
 	if (event->button() == Qt::RightButton) {
 		QMenu popup(this);
-		popup.addAction(QTStr("Close"), this, SLOT(EscapeTriggered()));
+		popup.addAction(tr("Close"), this, SLOT(EscapeTriggered()));
 		popup.exec(QCursor::pos());
 	}
 }

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -78,8 +78,8 @@ bool OBSRemux::Stop()
 		return true;
 
 	if (QMessageBox::critical(nullptr,
-				QTStr("Remux.ExitUnfinishedTitle"),
-				QTStr("Remux.ExitUnfinished"),
+				tr("Remux.ExitUnfinishedTitle"),
+				tr("Remux.ExitUnfinished"),
 				QMessageBox::Yes | QMessageBox::No,
 				QMessageBox::No) ==
 			QMessageBox::Yes) {
@@ -106,8 +106,8 @@ void OBSRemux::BrowseInput()
 		path = recPath;
 
 	path = QFileDialog::getOpenFileName(this,
-			QTStr("Remux.SelectRecording"), path,
-			QTStr("Remux.OBSRecording") + QString(" ") +
+			tr("Remux.SelectRecording"), path,
+			tr("Remux.OBSRecording") + QString(" ") +
 			RECORDING_PATTERN);
 
 	inputChanged(path);
@@ -134,7 +134,7 @@ void OBSRemux::inputChanged(const QString &path)
 void OBSRemux::BrowseOutput()
 {
 	QString path(ui->targetFile->text());
-	path = QFileDialog::getSaveFileName(this, QTStr("Remux.SelectTarget"),
+	path = QFileDialog::getSaveFileName(this, tr("Remux.SelectTarget"),
 				path, RECORDING_PATTERN);
 
 	if (path.isEmpty())
@@ -146,8 +146,8 @@ void OBSRemux::BrowseOutput()
 void OBSRemux::Remux()
 {
 	if (QFileInfo::exists(ui->targetFile->text()))
-		if (QMessageBox::question(this, QTStr("Remux.FileExistsTitle"),
-					QTStr("Remux.FileExists"),
+		if (QMessageBox::question(this, tr("Remux.FileExistsTitle"),
+					tr("Remux.FileExists"),
 					QMessageBox::Yes | QMessageBox::No) !=
 				QMessageBox::Yes)
 			return;
@@ -189,9 +189,9 @@ void OBSRemux::updateProgress(float percent)
 
 void OBSRemux::remuxFinished(bool success)
 {
-	QMessageBox::information(this, QTStr("Remux.FinishedTitle"),
+	QMessageBox::information(this, tr("Remux.FinishedTitle"),
 			success ?
-			QTStr("Remux.Finished") : QTStr("Remux.FinishedError"));
+			tr("Remux.Finished") : tr("Remux.FinishedError"));
 
 	worker->job.reset();
 	ui->progressBar->setVisible(false);


### PR DESCRIPTION
I flushed out the OBSTranslation implementation of QTranslation by
refactoring some logic from OBSApp into OBSTranslation. I then plumbed
QStrings into more places and use the Qt's tr() for translation instead
of the homegrown Str()/QTStr().