### PR TITLE
obs-transitions: Lerp instead of branch in swipe_transition.effect

### DIFF
--- a/plugins/obs-transitions/data/swipe_transition.effect
+++ b/plugins/obs-transitions/data/swipe_transition.effect
@@ -25,11 +25,12 @@ VertData VSDefault(VertData v_in)
 float4 PSSwipe(VertData v_in) : TARGET
 {
 	float2 swipe_uv = v_in.uv + swipe_val;
-
-	return (swipe_uv.x - saturate(swipe_uv.x) != 0.0) ||
-	       (swipe_uv.y - saturate(swipe_uv.y) != 0.0)
-		   ? tex_b.Sample(textureSampler, v_in.uv)
-		   : tex_a.Sample(textureSampler, swipe_uv);
+	
+	float4 tex_a_sample = tex_a.Sample(textureSampler, swipe_uv);
+	float4 tex_b_sample = tex_b.Sample(textureSampler, v_in.uv);
+	
+	float val = saturate(abs((swipe_uv.x - saturate(swipe_uv.x)) + (swipe_uv.y - saturate(swipe_uv.y))) * 65535);
+	return lerp(tex_a_sample, tex_b_sample, val);
 }
 
 technique Swipe


### PR DESCRIPTION
Same reason as with slide_transition.effect, branching (and especially sampling inside a branch) is inefficient. While only a minor gain, this can become a larger performance impact when the GPU is under heavy load and can't access the VRAM as often as the old code would have required.

See #673 for a better explanation as to why. The quick run down is: more VRAM usage, cache flushing required on older GPUs and not using all available assigned texture samplers.

HomeWorld asked me to look at this, so here it is. :3