### PR TITLE
obs-filters.c: Fix Color Correction Filter OpenGL Crash

### DIFF
--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -71,6 +71,10 @@ struct color_correction_filter_data {
 };
 
 const static float root3 = 0.57735f;
+const static float red_weight = 0.299f;
+const static float green_weight = 0.587f;
+const static float blue_weight = 0.114f;
+
 
 /*
  * As the functions' namesake, this provides the internal name of your Filter,
@@ -130,15 +134,19 @@ static void color_correction_filter_update(void *data, obs_data_t *settings)
 			SETTING_SATURATION) + 1.0f;
 
 	/* Factor in the selected color weights. */
-	float one_minus_sat = (1.0f - filter->saturation) / 3.0f;
-	float sat_val = one_minus_sat + filter->saturation;
+	float one_minus_sat_red = (1.0f - filter->saturation) * red_weight;
+	float one_minus_sat_green = (1.0f - filter->saturation) * green_weight;
+	float one_minus_sat_blue = (1.0f - filter->saturation) * blue_weight;
+	float sat_val_red   = one_minus_sat_red + filter->saturation;
+	float sat_val_green = one_minus_sat_green + filter->saturation;
+	float sat_val_blue  = one_minus_sat_blue + filter->saturation;
 
 	/* Now we build our Saturation matrix. */
 	filter->sat_matrix = (struct matrix4)
 	{
-		sat_val, one_minus_sat, one_minus_sat, 0.0f,
-		one_minus_sat, sat_val, one_minus_sat, 0.0f,
-		one_minus_sat, one_minus_sat, sat_val, 0.0f,
+		sat_val_red, one_minus_sat_red, one_minus_sat_red, 0.0f,
+		one_minus_sat_green, sat_val_green, one_minus_sat_green, 0.0f,
+		one_minus_sat_blue, one_minus_sat_blue, sat_val_blue, 0.0f,
 		0.0f, 0.0f, 0.0f, 1.0f
 	};
 

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -345,7 +345,6 @@ static obs_properties_t *color_correction_filter_properties(void *data)
 
 	obs_properties_add_float_slider(props, SETTING_GAMMA,
 			TEXT_GAMMA, -3.0f, 3.0f, 0.01f);
-
 	obs_properties_add_float_slider(props, SETTING_CONTRAST,
 			TEXT_CONTRAST, -2.0f, 2.0f, 0.01f);
 	obs_properties_add_float_slider(props, SETTING_BRIGHTNESS,
@@ -356,7 +355,6 @@ static obs_properties_t *color_correction_filter_properties(void *data)
 			TEXT_HUESHIFT, -180.0f, 180.0f, 0.01f);
 	obs_properties_add_int_slider(props, SETTING_OPACITY,
 			TEXT_OPACITY, 0, 100, 1);
-
 	obs_properties_add_color(props, SETTING_COLOR, TEXT_COLOR);
 
 	UNUSED_PARAMETER(data);

--- a/plugins/obs-filters/data/color_correction_filter.effect
+++ b/plugins/obs-filters/data/color_correction_filter.effect
@@ -35,10 +35,6 @@ struct VertData {
 	float2 uv : TEXCOORD0;
 };
 
-struct CurrentPixel {
-	float4 current_pixel;
-};
-
 VertData VSDefault(VertData vert_in)
 {
 	VertData vert_out;
@@ -49,23 +45,20 @@ VertData VSDefault(VertData vert_in)
 
 float4 PSColorFilterRGBA(VertData vert_in) : TARGET
 {
-	/* Realize the struct. */
-	CurrentPixel pixel = (CurrentPixel) 0;
-
 	/* Grab the current pixel to perform operations on. */
-	pixel.current_pixel = image.Sample(textureSampler, vert_in.uv);
+	float4 currentPixel = image.Sample(textureSampler, vert_in.uv);
 
 	/* Always address the gamma first. */
-	pixel.current_pixel.rgb = pow(pixel.current_pixel.rgb, gamma);
+	currentPixel.rgb = pow(currentPixel.rgb, gamma);
 
 	/* Much easier to manipulate pixels for these types of operations
 	 * when in a matrix such as the below. See
 	 * http://www.graficaobscura.com/matrix/index.html and
 	 * https://docs.rainmeter.net/tips/colormatrix-guide/for more info.
 	 */
-	pixel.current_pixel = mul(color_matrix, pixel.current_pixel);
+	currentPixel = mul(color_matrix, currentPixel);
 
-	return pixel.current_pixel;
+	return currentPixel;
 }
 
 technique Draw


### PR DESCRIPTION
When using this filter in/on OpenGL situations can cause crashes with an "int to vec4" cast.
This fix should resolve that issue.