### PR TITLE
Fix hardcoded session id in UWP named kernel objects

### DIFF
--- a/plugins/win-capture/CMakeLists.txt
+++ b/plugins/win-capture/CMakeLists.txt
@@ -1,7 +1,9 @@
 project(win-capture)
 
 set(win-capture_HEADERS
+	nt-stuff.h
 	obfuscate.h
+	app-helpers.h
 	hook-helpers.h
 	inject-library.h
 	cursor-capture.h
@@ -12,6 +14,7 @@ set(win-capture_HEADERS
 set(win-capture_SOURCES
 	dc-capture.c
 	obfuscate.c
+	app-helpers.c
 	inject-library.c
 	cursor-capture.c
 	game-capture.c

--- a/plugins/win-capture/app-helpers.c
+++ b/plugins/win-capture/app-helpers.c
@@ -50,25 +50,28 @@ wchar_t *get_app_sid(HANDLE process)
 }
 
 static const wchar_t *path_format =
-	L"\\Sessions\\1\\AppContainerNamedObjects\\%s\\%s";
+	L"\\Sessions\\%d\\AppContainerNamedObjects\\%s\\%s";
 
 HANDLE open_app_mutex(const wchar_t *sid, const wchar_t *name)
 {
 	wchar_t path[MAX_PATH];
-	_snwprintf(path, MAX_PATH, path_format, sid, name);
+	DWORD session_id = WTSGetActiveConsoleSessionId();
+	_snwprintf(path, MAX_PATH, path_format, session_id, sid, name);
 	return nt_open_mutex(path);
 }
 
 HANDLE open_app_event(const wchar_t *sid, const wchar_t *name)
 {
 	wchar_t path[MAX_PATH];
-	_snwprintf(path, MAX_PATH, path_format, sid, name);
+	DWORD session_id = WTSGetActiveConsoleSessionId();
+	_snwprintf(path, MAX_PATH, path_format, session_id, sid, name);
 	return nt_open_event(path);
 }
 
 HANDLE open_app_map(const wchar_t *sid, const wchar_t *name)
 {
 	wchar_t path[MAX_PATH];
-	_snwprintf(path, MAX_PATH, path_format, sid, name);
+	DWORD session_id = WTSGetActiveConsoleSessionId();
+	_snwprintf(path, MAX_PATH, path_format, session_id, sid, name);
 	return nt_open_map(path);
 }

--- a/plugins/win-capture/app-helpers.c
+++ b/plugins/win-capture/app-helpers.c
@@ -1,0 +1,74 @@
+#include <windows.h>
+#include <stdio.h>
+#include "app-helpers.h"
+#include "nt-stuff.h"
+
+WINADVAPI WINAPI ConvertSidToStringSidW(PSID sid, LPWSTR *str);
+
+bool is_app(HANDLE process)
+{
+	DWORD size_ret;
+	DWORD ret = 0;
+	HANDLE token;
+
+	if (OpenProcessToken(process, TOKEN_QUERY, &token)) {
+		BOOL success = GetTokenInformation(token, TokenIsAppContainer,
+				&ret, sizeof(ret), &size_ret);
+		if (!success) {
+			DWORD error = GetLastError();
+			int test = 0;
+		}
+
+		CloseHandle(token);
+	}
+	return !!ret;
+}
+
+wchar_t *get_app_sid(HANDLE process)
+{
+	wchar_t *ret = NULL;
+	DWORD size_ret;
+	BOOL success;
+	HANDLE token;
+
+	if (OpenProcessToken(process, TOKEN_QUERY, &token)) {
+		DWORD info_len = GetSidLengthRequired(12) +
+			sizeof(TOKEN_APPCONTAINER_INFORMATION);
+
+		PTOKEN_APPCONTAINER_INFORMATION info = malloc(info_len);
+
+		success = GetTokenInformation(token, TokenAppContainerSid,
+				info, info_len, &size_ret);
+		if (success)
+			ConvertSidToStringSidW(info->TokenAppContainer, &ret);
+
+		free(info);
+		CloseHandle(token);
+	}
+
+	return ret;
+}
+
+static const wchar_t *path_format =
+	L"\\Sessions\\1\\AppContainerNamedObjects\\%s\\%s";
+
+HANDLE open_app_mutex(const wchar_t *sid, const wchar_t *name)
+{
+	wchar_t path[MAX_PATH];
+	_snwprintf(path, MAX_PATH, path_format, sid, name);
+	return nt_open_mutex(path);
+}
+
+HANDLE open_app_event(const wchar_t *sid, const wchar_t *name)
+{
+	wchar_t path[MAX_PATH];
+	_snwprintf(path, MAX_PATH, path_format, sid, name);
+	return nt_open_event(path);
+}
+
+HANDLE open_app_map(const wchar_t *sid, const wchar_t *name)
+{
+	wchar_t path[MAX_PATH];
+	_snwprintf(path, MAX_PATH, path_format, sid, name);
+	return nt_open_map(path);
+}

--- a/plugins/win-capture/app-helpers.h
+++ b/plugins/win-capture/app-helpers.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdbool.h>
+
+extern bool is_app(HANDLE process);
+extern wchar_t *get_app_sid(HANDLE process);
+extern HANDLE open_app_mutex(const wchar_t *sid, const wchar_t *name);
+extern HANDLE open_app_event(const wchar_t *sid, const wchar_t *name);
+extern HANDLE open_app_map(const wchar_t *sid, const wchar_t *name);

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1729,13 +1729,17 @@ static void game_capture_tick(void *data, float seconds)
 static inline void game_capture_render_cursor(struct game_capture *gc)
 {
 	POINT p = {0};
+	HWND window;
 
-	if (!gc->global_hook_info->window ||
-	    !gc->global_hook_info->base_cx ||
+	if (!gc->global_hook_info->base_cx ||
 	    !gc->global_hook_info->base_cy)
 		return;
 
-	ClientToScreen((HWND)(uintptr_t)gc->global_hook_info->window, &p);
+	window = !!gc->global_hook_info->window
+		? (HWND)(uintptr_t)gc->global_hook_info->window
+		: gc->window;
+
+	ClientToScreen(window, &p);
 
 	float x_scale = (float)gc->global_hook_info->cx /
 		(float)gc->global_hook_info->base_cx;

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -308,6 +308,9 @@ static void stop_capture(struct game_capture *gc)
 		gc->texture = NULL;
 	}
 
+	if (gc->active)
+		info("capture stopped");
+
 	gc->copy_texture = NULL;
 	gc->wait_for_target_startup = false;
 	gc->active = false;
@@ -1556,10 +1559,14 @@ static bool start_capture(struct game_capture *gc)
 		if (!init_shmem_capture(gc)) {
 			return false;
 		}
+
+		info("memory capture successful");
 	} else {
 		if (!init_shtex_capture(gc)) {
 			return false;
 		}
+
+		info("shared texture capture successful");
 	}
 
 	return true;

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1016,8 +1016,9 @@ static bool init_hook(struct game_capture *gc)
 					exe.array);
 		}
 	} else {
-		info("attempting to hook process: %s", gc->executable.array);
-		dstr_copy_dstr(&exe, &gc->executable);
+		if (get_window_exe(&exe, gc->next_window)) {
+			info("attempting to hook process: %s", exe.array);
+		}
 	}
 
 	blacklisted_process = is_blacklisted_exe(exe.array);

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -13,6 +13,7 @@
 #include "window-helpers.h"
 #include "cursor-capture.h"
 #include "app-helpers.h"
