### PR TITLE
UI: chages to Reset/Close buttons creation order

### DIFF
--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -639,11 +639,22 @@
     </layout>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Reset|QDialogButtonBox::Close</set>
-     </property>
-    </widget>
+    <layout class="QGridLayout" name="gridLayout1">
+     <item row="0" column="1">
+      <widget class="QDialogButtonBox" name="buttonBox1">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QDialogButtonBox" name="buttonBox0">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Reset</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -56,9 +56,9 @@ OBSBasicTransform::OBSBasicTransform(OBSBasic *parent)
 	HookWidget(ui->cropTop,      ISCROLL_CHANGED, SLOT(OnCropChanged()));
 	HookWidget(ui->cropBottom,   ISCROLL_CHANGED, SLOT(OnCropChanged()));
 
-	connect(ui->buttonBox->button(QDialogButtonBox::Reset),
+	connect(ui->buttonBox0->button(QDialogButtonBox::Reset),
 		SIGNAL(clicked()), this, SLOT(on_resetButton_clicked()));
-	connect(ui->buttonBox,
+	connect(ui->buttonBox1,
 		SIGNAL(rejected()), this, SLOT(close()));
 
 	installEventFilter(CreateShortcutFilter());


### PR DESCRIPTION
The "Transform" window UI change. Improves ease of use.
Now "Close" button always focused instead of "Reset" when Transform window updates. This allows to close the Transform window by pressing Enter button on numpad.

This commit doesn't change UI appearance.
_Edit:_ It's hardcoded "Reset" on the left half of the window and "Close" on the right half of the window.

Suggestion origin: https://obsproject.com/mantis/view.php?id=740