### PR TITLE
libff: Allow custom demuxer options

### DIFF
--- a/deps/libff/libff/ff-demuxer.c
+++ b/deps/libff/libff/ff-demuxer.c
@@ -377,7 +377,7 @@ static bool open_input(struct ff_demuxer *demuxer,
 	}
 
 	if (avformat_open_input(format_context, demuxer->input,
-			input_format, NULL) != 0)
+			input_format, &demuxer->options.custom_options) != 0)
 		return false;
 
 	return avformat_find_stream_info(*format_context, NULL) >= 0;

--- a/deps/libff/libff/ff-demuxer.h
+++ b/deps/libff/libff/ff-demuxer.h
@@ -40,6 +40,7 @@ struct ff_demuxer_options
 	bool is_hw_decoding;
 	bool is_looping;
 	enum AVDiscard frame_drop;
+	AVDictionary *custom_options;
 };
 
 typedef struct ff_demuxer_options ff_demuxer_options_t;


### PR DESCRIPTION
Allows for more flexibility in libff based sources by providing access to demuxer specific options. Doesn't affect existing sources.