### PR TITLE
Add new obs_frontend_set_streaming_service() method to frontend API

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -219,6 +219,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		return main->outputHandler->StreamingActive();
 	}
 
+	void obs_frontend_set_streaming_service(obs_service_t *service) override
+	{
+		main->SetService(service);
+	}
+
 	void obs_frontend_recording_start(void) override
 	{
 		QMetaObject::invokeMethod(main, "StartRecording");

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -188,6 +188,12 @@ bool obs_frontend_streaming_active(void)
 		: false;
 }
 
+void obs_frontend_set_streaming_service(obs_service_t *service)
+{
+	if (callbacks_valid()) c->obs_frontend_set_streaming_service(service);
+}
+
+
 void obs_frontend_recording_start(void)
 {
 	if (callbacks_valid()) c->obs_frontend_recording_start();

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -65,6 +65,7 @@ EXPORT void obs_frontend_set_current_profile(const char *profile);
 EXPORT void obs_frontend_streaming_start(void);
 EXPORT void obs_frontend_streaming_stop(void);
 EXPORT bool obs_frontend_streaming_active(void);
+EXPORT void obs_frontend_set_streaming_service(obs_service_t *service);
 
 EXPORT void obs_frontend_recording_start(void);
 EXPORT void obs_frontend_recording_stop(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -34,6 +34,7 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_streaming_start(void)=0;
 	virtual void obs_frontend_streaming_stop(void)=0;
 	virtual bool obs_frontend_streaming_active(void)=0;
+	virtual void obs_frontend_set_streaming_service(obs_service_t *service)=0;
 
 	virtual void obs_frontend_recording_start(void)=0;
 	virtual void obs_frontend_recording_stop(void)=0;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1061,7 +1061,7 @@ void OBSBasic::ResetOutputs()
 			replayBufferButton = new QPushButton(
 					QTStr("Basic.Main.StartReplayBuffer"),
 					this);
-			connect(replayBufferButton,
+			connect(replayBufferButton.data(),
 					&QPushButton::clicked,
 					this,
 					&OBSBasic::ReplayBufferClicked);
@@ -4885,7 +4885,7 @@ void OBSBasic::SystemTrayInit()
 			this, SLOT(on_streamButton_clicked()));
 	connect(sysTrayRecord, SIGNAL(triggered()),
 			this, SLOT(on_recordButton_clicked()));
-	connect(sysTrayReplayBuffer, &QAction::triggered,
+	connect(sysTrayReplayBuffer.data(), &QAction::triggered,
 			this, &OBSBasic::ReplayBufferClicked);
 	connect(exit, SIGNAL(triggered()),
 			this, SLOT(close()));


### PR DESCRIPTION
Expose frontend SetService() via obs_frontend_set_streaming_service() so plugins can programmatically define and use a new streaming server/service without user interaction.