### PR TITLE
enc-amf: Update to 1.4.2.2 and fix preset and settings in simple mode

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -505,7 +505,6 @@ void SimpleOutput::UpdateStreamingSettings_amd(obs_data_t *settings,
 	obs_data_set_int(settings, "AMF.H264.Usage", 0);
 	obs_data_set_int(settings, "AMF.H264.Profile", 100); // High
 	obs_data_set_string(settings, "profile", "high"); // High
-	obs_data_set_int(settings, "AMF.H264.ProfileLevel", 0); // Automatic
 	
 	// Rate Control Properties
 	obs_data_set_int(settings, "AMF.H264.RateControlMethod", 1);
@@ -513,8 +512,6 @@ void SimpleOutput::UpdateStreamingSettings_amd(obs_data_t *settings,
 	obs_data_set_int(settings, "AMF.H264.Bitrate.Target", bitrate);
 	obs_data_set_int(settings, "bitrate", bitrate);
 	obs_data_set_int(settings, "AMF.H264.FillerData", 1);
-	obs_data_set_int(settings, "AMF.H264.VBVBuffer", 0); // Automatic VBV Buffer
-	obs_data_set_double(settings, "AMF.H264.VBVBuffer.Strictness", 0.9);
 	
 	// Picture Control Properties
 	obs_data_set_double(settings, "AMF.H264.KeyframeInterval", 2.0);
@@ -529,9 +526,8 @@ void SimpleOutput::UpdateRecordingSettings_amd_cqp(int cqp)
 	obs_data_set_int(settings, "AMF.H264.Usage", 0);
 	obs_data_set_int(settings, "AMF.H264.Profile", 100); // High
 	obs_data_set_string(settings, "profile", "high"); // High
-	obs_data_set_int(settings, "AMF.H264.ProfileLevel", 0); // Automatic
 
-															// Rate Control Properties
+	// Rate Control Properties
 	obs_data_set_int(settings, "AMF.H264.RateControlMethod", 0);
 	obs_data_set_string(settings, "rate_control", "CQP");
 	obs_data_set_int(settings, "AMF.H264.QP.IFrame", cqp);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1206,6 +1206,8 @@ void OBSBasicSettings::LoadSimpleOutputSettings()
 			"QSVPreset");
 	const char *nvPreset = config_get_string(main->Config(), "SimpleOutput",
 			"NVENCPreset");
+	const char* amdPreset = config_get_string(main->Config(), "SimpleOutput",
+			"AMDPreset");
 	const char *custom = config_get_string(main->Config(), "SimpleOutput",
 			"x264Settings");
 	const char *recQual = config_get_string(main->Config(), "SimpleOutput",
@@ -1218,6 +1220,7 @@ void OBSBasicSettings::LoadSimpleOutputSettings()
 	curPreset = preset;
 	curQSVPreset = qsvPreset;
 	curNVENCPreset = nvPreset;
+	curAMDPreset = amdPreset;
 
 	audioBitrate = FindClosestAvailableAACBitrate(audioBitrate);
 


### PR DESCRIPTION
Short changelog, for the hotfix patch notes:

- Updated AMD Encoder to version 1.4.2.2 from 1.4.1.0. (Changelogs: [1.4.1.1](https://github.com/Xaymar/obs-studio_amf-encoder-plugin/releases/tag/1.4.1.1), [1.4.1.5](https://github.com/Xaymar/obs-studio_amf-encoder-plugin/releases/tag/1.4.1.5), [1.4.2.2](https://github.com/Xaymar/obs-studio_amf-encoder-plugin/releases/tag/1.4.2.2))
- Fixed a crash on OBS startup on systems with switchable GPUs (AMD Hybrid).
- Updated simple mode settings for the AMD Encoder.

```
- Updated AMD Encoder to version 1.4.2.2 from 1.4.1.0. (Changelogs: [1.4.1.1](https://github.com/Xaymar/obs-studio_amf-encoder-plugin/releases/tag/1.4.1.1), [1.4.1.5](https://github.com/Xaymar/obs-studio_amf-encoder-plugin/releases/tag/1.4.1.5), [1.4.2.2](https://github.com/Xaymar/obs-studio_amf-encoder-plugin/releases/tag/1.4.2.2))
- Fixed a crash on OBS startup on systems with switchable GPUs (AMD Hybrid).
- Updated simple mode settings for the AMD Encoder.
```

## Full Plugin Changelog
### 1.4.2.1 -> 1.4.2.2 Changelog
- (Hotfix) Fixed: Potential crash when opening the settings.

### 1.4.2.0 -> 1.4.2.1 Changelog
- (Hotfix) Fixed: Presets were not being applied properly.

### 1.4.1.5 -> 1.4.2.0 Changelog
- Added: Full multi-GPU encoding support.
- Added: 'Coding Type' property which replaces 'CABAC'.
- Fixed: Filler Data was always being forced on for CBR.
- Fixed: Users should now be able to modify Delta QP for B-Pictures even when not using Constant QP.
- Fixed: Crash on OBS start on AMD Hybrid/Switchable GPU systems.
- Changed: Default device is always the primary/best available AMD GPU in the system.
- Changed: B-Picture properties will be properly hidden now if not in use.
- Changed: B-Pictures defaults to 0 and B-Picture Reference defaults to Disabled.
- Removed: 'Memory Type' property as the plugin will now always use the best available API.
- Removed: 'Surface Format' property as the plugin will now use the OBS settings for this.
- Removed: Deprecated encoder entry has been fully removed now.

### 1.4.1.1 -> 1.4.1.5 Changelog
- Added: Experimental Full Range encoding support for certain hardware and drivers.
- Fixed: Color Profile and Range will now be taken from OBS Studios Advanced settings.
- Fixed: Stable APU drivers should now work fine again.
- Fixed: Submission queue should no longer fill up when first starting encoding by waiting up to 5 seconds for the first frame to actually be submitted.
- Changed: Presets will disable properties that they override now and limit changeable properties within the allowed range.
- Changed: Default of VBV Buffer Strictness is now 0%.
- Changed: All presets no longer override VBV Buffer properties.

### 1.4.1.0 -> 1.4.1.1 Changelog
- Fixed: Automatic Profile Level will no longer always pick '4.1'.
- Fixed: Constant QP should now work properly again.
- Fixed: Plugin should no longer leak memory when initialization fails.
- Fixed: Intra-Refresh options should now actually work properly.
- Changed: Tooltips are now slightly more accurate for Intra-Refresh encoding.
- Changed: Adjusted the behaviour of some presets.
- 'Enforce HRD Compatibility', 'CABAC' and 'Quality Preset' are no longer overridden by Presets. 'Target Bitrate' and 'Peak Bitrate' are now allowed within a certain range in 'Twitch', 'YouTube' and 'Recording' Presets. Twitch limits between 1.0 and 4.0 mbit/s, YouTube between 1.0 and 25.0 mbit/s, Recording accepts anything larger than 10.0 mbit/s.
- Changed: OpenCL will be automatically disabled if not supported by the Memory Type.
- Changed: Log output should now be less ambiguous.
- Changed: Quality Preset option was moved further up in the UI.