### PR TITLE
UI: add Hide to Tray instead of Minimize option

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -414,6 +414,7 @@ Basic.Settings.General.RecordWhenStreaming="Automatically record when streaming"
 Basic.Settings.General.KeepRecordingWhenStreamStops="Keep recording when stream stops"
 Basic.Settings.General.SysTrayEnabled="Enable system tray icon"
 Basic.Settings.General.SysTrayWhenStarted="Minimize to system tray when started"
+Basic.Settings.General.SystemTrayHideMinimize="Hide to system tray instead of minimize to task bar"
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -209,14 +209,24 @@
            </property>
           </widget>
          </item>
-         <item row="11" column="0" colspan="2">
+         <item row="11" column="1">
+          <widget class="QCheckBox" name="systemTrayMinimizeToTray">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Basic.Settings.General.SystemTrayHideMinimize</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0" colspan="2">
           <widget class="Line" name="line_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
-         <item row="12" column="0" colspan="2">
+         <item row="13" column="0" colspan="2">
           <widget class="QGroupBox" name="groupBox_10">
            <property name="enabled">
             <bool>true</bool>
@@ -4188,6 +4198,12 @@
      <y>294</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>systemTrayEnabled</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>systemTrayMinimizeToTray</receiver>
+   <slot>setEnabled(bool)</slot>
   </connection>
  </connections>
 </ui>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2787,8 +2787,11 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 
 void OBSBasic::changeEvent(QEvent *event)
 {
-	/* TODO */
-	UNUSED_PARAMETER(event);
+	/* MORE TODO */
+	if ((event->type() == QEvent::WindowStateChange) && isMinimized() &&
+		trayIcon->isVisible() && sysTrayMinimizeToTray()) {
+			ToggleShowHide();
+	}
 }
 
 void OBSBasic::on_actionShow_Recordings_triggered()
@@ -4898,6 +4901,14 @@ void OBSBasic::SetShowing(bool showing)
 		setVisible(false);
 
 	} else if (showing && !isVisible()) {
+		
+		//If the window is not visible(i.e. isVisible() returns false),
+		//the window state will take effect when show() is called.
+		//Unminimize window if was hidden to tray instead of task bar.
+		if (sysTrayMinimizeToTray())
+			this->setWindowState((this->windowState() & ~Qt::WindowMinimized) | 
+				Qt::WindowActive);
+		
 		if (showHide)
 			showHide->setText(QTStr("Basic.SystemTray.Hide"));
 		QTimer::singleShot(250, this, SLOT(show()));

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4912,13 +4912,6 @@ void OBSBasic::SetShowing(bool showing)
 			"BasicWindow", "geometry",
 			saveGeometry().toBase64().constData());
 		
-		/* TODO - preserve projectors */
-		//delete projectors on hide
-		for (QPointer<QWidget> &projector : projectors) {
-			delete projector;
-			projector.clear();
-		}
-		
 		//hide all visible child dialogs
 		VisibleDialogsPos.clear();
 		if (!list_of_VisibleDialogs.isEmpty()) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4912,6 +4912,13 @@ void OBSBasic::SetShowing(bool showing)
 			"BasicWindow", "geometry",
 			saveGeometry().toBase64().constData());
 		
+		/* TODO - preserve projectors */
+		//delete projectors on hide
+		for (QPointer<QWidget> &projector : projectors) {
+			delete projector;
+			projector.clear();
+		}
+		
 		//hide all visible child dialogs
 		VisibleDialogsPos.clear();
 		if (!list_of_VisibleDialogs.isEmpty()) {

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -320,6 +320,12 @@ private:
 	void dropEvent(QDropEvent *event) override;
 
 	void ReplayBufferClicked();
+	
+	inline bool sysTrayMinimizeToTray() const
+	{
+		return config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "SysTrayMinimizeToTray");
+	}
 
 public slots:
 	void StartStreaming();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -338,16 +338,6 @@ private:
 
 	QList<QPoint> VisibleDialogsPos;
 
-	bool sysTrayMinimizeToTray();
-
-	void EnumDialogs();
-
-	QList<QDialog*> list_of_VisibleDialogs;
-	QList<QDialog*> list_of_ModalDialogs;
-	QList<QMessageBox*> list_of_VisibleMBoxes; //always modal
-
-	QList<QPoint> VisibleDialogsPos;
-
 public slots:
 	void StartStreaming();
 	void StopStreaming();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -338,6 +338,16 @@ private:
 
 	QList<QPoint> VisibleDialogsPos;
 
