### PR TITLE
rtmp-services: remove shut down services

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 42,
+	"version": 43,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 42
+			"version": 43
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -346,15 +346,6 @@
             ]
         },
         {
-            "name": "mSportz",
-            "servers": [
-                {
-                    "name": "Primary",
-                    "url": "rtmp://52.21.78.175/mSports"
-                }
-            ]
-        },
-        {
             "name": "Switchboard Live (Joicaster)",
             "servers": [
                 {
@@ -435,15 +426,6 @@
                 {
                     "name": "US: New York 2, NY",
                     "url": "rtmp://live-nyc2.vaughnsoft.net:443/live"
-                }
-            ]
-        },
-        {
-            "name": "Streamup",
-            "servers": [
-                {
-                    "name": "Worldwide",
-                    "url": "rtmp://origin.streamuplive.com/app"
                 }
             ]
         },


### PR DESCRIPTION
* StreamUp has changed into... something. No longer a live streaming service
* mSportz doesn't seem to exist any longer.
