### PR TITLE
UI: Fix tab order of Crop fields in Transform Properties

### DIFF
--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -493,6 +493,25 @@
      </item>
      <item row="9" column="1">
       <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="1">
+        <widget class="QSpinBox" name="cropLeft">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>70</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="3">
         <widget class="QSpinBox" name="cropRight">
          <property name="sizePolicy">
@@ -599,25 +618,6 @@
          </property>
          <property name="buddy">
           <cstring>cropRight</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QSpinBox" name="cropLeft">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>70</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Currently, tabbing through the Crop Fields in the Transform Properties dialog goes in the order:
1. Right
2. Top
3. Bottom
4. Left

This PR/commit changes it to:
1. Left
2. Right
3. Top
4. Bottom

This also means that the tab order going into and coming out of the Crop fields is adjusted.  As always, feedback and review are welcome.