+#include "nt-stuff.h"
 
 #define do_log(level, format, ...) \
 	blog(level, "[game-capture: '%s'] " format, \
@@ -984,6 +985,11 @@ static bool is_blacklisted_exe(const char *exe)
 	return false;
 }
 
+static bool target_suspended(struct game_capture *gc)
+{
+	return thread_is_suspended(gc->process_id, gc->thread_id);
+}
+
 static bool init_events(struct game_capture *gc);
 
 static bool init_hook(struct game_capture *gc)
@@ -1007,6 +1013,9 @@ static bool init_hook(struct game_capture *gc)
 	dstr_free(&exe);
 
 	if (blacklisted_process) {
+		return false;
+	}
+	if (target_suspended(gc)) {
 		return false;
 	}
 	if (!open_target_process(gc)) {

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1582,6 +1582,8 @@ static inline bool init_shtex_capture(struct game_capture *gc)
 
 static bool start_capture(struct game_capture *gc)
 {
+	debug("Starting capture");
+
 	if (gc->global_hook_info->type == CAPTURE_TYPE_MEMORY) {
 		if (!init_shmem_capture(gc)) {
 			return false;
@@ -1647,6 +1649,7 @@ static void game_capture_tick(void *data, float seconds)
 	}
 
 	if (gc->hook_stop && object_signalled(gc->hook_stop)) {
+		debug("hook stop signal received");
 		stop_capture(gc);
 	}
 	if (gc->active && deactivate) {
@@ -1674,10 +1677,13 @@ static void game_capture_tick(void *data, float seconds)
 	}
 
 	if (gc->hook_ready && object_signalled(gc->hook_ready)) {
+		debug("capture initializing!");
 		enum capture_result result = init_capture_data(gc);
 
 		if (result == CAPTURE_SUCCESS)
 			gc->capturing = start_capture(gc);
+		else
+			debug("init_capture_data failed");
 
 		if (result != CAPTURE_RETRY && !gc->capturing) {
 			gc->retry_interval = ERROR_RETRY_INTERVAL;

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -976,6 +976,7 @@ static const char *blacklisted_exes[] = {
 	"devenv",
 	"taskmgr",
 	"systemsettings",
+	"applicationframehost",
 	"cmd",
 	NULL
 };

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1186,7 +1186,9 @@ static void try_hook(struct game_capture *gc)
 		if (gc->process_id == GetCurrentProcessId())
 			return;
 
-		if (!gc->thread_id || !gc->process_id) {
+		if (!gc->thread_id && gc->process_id)
+			return;
+		if (!gc->process_id) {
 			warn("error acquiring, failed to get window "
 					"thread/process ids: %lu",
 					GetLastError());

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -135,6 +135,7 @@ struct game_capture {
 	struct hook_info              *global_hook_info;
 	HANDLE                        keepalive_thread;
 	DWORD                         keepalive_thread_id;
+	HANDLE                        hook_init;
 	HANDLE                        hook_restart;
 	HANDLE                        hook_stop;
 	HANDLE                        hook_ready;
@@ -230,6 +231,7 @@ static void stop_capture(struct game_capture *gc)
 	close_handle(&gc->hook_stop);
 	close_handle(&gc->hook_ready);
 	close_handle(&gc->hook_exit);
+	close_handle(&gc->hook_init);
 	close_handle(&gc->hook_data_map);
 	close_handle(&gc->global_hook_info_map);
 	close_handle(&gc->target_process);
@@ -648,13 +650,13 @@ static inline bool init_keepalive(struct game_capture *gc)
 
 static inline bool init_texture_mutexes(struct game_capture *gc)
 {
-	gc->texture_mutexes[0] = get_mutex_plus_id(MUTEX_TEXTURE1,
+	gc->texture_mutexes[0] = open_mutex_plus_id(MUTEX_TEXTURE1,
 			gc->process_id);
-	gc->texture_mutexes[1] = get_mutex_plus_id(MUTEX_TEXTURE2,
+	gc->texture_mutexes[1] = open_mutex_plus_id(MUTEX_TEXTURE2,
 			gc->process_id);
 
 	if (!gc->texture_mutexes[0] || !gc->texture_mutexes[1]) {
-		warn("failed to create texture mutexes: %lu", GetLastError());
+		warn("failed to open texture mutexes: %lu", GetLastError());
 		return false;
 	}
 
@@ -696,7 +698,7 @@ static inline void reset_frame_interval(struct game_capture *gc)
 
 static inline bool init_hook_info(struct game_capture *gc)
 {
-	gc->global_hook_info_map = get_hook_info(gc->process_id);
+	gc->global_hook_info_map = open_hook_info(gc->process_id);
 	if (!gc->global_hook_info_map) {
 		warn("init_hook_info: get_hook_info failed: %lu",
 				GetLastError());
@@ -921,6 +923,8 @@ static bool is_blacklisted_exe(const char *exe)
 	return false;
 }
 
+static bool init_events(struct game_capture *gc);
+
 static bool init_hook(struct game_capture *gc)
 {
 	struct dstr exe = {0};
@@ -950,12 +954,6 @@ static bool init_hook(struct game_capture *gc)
 	if (!init_keepalive(gc)) {
 		return false;
 	}
-	if (!init_texture_mutexes(gc)) {
-		return false;
-	}
-	if (!init_hook_info(gc)) {
-		return false;
-	}
 	if (!init_pipe(gc)) {
 		return false;
 	}
@@ -964,6 +962,17 @@ static bool init_hook(struct game_capture *gc)
 			return false;
 		}
 	}
+	if (!init_texture_mutexes(gc)) {
+		return false;
+	}
+	if (!init_hook_info(gc)) {
+		return false;
+	}
+	if (!init_events(gc)) {
+		return false;
+	}
+
+	SetEvent(gc->hook_init);
 
 	gc->window = gc->next_window;
 	gc->next_window = NULL;
@@ -1099,7 +1108,7 @@ static void try_hook(struct game_capture *gc)
 static inline bool init_events(struct game_capture *gc)
 {
 	if (!gc->hook_restart) {
-		gc->hook_restart = get_event_plus_id(EVENT_CAPTURE_RESTART,
+		gc->hook_restart = open_event_plus_id(EVENT_CAPTURE_RESTART,
 				gc->process_id);
 		if (!gc->hook_restart) {
 			warn("init_events: failed to get hook_restart "
@@ -1109,7 +1118,7 @@ static inline bool init_events(struct game_capture *gc)
 	}
 
 	if (!gc->hook_stop) {
-		gc->hook_stop = get_event_plus_id(EVENT_CAPTURE_STOP,
+		gc->hook_stop = open_event_plus_id(EVENT_CAPTURE_STOP,
 				gc->process_id);
 		if (!gc->hook_stop) {
 			warn("init_events: failed to get hook_stop event: %lu",
@@ -1118,8 +1127,18 @@ static inline bool init_events(struct game_capture *gc)
 		}
 	}
 
+	if (!gc->hook_init) {
+		gc->hook_init = open_event_plus_id(EVENT_HOOK_INIT,
+				gc->process_id);
+		if (!gc->hook_init) {
+			warn("init_events: failed to get hook_init event: %lu",
+					GetLastError());
+			return false;
+		}
+	}
+
 	if (!gc->hook_ready) {
-		gc->hook_ready = get_event_plus_id(EVENT_HOOK_READY,
+		gc->hook_ready = open_event_plus_id(EVENT_HOOK_READY,
 				gc->process_id);
 		if (!gc->hook_ready) {
 			warn("init_events: failed to get hook_ready event: %lu",
@@ -1129,7 +1148,7 @@ static inline bool init_events(struct game_capture *gc)
 	}
 
 	if (!gc->hook_exit) {
-		gc->hook_exit = get_event_plus_id(EVENT_HOOK_EXIT,
+		gc->hook_exit = open_event_plus_id(EVENT_HOOK_EXIT,
 				gc->process_id);
 		if (!gc->hook_exit) {
 			warn("init_events: failed to get hook_exit event: %lu",
@@ -1471,9 +1490,6 @@ static inline bool init_shtex_capture(struct game_capture *gc)
 
 static bool start_capture(struct game_capture *gc)
 {
-	if (!init_events(gc)) {
-		return false;
-	}
 	if (gc->global_hook_info->type == CAPTURE_TYPE_MEMORY) {
 		if (!init_shmem_capture(gc)) {
 			return false;
@@ -1539,7 +1555,7 @@ static void game_capture_tick(void *data, float seconds)
 	}
 
 	if (gc->active && !gc->hook_ready && gc->process_id) {
-		gc->hook_ready = get_event_plus_id(EVENT_HOOK_READY,
+		gc->hook_ready = open_event_plus_id(EVENT_HOOK_READY,
 				gc->process_id);
 	}
 

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1616,6 +1616,9 @@ static void game_capture_tick(void *data, float seconds)
 	if (activate_now) {
 		HWND hwnd = (HWND)os_atomic_load_long(&gc->hotkey_window);
 
+		if (is_uwp_window(hwnd))
+			hwnd = get_uwp_actual_window(hwnd);
+
 		if (get_window_exe(&gc->executable, hwnd)) {
 			get_window_title(&gc->title, hwnd);
 			get_window_class(&gc->class, hwnd);

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -12,6 +12,7 @@
 #include "graphics-hook-info.h"
 #include "window-helpers.h"
 #include "cursor-capture.h"
+#include "app-helpers.h"
 
 #define do_log(level, format, ...) \
 	blog(level, "[game-capture: '%s'] " format, \
@@ -127,6 +128,7 @@ struct game_capture {
 	bool                          dwm_capture : 1;
 	bool                          initial_config : 1;
 	bool                          convert_16bit : 1;
+	bool                          is_app : 1;
 
 	struct game_capture_config    config;
 
@@ -144,6 +146,7 @@ struct game_capture {
 	HANDLE                        global_hook_info_map;
 	HANDLE                        target_process;
 	HANDLE                        texture_mutexes[2];
+	wchar_t                       *app_sid;
 
 	union {
 		struct {
@@ -160,6 +163,61 @@ struct game_capture {
 
 struct graphics_offsets offsets32 = {0};
 struct graphics_offsets offsets64 = {0};
+
+static inline bool use_anticheat(struct game_capture *gc)
+{
+	return gc->config.anticheat_hook && !gc->is_app;
+}
+
+static inline HANDLE open_mutex_plus_id(struct game_capture *gc,
+		const wchar_t *name, DWORD id)
+{
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
+	return gc->is_app
+		? open_app_mutex(gc->app_sid, new_name)
+		: open_mutex(new_name);
+}
+
+static inline HANDLE open_mutex_gc(struct game_capture *gc,
+		const wchar_t *name)
+{
+	return open_mutex_plus_id(gc, name, gc->process_id);
+}
+
+static inline HANDLE open_event_plus_id(struct game_capture *gc,
+		const wchar_t *name, DWORD id)
+{
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
+	return gc->is_app
+		? open_app_event(gc->app_sid, new_name)
+		: open_event(new_name);
+}
+
+static inline HANDLE open_event_gc(struct game_capture *gc,
+		const wchar_t *name)
+{
+	return open_event_plus_id(gc, name, gc->process_id);
+}
+
+static inline HANDLE open_map_plus_id(struct game_capture *gc,
+		const wchar_t *name, DWORD id)
+{
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
+
+	debug("map id: %S", new_name);
+
+	return gc->is_app
+		? open_app_map(gc->app_sid, new_name)
+		: OpenFileMappingW(GC_MAPPING_FLAGS, false, new_name);
+}
+
+static inline HANDLE open_hook_info(struct game_capture *gc)
+{
+	return open_map_plus_id(gc, SHMEM_HOOK_INFO, gc->process_id);
+}
 
 static inline enum gs_color_format convert_format(uint32_t format)
 {
@@ -225,6 +283,11 @@ static void stop_capture(struct game_capture *gc)
 		PostThreadMessage(gc->keepalive_thread_id, WM_QUIT, 0, 0);
 		WaitForSingleObject(gc->keepalive_thread, 300);
 		close_handle(&gc->keepalive_thread);
+	}
+
+	if (gc->app_sid) {
+		LocalFree(gc->app_sid);
+		gc->app_sid = NULL;
 	}
 
 	close_handle(&gc->hook_restart);
@@ -563,6 +626,10 @@ static inline bool open_target_process(struct game_capture *gc)
 	}
 
 	gc->process_is_64bit = is_64bit_process(gc->target_process);
+	gc->is_app = is_app(gc->target_process);
+	if (gc->is_app) {
+		gc->app_sid = get_app_sid(gc->target_process);
+	}
 	return true;
 }
 
@@ -643,10 +710,8 @@ static inline bool init_keepalive(struct game_capture *gc)
 
 static inline bool init_texture_mutexes(struct game_capture *gc)
 {
-	gc->texture_mutexes[0] = open_mutex_plus_id(MUTEX_TEXTURE1,
-			gc->process_id);
-	gc->texture_mutexes[1] = open_mutex_plus_id(MUTEX_TEXTURE2,
-			gc->process_id);
+	gc->texture_mutexes[0] = open_mutex_gc(gc, MUTEX_TEXTURE1);
+	gc->texture_mutexes[1] = open_mutex_gc(gc, MUTEX_TEXTURE2);
 
 	if (!gc->texture_mutexes[0] || !gc->texture_mutexes[1]) {
 		warn("failed to open texture mutexes: %lu", GetLastError());
@@ -659,8 +724,7 @@ static inline bool init_texture_mutexes(struct game_capture *gc)
 /* if there's already a hook in the process, then signal and start */
 static inline bool attempt_existing_hook(struct game_capture *gc)
 {
-	gc->hook_restart = open_event_plus_id(EVENT_CAPTURE_RESTART,
-			gc->process_id);
+	gc->hook_restart = open_event_gc(gc, EVENT_CAPTURE_RESTART);
 	if (gc->hook_restart) {
 		debug("existing hook found, signaling process: %s",
 				gc->config.executable);
@@ -692,7 +756,7 @@ static inline void reset_frame_interval(struct game_capture *gc)
 
 static inline bool init_hook_info(struct game_capture *gc)
 {
-	gc->global_hook_info_map = open_hook_info(gc->process_id);
+	gc->global_hook_info_map = open_hook_info(gc);
 	if (!gc->global_hook_info_map) {
 		warn("init_hook_info: get_hook_info failed: %lu",
 				GetLastError());
@@ -807,7 +871,7 @@ static inline bool create_inject_process(struct game_capture *gc,
 	wchar_t *command_line_w = malloc(4096 * sizeof(wchar_t));
 	wchar_t *inject_path_w;
 	wchar_t *hook_dll_w;
-	bool anti_cheat = gc->config.anticheat_hook;
+	bool anti_cheat = use_anticheat(gc);
 	PROCESS_INFORMATION pi = {0};
 	STARTUPINFO si = {0};
 	bool success = false;
@@ -869,11 +933,11 @@ static inline bool inject_hook(struct game_capture *gc)
 	matching_architecture = !gc->process_is_64bit;
 #endif
 
-	if (matching_architecture && !gc->config.anticheat_hook) {
+	if (matching_architecture && !use_anticheat(gc)) {
 		info("using direct hook");
 		success = hook_direct(gc, hook_path);
 	} else {
-		info("using helper (%s hook)", gc->config.anticheat_hook ?
+		info("using helper (%s hook)", use_anticheat(gc) ?
 				"compatibility" : "direct");
 		success = create_inject_process(gc, inject_path, hook_dll);
 	}
@@ -976,13 +1040,24 @@ static bool init_hook(struct game_capture *gc)
 
 static void setup_window(struct game_capture *gc, HWND window)
 {
-	DWORD process_id = 0;
 	HANDLE hook_restart;
+	HANDLE process;
 
-	GetWindowThreadProcessId(window, &process_id);
+	GetWindowThreadProcessId(window, &gc->process_id);
+	if (gc->process_id) {
+		process = open_process(PROCESS_QUERY_INFORMATION,
+			false, gc->process_id);
+		if (process) {
+			gc->is_app = is_app(process);
+			if (gc->is_app) {
+				gc->app_sid = get_app_sid(process);
+			}
+			CloseHandle(process);
+		}
+	}
 
 	/* do not wait if we're re-hooking a process */
-	hook_restart = open_event_plus_id(EVENT_CAPTURE_RESTART, process_id);
+	hook_restart = open_event_gc(gc, EVENT_CAPTURE_RESTART);
 	if (hook_restart) {
 		gc->wait_for_target_startup = false;
 		CloseHandle(hook_restart);
@@ -1102,8 +1177,7 @@ static void try_hook(struct game_capture *gc)
 static inline bool init_events(struct game_capture *gc)
 {
 	if (!gc->hook_restart) {
-		gc->hook_restart = open_event_plus_id(EVENT_CAPTURE_RESTART,
-				gc->process_id);
+		gc->hook_restart = open_event_gc(gc, EVENT_CAPTURE_RESTART);
 		if (!gc->hook_restart) {
 			warn("init_events: failed to get hook_restart "
 			     "event: %lu", GetLastError());
@@ -1112,8 +1186,7 @@ static inline bool init_events(struct game_capture *gc)
 	}
 
 	if (!gc->hook_stop) {
-		gc->hook_stop = open_event_plus_id(EVENT_CAPTURE_STOP,
-				gc->process_id);
+		gc->hook_stop = open_event_gc(gc, EVENT_CAPTURE_STOP);
 		if (!gc->hook_stop) {
 			warn("init_events: failed to get hook_stop event: %lu",
 					GetLastError());
@@ -1122,8 +1195,7 @@ static inline bool init_events(struct game_capture *gc)
 	}
 
 	if (!gc->hook_init) {
-		gc->hook_init = open_event_plus_id(EVENT_HOOK_INIT,
-				gc->process_id);
+		gc->hook_init = open_event_gc(gc, EVENT_HOOK_INIT);
 		if (!gc->hook_init) {
 			warn("init_events: failed to get hook_init event: %lu",
 					GetLastError());
@@ -1132,8 +1204,7 @@ static inline bool init_events(struct game_capture *gc)
 	}
 
 	if (!gc->hook_ready) {
-		gc->hook_ready = open_event_plus_id(EVENT_HOOK_READY,
-				gc->process_id);
+		gc->hook_ready = open_event_gc(gc, EVENT_HOOK_READY);
 		if (!gc->hook_ready) {
 			warn("init_events: failed to get hook_ready event: %lu",
 					GetLastError());
@@ -1142,8 +1213,7 @@ static inline bool init_events(struct game_capture *gc)
 	}
 
 	if (!gc->hook_exit) {
-		gc->hook_exit = open_event_plus_id(EVENT_HOOK_EXIT,
-				gc->process_id);
+		gc->hook_exit = open_event_gc(gc, EVENT_HOOK_EXIT);
 		if (!gc->hook_exit) {
 			warn("init_events: failed to get hook_exit event: %lu",
 					GetLastError());
@@ -1162,9 +1232,6 @@ enum capture_result {
 
 static inline enum capture_result init_capture_data(struct game_capture *gc)
 {
-	char name[64];
-	sprintf(name, "%s%u", SHMEM_TEXTURE, gc->global_hook_info->map_id);
-
 	gc->cx = gc->global_hook_info->cx;
 	gc->cy = gc->global_hook_info->cy;
 	gc->pitch = gc->global_hook_info->pitch;
@@ -1176,7 +1243,8 @@ static inline enum capture_result init_capture_data(struct game_capture *gc)
 
 	CloseHandle(gc->hook_data_map);
 
-	gc->hook_data_map = OpenFileMappingA(FILE_MAP_ALL_ACCESS, false, name);
+	gc->hook_data_map = open_map_plus_id(gc, SHMEM_TEXTURE,
+			gc->global_hook_info->map_id);
 	if (!gc->hook_data_map) {
 		DWORD error = GetLastError();
 		if (error == 2) {
@@ -1549,8 +1617,7 @@ static void game_capture_tick(void *data, float seconds)
 	}
 
 	if (gc->active && !gc->hook_ready && gc->process_id) {
-		gc->hook_ready = open_event_plus_id(EVENT_HOOK_READY,
-				gc->process_id);
+		gc->hook_ready = open_event_gc(gc, EVENT_HOOK_READY);
 	}
 
 	if (gc->injector_process && object_signalled(gc->injector_process)) {

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -13,6 +13,8 @@
 #define EVENT_HOOK_READY      "CaptureHook_HookReady"
 #define EVENT_HOOK_EXIT       "CaptureHook_Exit"
 
+#define EVENT_HOOK_INIT       "CaptureHook_Initialize"
+
 #define WINDOW_HOOK_KEEPALIVE L"CaptureHook_KeepAlive"
 
 #define MUTEX_TEXTURE1        "CaptureHook_TextureMutex1"
@@ -103,19 +105,19 @@ struct hook_info {
 
 #define GC_MAPPING_FLAGS (FILE_MAP_READ | FILE_MAP_WRITE)
 
-static inline HANDLE get_hook_info(DWORD id)
+static inline HANDLE create_hook_info(DWORD id)
 {
-	HANDLE handle;
 	char new_name[64];
 	sprintf(new_name, "%s%lu", SHMEM_HOOK_INFO, id);
 
-	handle = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL,
-			PAGE_READWRITE, 0, sizeof(struct hook_info), new_name);
+	return CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
+			0, sizeof(struct hook_info), new_name);
+}
 
-	if (!handle && GetLastError() == ERROR_ALREADY_EXISTS) {
-		handle = OpenFileMappingA(GC_MAPPING_FLAGS, false,
-				new_name);
-	}
+static inline HANDLE open_hook_info(DWORD id)
+{
+	char new_name[64];
+	sprintf(new_name, "%s%lu", SHMEM_HOOK_INFO, id);
 
-	return handle;
+	return OpenFileMappingA(GC_MAPPING_FLAGS, false, new_name);
 }

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -20,8 +20,8 @@
 #define MUTEX_TEXTURE1        "CaptureHook_TextureMutex1"
 #define MUTEX_TEXTURE2        "CaptureHook_TextureMutex2"
 
-#define SHMEM_HOOK_INFO       "Local\\CaptureHook_HookInfo"
-#define SHMEM_TEXTURE         "Local\\CaptureHook_Texture"
+#define SHMEM_HOOK_INFO       "CaptureHook_HookInfo"
+#define SHMEM_TEXTURE         "CaptureHook_Texture"
 
 #define PIPE_NAME             "CaptureHook_Pipe"
 

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -113,11 +113,3 @@ static inline HANDLE create_hook_info(DWORD id)
 	return CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
 			0, sizeof(struct hook_info), new_name);
 }
-
-static inline HANDLE open_hook_info(DWORD id)
-{
-	wchar_t new_name[64];
-	_snwprintf(new_name, 64, L"%s%lu", SHMEM_HOOK_INFO, id);
-
-	return OpenFileMappingW(GC_MAPPING_FLAGS, false, new_name);
-}

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -7,21 +7,21 @@
 
 #include "hook-helpers.h"
 
-#define EVENT_CAPTURE_RESTART "CaptureHook_Restart"
-#define EVENT_CAPTURE_STOP    "CaptureHook_Stop"
+#define EVENT_CAPTURE_RESTART L"CaptureHook_Restart"
+#define EVENT_CAPTURE_STOP    L"CaptureHook_Stop"
 
-#define EVENT_HOOK_READY      "CaptureHook_HookReady"
-#define EVENT_HOOK_EXIT       "CaptureHook_Exit"
+#define EVENT_HOOK_READY      L"CaptureHook_HookReady"
+#define EVENT_HOOK_EXIT       L"CaptureHook_Exit"
 
-#define EVENT_HOOK_INIT       "CaptureHook_Initialize"
+#define EVENT_HOOK_INIT       L"CaptureHook_Initialize"
 
 #define WINDOW_HOOK_KEEPALIVE L"CaptureHook_KeepAlive"
 
-#define MUTEX_TEXTURE1        "CaptureHook_TextureMutex1"
-#define MUTEX_TEXTURE2        "CaptureHook_TextureMutex2"
+#define MUTEX_TEXTURE1        L"CaptureHook_TextureMutex1"
+#define MUTEX_TEXTURE2        L"CaptureHook_TextureMutex2"
 
-#define SHMEM_HOOK_INFO       "CaptureHook_HookInfo"
-#define SHMEM_TEXTURE         "CaptureHook_Texture"
+#define SHMEM_HOOK_INFO       L"CaptureHook_HookInfo"
+#define SHMEM_TEXTURE         L"CaptureHook_Texture"
 
 #define PIPE_NAME             "CaptureHook_Pipe"
 
@@ -107,17 +107,17 @@ struct hook_info {
 
 static inline HANDLE create_hook_info(DWORD id)
 {
-	char new_name[64];
-	sprintf(new_name, "%s%lu", SHMEM_HOOK_INFO, id);
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", SHMEM_HOOK_INFO, id);
 
-	return CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
+	return CreateFileMappingW(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE,
 			0, sizeof(struct hook_info), new_name);
 }
 
 static inline HANDLE open_hook_info(DWORD id)
 {
-	char new_name[64];
-	sprintf(new_name, "%s%lu", SHMEM_HOOK_INFO, id);
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", SHMEM_HOOK_INFO, id);
 
-	return OpenFileMappingA(GC_MAPPING_FLAGS, false, new_name);
+	return OpenFileMappingW(GC_MAPPING_FLAGS, false, new_name);
 }

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -13,7 +13,7 @@
 #define EVENT_HOOK_READY      "CaptureHook_HookReady"
 #define EVENT_HOOK_EXIT       "CaptureHook_Exit"
 
-#define EVENT_HOOK_KEEPALIVE  "CaptureHook_KeepAlive"
+#define WINDOW_HOOK_KEEPALIVE L"CaptureHook_KeepAlive"
 
 #define MUTEX_TEXTURE1        "CaptureHook_TextureMutex1"
 #define MUTEX_TEXTURE2        "CaptureHook_TextureMutex2"

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -39,7 +39,7 @@ static volatile bool           stop_loop                       = false;
 static HANDLE                  capture_thread                  = NULL;
 char                           system_path[MAX_PATH]           = {0};
 char                           process_name[MAX_PATH]          = {0};
-char                           keepalive_name[64]              = {0};
+wchar_t                        keepalive_name[64]              = {0};
 HWND                           dummy_window                    = NULL;
 
 static unsigned int            shmem_id_counter                = 0;
@@ -234,8 +234,8 @@ static inline bool init_hook(HANDLE thread_handle)
 {
 	wait_for_dll_main_finish(thread_handle);
 
-	sprintf(keepalive_name, "%s%lu", EVENT_HOOK_KEEPALIVE,
-			GetCurrentProcessId());
+	_snwprintf(keepalive_name, sizeof(keepalive_name), L"%s%lu",
+			WINDOW_HOOK_KEEPALIVE, GetCurrentProcessId());
 
 	init_pipe();
 	if (!init_signals()) {

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -74,7 +74,7 @@ bool init_pipe(void)
 	return true;
 }
 
-static HANDLE init_event(const char *name, DWORD pid)
+static HANDLE init_event(const wchar_t *name, DWORD pid)
 {
 	HANDLE handle = create_event_plus_id(name, pid);
 	if (!handle)
@@ -82,7 +82,7 @@ static HANDLE init_event(const char *name, DWORD pid)
 	return handle;
 }
 
-static HANDLE init_mutex(const char *name, DWORD pid)
+static HANDLE init_mutex(const wchar_t *name, DWORD pid)
 {
 	HANDLE handle = create_mutex_plus_id(name, pid);
 	if (!handle)
@@ -484,10 +484,10 @@ static inline void unlock_shmem_tex(int id)
 
 static inline bool init_shared_info(size_t size)
 {
-	char name[64];
-	sprintf_s(name, 64, "%s%u", SHMEM_TEXTURE, ++shmem_id_counter);
+	wchar_t name[64];
+	_snwprintf(name, 64, L"%s%ld", SHMEM_TEXTURE, ++shmem_id_counter);
 
-	shmem_file_handle = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL,
+	shmem_file_handle = CreateFileMappingW(INVALID_HANDLE_VALUE, NULL,
 			PAGE_READWRITE, 0, (DWORD)size, name);
 	if (!shmem_file_handle) {
 		hlog("init_shared_info: Failed to create shared memory: %d",

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -315,6 +315,7 @@ static inline bool attempt_hook(void)
 
 	if (!d3d9_hooked) {
 		if (!d3d9_hookable()) {
+			DbgOut("no D3D9 hook address found!\n");
 			d3d9_hooked = true;
 		} else {
 			d3d9_hooked = hook_d3d9();
@@ -326,6 +327,7 @@ static inline bool attempt_hook(void)
 
 	if (!dxgi_hooked) {
 		if (!dxgi_hookable()) {
+			DbgOut("no DXGI hook address found!\n");
 			dxgi_hooked = true;
 		} else {
 			dxgi_hooked = hook_dxgi();

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -98,7 +98,7 @@ extern HANDLE signal_exit;
 extern HANDLE tex_mutexes[2];
 extern char system_path[MAX_PATH];
 extern char process_name[MAX_PATH];
-extern char keepalive_name[64];
+extern wchar_t keepalive_name[64];
 extern HWND dummy_window;
 extern volatile bool active;
 
@@ -143,13 +143,7 @@ static inline HMODULE load_system_library(const char *name)
 
 static inline bool capture_alive(void)
 {
-	HANDLE event = OpenEventA(GC_EVENT_FLAGS, false, keepalive_name);
-	if (event) {
-		CloseHandle(event);
-		return true;
-	}
-
-	return false;
+	return !!FindWindowW(keepalive_name, NULL);
 }
 
 static inline bool capture_active(void)
@@ -198,8 +192,18 @@ static inline bool capture_should_stop(void)
 {
 	bool stop_requested = false;
 
-	if (capture_active())
-		stop_requested = capture_stopped() || !capture_alive();
+	if (capture_active()) {
+		static uint64_t last_keepalive_check = 0;
+		uint64_t cur_time = os_gettime_ns();
+		bool alive = true;
+
+		if (cur_time - last_keepalive_check > 5000000000) {
+			alive = capture_alive();
+			last_keepalive_check = cur_time;
+		}
+
+		stop_requested = capture_stopped() || !alive;
+	}
 
 	return stop_requested;
 }

--- a/plugins/win-capture/hook-helpers.h
+++ b/plugins/win-capture/hook-helpers.h
@@ -7,36 +7,52 @@
 #define GC_EVENT_FLAGS (EVENT_MODIFY_STATE | SYNCHRONIZE)
 #define GC_MUTEX_FLAGS (SYNCHRONIZE)
 
-static inline HANDLE get_event(const char *name)
+static inline HANDLE create_event(const char *name)
 {
-	HANDLE event = CreateEventA(NULL, false, false, name);
-	if (!event)
-		event = OpenEventA(GC_EVENT_FLAGS, false, name);
-
-	return event;
+	return CreateEventA(NULL, false, false, name);
 }
 
-static inline HANDLE get_mutex(const char *name)
+static inline HANDLE open_event(const char *name)
 {
-	HANDLE event = CreateMutexA(NULL, false, name);
-	if (!event)
-		event = OpenMutexA(GC_MUTEX_FLAGS, false, name);
-
-	return event;
+	return OpenEventA(GC_EVENT_FLAGS, false, name);
 }
 
-static inline HANDLE get_event_plus_id(const char *name, DWORD id)
+static inline HANDLE create_mutex(const char *name)
+{
+	return CreateMutexA(NULL, false, name);
+}
+
+static inline HANDLE open_mutex(const char *name)
+{
+	return OpenMutexA(GC_MUTEX_FLAGS, false, name);
+}
+
+static inline HANDLE create_event_plus_id(const char *name, DWORD id)
 {
 	char new_name[64];
 	sprintf(new_name, "%s%lu", name, id);
-	return get_event(new_name);
+	return create_event(new_name);
 }
 
-static inline HANDLE get_mutex_plus_id(const char *name, DWORD id)
+static inline HANDLE open_event_plus_id(const char *name, DWORD id)
 {
 	char new_name[64];
 	sprintf(new_name, "%s%lu", name, id);
-	return get_mutex(new_name);
+	return open_event(new_name);
+}
+
+static inline HANDLE create_mutex_plus_id(const char *name, DWORD id)
+{
+	char new_name[64];
+	sprintf(new_name, "%s%lu", name, id);
+	return create_mutex(new_name);
+}
+
+static inline HANDLE open_mutex_plus_id(const char *name, DWORD id)
+{
+	char new_name[64];
+	sprintf(new_name, "%s%lu", name, id);
+	return open_mutex(new_name);
 }
 
 static inline bool object_signalled(HANDLE event)

--- a/plugins/win-capture/hook-helpers.h
+++ b/plugins/win-capture/hook-helpers.h
@@ -34,25 +34,11 @@ static inline HANDLE create_event_plus_id(const wchar_t *name, DWORD id)
 	return create_event(new_name);
 }
 
-static inline HANDLE open_event_plus_id(const wchar_t *name, DWORD id)
-{
-	wchar_t new_name[64];
-	_snwprintf(new_name, 64, L"%s%lu", name, id);
-	return open_event(new_name);
-}
-
 static inline HANDLE create_mutex_plus_id(const wchar_t *name, DWORD id)
 {
 	wchar_t new_name[64];
 	_snwprintf(new_name, 64, L"%s%lu", name, id);
 	return create_mutex(new_name);
-}
-
-static inline HANDLE open_mutex_plus_id(const wchar_t *name, DWORD id)
-{
-	wchar_t new_name[64];
-	_snwprintf(new_name, 64, L"%s%lu", name, id);
-	return open_mutex(new_name);
 }
 
 static inline bool object_signalled(HANDLE event)

--- a/plugins/win-capture/hook-helpers.h
+++ b/plugins/win-capture/hook-helpers.h
@@ -7,51 +7,51 @@
 #define GC_EVENT_FLAGS (EVENT_MODIFY_STATE | SYNCHRONIZE)
 #define GC_MUTEX_FLAGS (SYNCHRONIZE)
 
-static inline HANDLE create_event(const char *name)
+static inline HANDLE create_event(const wchar_t *name)
 {
-	return CreateEventA(NULL, false, false, name);
+	return CreateEventW(NULL, false, false, name);
 }
 
-static inline HANDLE open_event(const char *name)
+static inline HANDLE open_event(const wchar_t *name)
 {
-	return OpenEventA(GC_EVENT_FLAGS, false, name);
+	return OpenEventW(GC_EVENT_FLAGS, false, name);
 }
 
-static inline HANDLE create_mutex(const char *name)
+static inline HANDLE create_mutex(const wchar_t *name)
 {
-	return CreateMutexA(NULL, false, name);
+	return CreateMutexW(NULL, false, name);
 }
 
-static inline HANDLE open_mutex(const char *name)
+static inline HANDLE open_mutex(const wchar_t *name)
 {
-	return OpenMutexA(GC_MUTEX_FLAGS, false, name);
+	return OpenMutexW(GC_MUTEX_FLAGS, false, name);
 }
 
-static inline HANDLE create_event_plus_id(const char *name, DWORD id)
+static inline HANDLE create_event_plus_id(const wchar_t *name, DWORD id)
 {
-	char new_name[64];
-	sprintf(new_name, "%s%lu", name, id);
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
 	return create_event(new_name);
 }
 
-static inline HANDLE open_event_plus_id(const char *name, DWORD id)
+static inline HANDLE open_event_plus_id(const wchar_t *name, DWORD id)
 {
-	char new_name[64];
-	sprintf(new_name, "%s%lu", name, id);
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
 	return open_event(new_name);
 }
 
-static inline HANDLE create_mutex_plus_id(const char *name, DWORD id)
+static inline HANDLE create_mutex_plus_id(const wchar_t *name, DWORD id)
 {
-	char new_name[64];
-	sprintf(new_name, "%s%lu", name, id);
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
 	return create_mutex(new_name);
 }
 
-static inline HANDLE open_mutex_plus_id(const char *name, DWORD id)
+static inline HANDLE open_mutex_plus_id(const wchar_t *name, DWORD id)
 {
-	char new_name[64];
-	sprintf(new_name, "%s%lu", name, id);
+	wchar_t new_name[64];
+	_snwprintf(new_name, 64, L"%s%lu", name, id);
 	return open_mutex(new_name);
 }
 

--- a/plugins/win-capture/nt-stuff.h
+++ b/plugins/win-capture/nt-stuff.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <winternl.h>
+
+#ifndef NT_SUCCESS
+#define NT_SUCCESS(status) ((NTSTATUS)(status) >= 0)
+#endif
+
+#define init_named_attribs(o, name) \
+	do { \
+		(o)->Length = sizeof(*(o)); \
+		(o)->ObjectName = name; \
+		(o)->RootDirectory = NULL; \
+		(o)->Attributes = 0; \
+		(o)->SecurityDescriptor = NULL; \
+		(o)->SecurityQualityOfService = NULL; \
+	} while (false)
+
+typedef void (WINAPI *RTLINITUNICODESTRINGFUNC)(PCUNICODE_STRING pstr, const wchar_t *lpstrName);
+typedef NTSTATUS (WINAPI *NTOPENFUNC)(PHANDLE phandle, ACCESS_MASK access, POBJECT_ATTRIBUTES objattr);
+
+static FARPROC get_nt_func(const char *name)
+{
+	static bool initialized = false;
+	static HANDLE ntdll = NULL;
+	if (!initialized) {
+		ntdll = GetModuleHandleW(L"ntdll");
+		initialized = true;
+	}
+
+	return GetProcAddress(ntdll, name);
+}
+
+static void nt_set_last_error(NTSTATUS status)
+{
+	static bool initialized = false;
+	static RTLNTSTATUSTODOSERRORFUNC func = NULL;
+
+	if (!initialized) {
+		func = (RTLNTSTATUSTODOSERRORFUNC)get_nt_func(
+				"RtlNtStatusToDosError");
+		initialized = true;
+	}
+
+	if (func)
+		SetLastError(func(status));
+}
+
+static void rtl_init_str(UNICODE_STRING *unistr, const wchar_t *str)
+{
+	static bool initialized = false;
+	static RTLINITUNICODESTRINGFUNC func = NULL;
+
+	if (!initialized) {
+		func = (RTLINITUNICODESTRINGFUNC)get_nt_func(
+				"RtlInitUnicodeString");
+		initialized = true;
+	}
+
+	if (func)
+		func(unistr, str);
+}
+
+#define MAKE_NT_OPEN_FUNC(func_name, nt_name, access) \
+static HANDLE func_name(const wchar_t *name) \
+{ \
+	static bool initialized = false; \
+	static NTOPENFUNC open = NULL; \
+	HANDLE handle; \
+	NTSTATUS status; \
+	UNICODE_STRING unistr; \
+	OBJECT_ATTRIBUTES attr; \
+\
+	if (!initialized) { \
+		open = (NTOPENFUNC)get_nt_func(#nt_name); \
+		initialized = true; \
+	} \
+\
+	if (!open) \
+		return NULL; \
+\
+	rtl_init_str(&unistr, name); \
+	init_named_attribs(&attr, &unistr); \
+\
+	status = open(&handle, access, &attr); \
+	if (NT_SUCCESS(status)) \
+		return handle; \
+	nt_set_last_error(status); \
+	return NULL; \
+}
+
+MAKE_NT_OPEN_FUNC(nt_open_mutex, NtOpenMutant, SYNCHRONIZE)
+MAKE_NT_OPEN_FUNC(nt_open_event, NtOpenEvent, EVENT_MODIFY_STATE | SYNCHRONIZE)
+MAKE_NT_OPEN_FUNC(nt_open_map, NtOpenSection, FILE_MAP_READ | FILE_MAP_WRITE)

--- a/plugins/win-capture/nt-stuff.h
+++ b/plugins/win-capture/nt-stuff.h
@@ -2,9 +2,45 @@
 
 #include <winternl.h>
 
+#define THREAD_STATE_WAITING 5
+#define THREAD_WAIT_REASON_SUSPENDED 5
+
+typedef struct _SYSTEM_PROCESS_INFORMATION2 {
+    ULONG NextEntryOffset;
+    ULONG ThreadCount;
+    BYTE Reserved1[48];
+    PVOID Reserved2[3];
+    HANDLE UniqueProcessId;
+    PVOID Reserved3;
+    ULONG HandleCount;
+    BYTE Reserved4[4];
+    PVOID Reserved5[11];
+    SIZE_T PeakPagefileUsage;
+    SIZE_T PrivatePageCount;
+    LARGE_INTEGER Reserved6[6];
+} SYSTEM_PROCESS_INFORMATION2;
+
+typedef struct _SYSTEM_THREAD_INFORMATION {
+	FILETIME KernelTime;
+	FILETIME UserTime;
+	FILETIME CreateTime;
+	DWORD WaitTime;
+	PVOID Address;
+	HANDLE UniqueProcessId;
+	HANDLE UniqueThreadId;
+	DWORD Priority;
+	DWORD BasePriority;
+	DWORD ContextSwitches;
+	DWORD ThreadState;
+	DWORD WaitReason;
+	DWORD Reserved1;
+} SYSTEM_THREAD_INFORMATION;
+
 #ifndef NT_SUCCESS
 #define NT_SUCCESS(status) ((NTSTATUS)(status) >= 0)
 #endif
+
+#define STATUS_INFO_LENGTH_MISMATCH      ((NTSTATUS)0xC0000004L)
 
 #define init_named_attribs(o, name) \
 	do { \
@@ -18,6 +54,8 @@
 
 typedef void (WINAPI *RTLINITUNICODESTRINGFUNC)(PCUNICODE_STRING pstr, const wchar_t *lpstrName);
 typedef NTSTATUS (WINAPI *NTOPENFUNC)(PHANDLE phandle, ACCESS_MASK access, POBJECT_ATTRIBUTES objattr);
+typedef ULONG (WINAPI *RTLNTSTATUSTODOSERRORFUNC)(NTSTATUS status);
+typedef NTSTATUS (WINAPI *NTQUERYSYSTEMINFORMATIONFUNC)(SYSTEM_INFORMATION_CLASS, PVOID, ULONG, PULONG);
 
 static FARPROC get_nt_func(const char *name)
 {
@@ -59,6 +97,79 @@ static void rtl_init_str(UNICODE_STRING *unistr, const wchar_t *str)
 
 	if (func)
 		func(unistr, str);
+}
+
+static NTSTATUS nt_query_information(SYSTEM_INFORMATION_CLASS info_class,
+		PVOID info, ULONG info_len, PULONG ret_len)
+{
+	static bool initialized = false;
+	static NTQUERYSYSTEMINFORMATIONFUNC func = NULL;
+
+	if (!initialized) {
+		func = (NTQUERYSYSTEMINFORMATIONFUNC)get_nt_func(
+				"NtQuerySystemInformation");
+		initialized = true;
+	}
+
+	if (func)
+		return func(info_class, info, info_len, ret_len);
+	return (NTSTATUS)-1;
+}
+
+static bool thread_is_suspended(DWORD process_id, DWORD thread_id)
+{
+	ULONG size = 4096;
+	bool suspended = false;
+	void *data = malloc(size);
+
+	for (;;) {
+		NTSTATUS stat = nt_query_information(SystemProcessInformation,
+				data, size, &size);
+		if (NT_SUCCESS(stat))
+			break;
+
+		if (stat != STATUS_INFO_LENGTH_MISMATCH) {
+			goto fail;
+		}
+
+		free(data);
+		size += 1024;
+		data = malloc(size);
+	}
+
+	SYSTEM_PROCESS_INFORMATION2 *spi = data;
+
+	for (;;) {
+		if (spi->UniqueProcessId == (HANDLE)process_id) {
+			break;
+		}
+
+		ULONG offset = spi->NextEntryOffset;
+		if (!offset)
+			goto fail;
+
+		spi = (SYSTEM_PROCESS_INFORMATION2*)((BYTE*)spi + offset);
+	}
+
+	SYSTEM_THREAD_INFORMATION *sti;
+	SYSTEM_THREAD_INFORMATION *info = NULL;
+	sti = (SYSTEM_THREAD_INFORMATION*)((BYTE*)spi + sizeof(*spi));
+
+	for (ULONG i = 0; i < spi->ThreadCount; i++) {
+		if (sti[i].UniqueThreadId == (HANDLE)thread_id) {
+			info = &sti[i];
+			break;
+		}
+	}
+
+	if (info) {
+		suspended = info->ThreadState == THREAD_STATE_WAITING &&
+			info->WaitReason == THREAD_WAIT_REASON_SUSPENDED;
+	}
+
+fail:
+	free(data);
+	return suspended;
 }
 
 #define MAKE_NT_OPEN_FUNC(func_name, nt_name, access) \

--- a/plugins/win-capture/window-helpers.h
+++ b/plugins/win-capture/window-helpers.h
@@ -16,6 +16,8 @@ enum window_search_mode {
 extern bool get_window_exe(struct dstr *name, HWND window);
 extern void get_window_title(struct dstr *name, HWND hwnd);
 extern void get_window_class(struct dstr *class, HWND hwnd);
+extern bool is_uwp_window(HWND hwnd);
+extern HWND get_uwp_actual_window(HWND parent);
 
 typedef bool (*add_window_cb)(const char *title, const char *class,
 		const char *exe);


### PR DESCRIPTION
When logging out and back in again or when booting with Windows 10's "fast startup" the session id will no longer be 1.

This change always retrieves the current session Id for the path.

There is probably be a nicer way to do this other than calling `WTSGetActiveConsoleSessionId` every time one of those functions is called. Feedback appreciated.