### PR TITLE
Add Windows bitness/arch to crash handler

### DIFF
--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -259,7 +259,7 @@ static inline void write_header(struct exception_handler_data *data)
 			"Date/Time: %s\r\n"
 			"Fault address: %"PRIX64" (%s)\r\n"
 			"libobs version: "OBS_VERSION"\r\n"
-			"Windows version: %d.%d build %d (revision %d)\r\n"
+			"Windows version: %d.%d build %d (revision: %d; %d-bit)\r\n"
 			"CPU: %s\r\n\r\n",
 			data->exception->ExceptionRecord->ExceptionCode,
 			date_time,
@@ -267,6 +267,7 @@ static inline void write_header(struct exception_handler_data *data)
 			data->module_name.array,
 			data->win_version.major, data->win_version.minor,
 			data->win_version.build, data->win_version.revis,
+			data->win_version.bitness,
 			data->cpu_info.array);
 }
 

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -172,27 +172,14 @@ static void log_available_memory(void)
 			note);
 }
 
-static bool is_64_bit_windows(void)
-{
-#if defined(_WIN64)
-	return true;
-#elif defined(_WIN32)
-	BOOL b64 = false;
-	return IsWow64Process(GetCurrentProcess(), &b64) && b64;
-#endif
-}
-
 static void log_windows_version(void)
 {
 	struct win_version_info ver;
 	get_win_ver(&ver);
 
-	bool b64 = is_64_bit_windows();
-	const char *windows_bitness = b64 ? "64" : "32";
-
-	blog(LOG_INFO, "Windows Version: %d.%d Build %d (revision: %d; %s-bit)",
+	blog(LOG_INFO, "Windows Version: %d.%d Build %d (revision: %d; %d-bit)",
 			ver.major, ver.minor, ver.build, ver.revis,
-			windows_bitness);
+			ver.bitness);
 }
 
 static void log_admin_status(void)

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -757,6 +757,16 @@ bool get_dll_ver(const wchar_t *lib, struct win_version_info *ver_info)
 	return true;
 }
 
+static bool is_64_bit_windows(void)
+{
+#if defined(_WIN64)
+	return true;
+#elif defined(_WIN32)
+	BOOL b64 = false;
+	return IsWow64Process(GetCurrentProcess(), &b64) && b64;
+#endif
+}
+
 #define WINVER_REG_KEY L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"
 
 void get_win_ver(struct win_version_info *info)
@@ -790,6 +800,9 @@ void get_win_ver(struct win_version_info *info)
 
 			RegCloseKey(key);
 		}
+
+		bool b64 = is_64_bit_windows();
+		ver.bitness = b64 ? 64 : 32;
 	}
 
 	*info = ver;

--- a/libobs/util/windows/win-version.h
+++ b/libobs/util/windows/win-version.h
@@ -27,6 +27,7 @@ struct win_version_info {
 	int minor;
 	int build;
 	int revis;
+	int bitness;
 };
 
 EXPORT bool get_dll_ver(const wchar_t *lib, struct win_version_info *info);


### PR DESCRIPTION
Commit aa899c2 (PR #603) added logging for Windows bitness/arch, but it was a bit incomplete/short-sighted.  It only added that information to the regular logs.  This PR makes it easier to retrieve that information for other purposes, like the crash handler, and adds that information to the crash log.

I've explained this before, but I use the term "bitness" because "arch" tends to be thought of as x86-64 vs. x86, whereas I want to clearly indicate 32-bit vs. 64-bit.

This PR contains two separate commits (neither is broken, and each addressed different changes).  Let me know if they should be squashed.  I've tested this code on Win10 Pro 64-bit (though I haven't tried crashing the app).  As always, feedback, testing, or reviews are welcomed.