### PR TITLE
rtmp-services: Change YouTube keyint from 4 to 2

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 40,
+	"version": 41,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 40
+			"version": 41
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -131,7 +131,7 @@
                 }
             ],
             "recommended": {
-                "keyint": 4,
+                "keyint": 2,
                 "profile": "main",
                 "max video bitrate": 18000,
                 "max audio bitrate": 160


### PR DESCRIPTION
YouTube [recommends a keyframe interval of 2 seconds](https://support.google.com/youtube/answer/2853702).  Their maximum keyframe interval is 4 seconds.  This PR changes the keyframe interval from 4 seconds to 2 seconds.  If there was some technical reason for having it at 4, please educate me, and close this PR.  As always, reviews, feedback, and edits are welcome.