### PR TITLE
libobs: Duplicate filters of a scene when it is is duplicated

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -410,7 +410,9 @@ obs_source_t *obs_source_duplicate(obs_source_t *source,
 		obs_scene_t *new_scene = obs_scene_duplicate(scene, new_name,
 				create_private ? OBS_SCENE_DUP_PRIVATE_COPY :
 					OBS_SCENE_DUP_COPY);
-		return obs_scene_get_source(new_scene);
+		obs_source_t *new_source = obs_scene_get_source(new_scene);
+		duplicate_filters(new_source, source, create_private);
+		return new_source;
 	}
 
 	settings = obs_data_create();


### PR DESCRIPTION
When a scene is duplicated the filters on the scene were not copied to
the new scene. This causes that a temporary copy of a scene renders
differently in the program than in the preview when using studio mode.