### PR TITLE
UI: Enable scrolling while preview is locked

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -380,8 +380,7 @@ void OBSBasicPreview::GetStretchHandleData(const vec2 &pos)
 
 void OBSBasicPreview::keyPressEvent(QKeyEvent *event)
 {
-	if (locked ||
-	    GetScalingMode() == ScalingMode::Window ||
+	if (GetScalingMode() == ScalingMode::Window ||
 	    event->isAutoRepeat()) {
 		OBSQTDisplay::keyPressEvent(event);
 		return;
@@ -416,6 +415,19 @@ void OBSBasicPreview::keyReleaseEvent(QKeyEvent *event)
 
 void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 {
+	if (scrollMode && GetScalingMode() != ScalingMode::Window &&
+	    event->button() == Qt::LeftButton) {
+		setCursor(Qt::ClosedHandCursor);
+		scrollingFrom.x = event->x();
+		scrollingFrom.y = event->y();
+		return;
+	}
+
+	if (event->button() == Qt::RightButton) {
+		scrollMode = false;
+		setCursor(Qt::ArrowCursor);
+	}
+
 	if (locked) {
 		OBSQTDisplay::mousePressEvent(event);
 		return;
@@ -429,13 +441,6 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 	bool altDown = (modifiers & Qt::AltModifier);
 
 	OBSQTDisplay::mousePressEvent(event);
-
-	if (scrollMode && GetScalingMode() != ScalingMode::Window) {
-		setCursor(Qt::ClosedHandCursor);
-		scrollingFrom.x = event->x();
-		scrollingFrom.y = event->y();
-		return;
-	}
 
 	if (event->button() != Qt::LeftButton &&
 	    event->button() != Qt::RightButton)
@@ -500,13 +505,13 @@ void OBSBasicPreview::ProcessClick(const vec2 &pos)
 
 void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 {
+	if (scrollMode)
+		setCursor(Qt::OpenHandCursor);
+
 	if (locked) {
 		OBSQTDisplay::mouseReleaseEvent(event);
 		return;
 	}
-
-	if (scrollMode)
-		setCursor(Qt::OpenHandCursor);
 
 	if (mouseDown) {
 		vec2 pos = GetMouseEventPos(event);
@@ -998,9 +1003,6 @@ void OBSBasicPreview::StretchItem(const vec2 &pos)
 
 void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 {
-	if (locked)
-		return;
-
 	if (scrollMode && event->buttons() == Qt::LeftButton) {
 		scrollingOffset.x += event->x() - scrollingFrom.x;
 		scrollingOffset.y += event->y() - scrollingFrom.y;
@@ -1009,6 +1011,9 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 		emit DisplayResized();
 		return;
 	}
+
+	if (locked)
+		return;
 
 	if (mouseDown) {
 		vec2 pos = GetMouseEventPos(event);


### PR DESCRIPTION
As reboot pointed out, it's assumed that the intention of a locked
preview is to prevent editing the scene. Because scrolling the preview
does not have any interaction with the scene and its sources, you should
be able to still scroll around and look at different parts of your
preview while the preview is locked.

There is also a bugfix included for a small bug: previously, if you were
to right click while space bar was held down, you would be stuck in
scroll mode until spacebar is pressed/released again. This gets around
it by forcing scroll mode to end when a right click is issued on the
preview.

edit: looked up the definition of hotfix and it seems bugfix is more appropriate of a word