### PR TITLE
win-capture: Add code to allow hooking DXGI's Present1

### DIFF
--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
 	printf("is_d3d9ex_clsoff=0x%"PRIx32"\n", d3d9.is_d3d9ex_clsoff);
 	printf("[dxgi]\n");
 	printf("present=0x%"PRIx32"\n", dxgi.present);
+	printf("present1=0x%"PRIx32"\n", dxgi.present1);
 	printf("resize=0x%"PRIx32"\n", dxgi.resize);
 
 	(void)argc;

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -39,6 +39,7 @@ struct d3d9_offsets {
 
 struct dxgi_offsets {
 	uint32_t present;
+	uint32_t present1;
 	uint32_t resize;
 };
 

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -1,7 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #include <d3d10_1.h>
 #include <d3d11.h>
-#include <dxgi.h>
+#include <dxgi1_2.h>
 #include <d3dcompiler.h>
 
 #include "d3d1x_shaders.hpp"
@@ -11,9 +11,12 @@
 typedef HRESULT (STDMETHODCALLTYPE *resize_buffers_t)(IDXGISwapChain*, UINT,
 		UINT, UINT, DXGI_FORMAT, UINT);
 typedef HRESULT (STDMETHODCALLTYPE *present_t)(IDXGISwapChain*, UINT, UINT);
+typedef HRESULT (STDMETHODCALLTYPE *present1_t)(IDXGISwapChain*, UINT, UINT,
+		const DXGI_PRESENT_PARAMETERS*);
 
 static struct func_hook resize_buffers;
 static struct func_hook present;
+static struct func_hook present1;
 
 struct dxgi_swap_data {
 	IDXGISwapChain *swap;
@@ -150,6 +153,51 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 	return hr;
 }
 
+static HRESULT STDMETHODCALLTYPE hook_present1(IDXGISwapChain1 *swap,
+		UINT sync_interval, UINT flags,
+		const DXGI_PRESENT_PARAMETERS *pp)
+{
+	IDXGIResource *backbuffer = nullptr;
+	bool capture_overlay = global_hook_info->capture_overlay;
+	bool test_draw = (flags & DXGI_PRESENT_TEST) != 0;
+	bool capture;
+	HRESULT hr;
+
+	if (!data.swap && !capture_active()) {
+		setup_dxgi(swap);
+	}
+
+	capture = !test_draw && swap == data.swap && !!data.capture;
+	if (capture && !capture_overlay) {
+		backbuffer = get_dxgi_backbuffer(swap);
+
+		if (!!backbuffer) {
+			data.capture(swap, backbuffer);
+			backbuffer->Release();
+		}
+	}
+
+	unhook(&present1);
+	present1_t call = (present1_t)present1.call_addr;
+	hr = call(swap, sync_interval, flags, pp);
+	rehook(&present1);
+
+	if (capture && capture_overlay) {
+		if (resize_buffers_called) {
+			resize_buffers_called = false;
+		} else {
+			backbuffer = get_dxgi_backbuffer(swap);
+
+			if (!!backbuffer) {
+				data.capture(swap, backbuffer);
+				backbuffer->Release();
+			}
+		}
+	}
+
+	return hr;
+}
+
 static pD3DCompile get_compiler(void)
 {
 	pD3DCompile compile = nullptr;
@@ -186,6 +234,7 @@ bool hook_dxgi(void)
 	HMODULE dxgi_module = get_system_module("dxgi.dll");
 	HRESULT hr;
 	void *present_addr;
+	void *present1_addr = 0;
 	void *resize_addr;
 
 	if (!dxgi_module) {
@@ -236,14 +285,22 @@ bool hook_dxgi(void)
 			global_hook_info->offsets.dxgi.present);
 	resize_addr = get_offset_addr(dxgi_module,
 			global_hook_info->offsets.dxgi.resize);
+	if (global_hook_info->offsets.dxgi.present1)
+		present1_addr = get_offset_addr(dxgi_module,
+				global_hook_info->offsets.dxgi.present1);
 
 	hook_init(&present, present_addr, (void*)hook_present,
 			"IDXGISwapChain::Present");
 	hook_init(&resize_buffers, resize_addr, (void*)hook_resize_buffers,
 			"IDXGISwapChain::ResizeBuffers");
+	if (present1_addr)
+		hook_init(&present1, present1_addr, (void*)hook_present1,
+				"IDXGISwapChain1::Present1");
 
 	rehook(&resize_buffers);
 	rehook(&present);
+	if (present1_addr)
+		rehook(&present1);
 
 	hlog("Hooked DXGI");
 	return true;

--- a/plugins/win-capture/load-graphics-offsets.c
+++ b/plugins/win-capture/load-graphics-offsets.c
@@ -37,6 +37,8 @@ static inline bool load_offsets_from_string(struct graphics_offsets *offsets,
 
 	offsets->dxgi.present =
 		(uint32_t)config_get_uint(config, "dxgi", "present");
+	offsets->dxgi.present1 =
+		(uint32_t)config_get_uint(config, "dxgi", "present1");
 	offsets->dxgi.resize =
 		(uint32_t)config_get_uint(config, "dxgi", "resize");
 


### PR DESCRIPTION
This should fix a case where games or programs using
IDXGISwapChain1::Present1 weren't capturable.