### PR TITLE
FFmpeg Default AAC Encoder Min Bitrate Change

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-aac.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-aac.c
@@ -259,7 +259,7 @@ static obs_properties_t *aac_properties(void *unused)
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_int(props, "bitrate",
-			obs_module_text("Bitrate"), 32, 320, 32);
+			obs_module_text("Bitrate"), 64, 320, 32);
 	return props;
 }
 


### PR DESCRIPTION
FFmpeg Default AAC Encoder Remove 32 Kbps.
New FFmpeg Default AAC Encoder Min Bitrate 64 Kbps.
FFmpeg Default AAC Encoder 32Kbps Sound is Very bad.
Users currently using FFmpeg Default AAC Encoder 32 Kbps will be changed to 64 Kbps.
If you want to use 32 Kbps, CoreAudio is ideal.

I want to prevent users who do not install iTunes from selecting FFmpeg Default AAC Encoder 32 kbps.
The user of the low bitrate streaming site lowers the audio bitrate and assigns it to the video.
People who do not have iTunes installed are puzzled by FFmpeg Default AAC Encoder 32Kbps sound quality.