### PR TITLE
UI: disable quit when the last window is closed

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -871,6 +871,10 @@ bool OBSApp::OBSInit()
 		blog(LOG_INFO, "Portable mode: %s",
 				portable_mode ? "true" : "false");
 
+		//disable implicitly quit when the last window is closed
+		//we will call for quit manually later
+		this->setQuitOnLastWindowClosed(false);
+
 		mainWindow = new OBSBasic();
 
 		mainWindow->setAttribute(Qt::WA_DeleteOnClose, true);


### PR DESCRIPTION
Disable application's implicitly quit when the last window is closed.

Also, solves this rare crash: https://obsproject.com/mantis/view.php?id=625