### PR TITLE
UI: Fix import/export profiles

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -481,6 +481,8 @@ void OBSBasic::on_actionImportProfile_triggered()
 					profileDir + "/basic.ini");
 			QFile::copy(dir + "/service.json",
 					profileDir + "/service.json");
+			QFile::copy(dir + "/streamEncoder.json",
+					profileDir + "/streamEncoder.json");
 			RefreshProfiles();
 		} else {
 			QMessageBox::information(this,
@@ -524,6 +526,8 @@ void OBSBasic::on_actionExportProfile_triggered()
 					outputDir + "/basic.ini");
 			QFile::copy(inputPath + currentProfile + "/service.json",
 					outputDir + "/service.json");
+			QFile::copy(inputPath + currentProfile + "/streamEncoder.json",
+					outputDir + "/streamEncoder.json");
 		}
 	}
 }


### PR DESCRIPTION
StreamEncoder.json is missing.
This file is generated when the output mode is advanced.
advanced bitrate and Rate Control and x264 profile etc save.