### PR TITLE
UI: Fix freeze when reordering filters

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -147,7 +147,7 @@ inline OBSSource OBSBasicFilters::GetFilter(int row, bool async)
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
 	if (view) {
-		view->deleteLater();
+		delete view;
 		view = nullptr;
 	}
 


### PR DESCRIPTION
This seems to fix the problem where the UI would freeze when reordering filters.