### PR TITLE
UI: Use dedicated GPU on Hybrid GPU systems

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -67,6 +67,30 @@ string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
 
+// AMD PowerXpress & Nvidia Optimus High Performance Flags
+#if defined(_MSC_VER) //  Microsoft 
+#define EXPORT __declspec(dllexport)
+#define IMPORT __declspec(dllimport)
+#elif defined(__GNUC__) //  GCC
+#define EXPORT __attribute__((visibility("default")))
+#define IMPORT
+#else // Do nothing
+#define EXPORT
+#define IMPORT
+#pragma warning Unknown dynamic link import/export semantics.
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+	EXPORT int NvOptimusEnablement = 0x00000001; // NVidia
+	EXPORT int AmdPowerXpressRequestHighPerformance = 0x00000001; // AMD
+#ifdef __cplusplus
+}
+#endif
+// End Of: AMD PowerXpress & Nvidia Optimus High Performance Flags
+
 QObject *CreateShortcutFilter()
 {
 	return new OBSEventFilter([](QObject *obj, QEvent *event)


### PR DESCRIPTION
This changes the OBS interface to always default to the high performance GPU on Hybrid GPU systems, like Nvidia Optimus or AMD PowerXpress (APU systems and similar).

I did not see this exported by the obs*.exe, so I don't know if this is wanted or not wanted. It should help with game capture on those systems, since most games use the dedicated GPU, but may negatively affect display capture as that usually goes through the internal GPU.