### PR TITLE
UI: Fix crash when switching encoders in advanced mode

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1290,14 +1290,16 @@ OBSPropertiesView *OBSBasicSettings::CreateEncoderPropertyView(
 	obs_data_t *settings = obs_encoder_defaults(encoder);
 	OBSPropertiesView *view;
 
-	char encoderJsonPath[512];
-	int ret = GetProfilePath(encoderJsonPath, sizeof(encoderJsonPath),
-			path);
-	if (ret > 0) {
-		obs_data_t *data = obs_data_create_from_json_file_safe(
-				encoderJsonPath, "bak");
-		obs_data_apply(settings, data);
-		obs_data_release(data);
+	if (path) {
+		char encoderJsonPath[512];
+		int ret = GetProfilePath(encoderJsonPath, sizeof(encoderJsonPath),
+				path);
+		if (ret > 0) {
+			obs_data_t *data = obs_data_create_from_json_file_safe(
+					encoderJsonPath, "bak");
+			obs_data_apply(settings, data);
+			obs_data_release(data);
+		}
 	}
 
 	view = new OBSPropertiesView(settings, encoder,


### PR DESCRIPTION
Fix for [issue 657](https://obsproject.com/mantis/view.php?id=657) on the bug tracker.

`CreateEncoderPropertyView` is called with a null path when a new encoder is selected and the settings should not be loaded from a file. Since it didn't handle this case it was trying to open and read the profile directory itself which caused an eventual crash.

I believe that simply loading and using the encoder defaults when no file is specified is expected behaviour.