+	bool sysTrayMinimizeToTray();
+
+	void EnumDialogs();
+
+	QList<QDialog*> list_of_VisibleDialogs;
+	QList<QDialog*> list_of_ModalDialogs;
+	QList<QMessageBox*> list_of_VisibleMBoxes; //always modal
+
+	QList<QPoint> VisibleDialogsPos;
+
 public slots:
 	void StartStreaming();
 	void StopStreaming();

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -38,6 +38,8 @@
 
 #include <QPointer>
 
+#include <QMessageBox>
+
 class QListWidgetItem;
 class VolControl;
 class QNetworkReply;
@@ -162,7 +164,6 @@ private:
 	QPointer<QAction>         showHide;
 	QPointer<QAction>         exit;
 	QPointer<QMenu>           trayMenu;
-	bool          disableHiding = false;
 
 	void          DrawBackdrop(float cx, float cy);
 
@@ -327,6 +328,16 @@ private:
 			"BasicWindow", "SysTrayMinimizeToTray");
 	}
 
+	bool sysTrayMinimizeToTray();
+
+	void EnumDialogs();
+
+	QList<QDialog*> list_of_VisibleDialogs;
+	QList<QDialog*> list_of_ModalDialogs;
+	QList<QMessageBox*> list_of_VisibleMBoxes; //always modal
+
+	QList<QPoint> VisibleDialogsPos;
+
 public slots:
 	void StartStreaming();
 	void StopStreaming();
@@ -397,15 +408,7 @@ private slots:
 	void IconActivated(QSystemTrayIcon::ActivationReason reason);
 	void SetShowing(bool showing);
 
-	inline void ToggleShowHide()
-	{
-		bool showing = isVisible();
-		if (disableHiding && showing)
-			return;
-		if (showing)
-			CloseDialogs();
-		SetShowing(!showing);
-	}
+	void ToggleShowHide();
 
 private:
 	/* OBS Callbacks */

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -321,12 +321,6 @@ private:
 	void dropEvent(QDropEvent *event) override;
 
 	void ReplayBufferClicked();
-	
-	inline bool sysTrayMinimizeToTray() const
-	{
-		return config_get_bool(GetGlobalConfig(),
-			"BasicWindow", "SysTrayMinimizeToTray");
-	}
 
 	bool sysTrayMinimizeToTray();
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -281,6 +281,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->keepRecordStreamStops,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayEnabled,    CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayWhenStarted,CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->systemTrayMinimizeToTray, CHECK_CHANGED, GENERAL_CHANGED);
 	HookWidget(ui->snappingEnabled,      CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->screenSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->centerSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
@@ -890,6 +891,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool systemTrayWhenStarted = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SysTrayWhenStarted");
 	ui->systemTrayWhenStarted->setChecked(systemTrayWhenStarted);
+	
+	bool systemTrayMinimizeToTray = config_get_bool(GetGlobalConfig(),
+		"BasicWindow", "SysTrayMinimizeToTray");
+	ui->systemTrayMinimizeToTray->setChecked(systemTrayMinimizeToTray);
 
 	bool snappingEnabled = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SnappingEnabled");
@@ -2341,6 +2346,11 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"SysTrayWhenStarted",
 				ui->systemTrayWhenStarted->isChecked());
+	
+	if (WidgetChanged(ui->systemTrayMinimizeToTray))
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		"SysTrayMinimizeToTray",
+		ui->systemTrayMinimizeToTray->isChecked());
 }
 
 void OBSBasicSettings::SaveStream1Settings()

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -19,6 +19,9 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_)
 {
 	setAttribute(Qt::WA_DeleteOnClose, true);
 
+	//disable application quit when last window closed
+	setAttribute(Qt::WA_QuitOnClose, false);
+
 	installEventFilter(CreateShortcutFilter());
 
 	auto addDrawCallback = [this] ()


### PR DESCRIPTION
* UI: add Hide to system tray instead of minimize to Task bar option.
Enables new option to control Hide on minimize window.

* UI: changes to window management during hide to tray.
New behavior:
1. Ignores Hide to tray when any modal dialog or message box is visible;
2. All child dialogs preserved upon hiding (doesn't forced to close);
3. Switching virtual desktops may cause window minimize forced and thus "Hide" triggered if "Hide to system tray instead of minimize to task bar" is checked. Possible workaround: click "Show" from the tray menu.
4. Fullscreen Projectors not switching off on hiding to tray (doesn't forced to close).