### PR TITLE
frontend-tools: Fixed bug that output-timer

### DIFF
--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -88,7 +88,7 @@ void OutputTimer::StreamTimerStart()
 
 	streamingTimer->start();
 	streamingTimerDisplay->start(1000);
-	ui->outputTimerStream->setText(tr("Stop"));
+	ui->outputTimerStream->setText(obs_module_text("Stop"));
 
 	UpdateStreamTimerDisplay();
 }
@@ -122,7 +122,7 @@ void OutputTimer::RecordTimerStart()
 
 	recordingTimer->start();
 	recordingTimerDisplay->start(1000);
-	ui->outputTimerRecord->setText(tr("Stop"));
+	ui->outputTimerRecord->setText(obs_module_text("Stop"));
 
 	UpdateRecordTimerDisplay();
 }
@@ -137,7 +137,7 @@ void OutputTimer::StreamTimerStop()
 	if (streamingTimer->isActive())
 		streamingTimer->stop();
 
-	ui->outputTimerStream->setText(tr("Start"));
+	ui->outputTimerStream->setText(obs_module_text("Start"));
 
 	if (streamingTimerDisplay->isActive())
 		streamingTimerDisplay->stop();
@@ -155,7 +155,7 @@ void OutputTimer::RecordTimerStop()
 	if (recordingTimer->isActive())
 		recordingTimer->stop();
 
-	ui->outputTimerRecord->setText(tr("Start"));
+	ui->outputTimerRecord->setText(obs_module_text("Start"));
 
 	if (recordingTimerDisplay->isActive())
 		recordingTimerDisplay->stop();


### PR DESCRIPTION
Fixed bug that no translation is applied after start

Bug gif image 「開始(Translation applies) → stop(no translation) → start(no translation)」
https://gyazo.com/ec952bf4db8152d4fbb599d9fc928e21