### PR TITLE
UI: Fix freeze when reordering filters

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -146,14 +146,24 @@ inline OBSSource OBSBasicFilters::GetFilter(int row, bool async)
 
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
-	if (view) {
+	OBSSource filter = GetFilter(row, async);
+
+	if (!filter && !view) {
+		return;
+	}
+	else if (!filter && view) {
+		view->hide();
 		view->deleteLater();
 		view = nullptr;
 	}
-
-	OBSSource filter = GetFilter(row, async);
-	if (!filter)
+	else if (!filter) {
 		return;
+	}
+	else if (view) {
+		view->hide();
+		view->deleteLater();
+		view = nullptr;
+	}
 
 	obs_data_t *settings = obs_source_get_settings(filter);
 


### PR DESCRIPTION
I opened a new PR because it said I couldn't reopen the old one because I forced pushed to the branch. After messing around with the code for a couple of hours, I figured out that you need to hide the widget before deleting it.