### PR TITLE
UI: Fix property name typo in frontend API

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -155,7 +155,7 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 		for (int i = 0; i < menuActions.count(); i++) {
 			QAction *action = menuActions[i];
-			QVariant v = action->property("file_name");
+			QVariant v = action->property("fileName");
 
 			if (v.typeName() != nullptr) {
 				if (action->text() == qstrCollection) {


### PR DESCRIPTION
this typo "cause obs_frontend_set_current_scene_collection" function will never be successful, because the property typeName always null.