### PR TITLE
UI: Add option to save projectors

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -414,6 +414,7 @@ Basic.Settings.General.RecordWhenStreaming="Automatically record when streaming"
 Basic.Settings.General.KeepRecordingWhenStreamStops="Keep recording when stream stops"
 Basic.Settings.General.SysTrayEnabled="Enable system tray icon"
 Basic.Settings.General.SysTrayWhenStarted="Minimize to system tray when started"
+Basic.Settings.General.SaveProjectors="Save projectors on exit"
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -185,21 +185,21 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="8" column="1">
           <widget class="QCheckBox" name="recordWhenStreaming">
            <property name="text">
             <string>Basic.Settings.General.RecordWhenStreaming</string>
            </property>
           </widget>
          </item>
-         <item row="9" column="1">
+         <item row="10" column="1">
           <widget class="QCheckBox" name="systemTrayEnabled">
            <property name="text">
             <string>Basic.Settings.General.SysTrayEnabled</string>
            </property>
           </widget>
          </item>
-         <item row="10" column="1">
+         <item row="11" column="1">
           <widget class="QCheckBox" name="systemTrayWhenStarted">
            <property name="enabled">
             <bool>false</bool>
@@ -209,14 +209,21 @@
            </property>
           </widget>
          </item>
-         <item row="11" column="0" colspan="2">
+         <item row="7" column="1">
+          <widget class="QCheckBox" name="saveProjectors">
+           <property name="text">
+            <string>Basic.Settings.General.SaveProjectors</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0" colspan="2">
           <widget class="Line" name="line_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
           </widget>
          </item>
-         <item row="12" column="0" colspan="2">
+         <item row="13" column="0" colspan="2">
           <widget class="QGroupBox" name="groupBox_10">
            <property name="enabled">
             <bool>true</bool>
@@ -316,7 +323,7 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="1">
+         <item row="9" column="1">
           <widget class="QCheckBox" name="keepRecordStreamStops">
            <property name="enabled">
             <bool>false</bool>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -378,6 +378,8 @@ bool OBSApp::InitGlobalConfigDefaults()
 	config_set_default_bool(globalConfig, "BasicWindow",
 			"SysTrayWhenStarted", false);
 	config_set_default_bool(globalConfig, "BasicWindow",
+			"SaveProjectors", false);
+	config_set_default_bool(globalConfig, "BasicWindow",
 			"ShowTransitions", true);
 	config_set_default_bool(globalConfig, "BasicWindow",
 			"ShowListboxToolbars", true);

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -222,6 +222,9 @@ void OBSBasic::RefreshSceneCollections()
 	EnumSceneCollections(addCollection);
 
 	ui->actionRemoveSceneCollection->setEnabled(count > 1);
+
+	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
+	main->OpenSavedProjectors();
 }
 
 void OBSBasic::on_actionNewSceneCollection_triggered()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -123,6 +123,9 @@ OBSBasic::OBSBasic(QWidget *parent)
 	: OBSMainWindow  (parent),
 	  ui             (new Ui::OBSBasic)
 {
+	projectorArray.resize(10, "");
+	previewProjectorArray.resize(10, 0);
+
 	setAcceptDrops(true);
 
 	ui->setupUi(this);
@@ -262,7 +265,9 @@ static void SaveAudioDevice(const char *name, int channel, obs_data_t *parent,
 static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 		obs_data_array_t *quickTransitionData, int transitionDuration,
 		obs_data_array_t *transitions,
-		OBSScene &scene, OBSSource &curProgramScene)
+		OBSScene &scene, OBSSource &curProgramScene,
+		obs_data_array_t *savedProjectorList,
+		obs_data_array_t *savedPreviewProjectorList)
 {
 	obs_data_t *saveData = obs_data_create();
 
@@ -303,6 +308,9 @@ static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 	obs_data_set_array(saveData, "sources", sourcesArray);
 	obs_data_set_array(saveData, "quick_transitions", quickTransitionData);
 	obs_data_set_array(saveData, "transitions", transitions);
+	obs_data_set_array(saveData, "saved_projectors", savedProjectorList);
+	obs_data_set_array(saveData, "saved_preview_projectors",
+			savedPreviewProjectorList);
 	obs_data_array_release(sourcesArray);
 
 	obs_data_set_string(saveData, "current_transition",
@@ -360,6 +368,36 @@ obs_data_array_t *OBSBasic::SaveSceneListOrder()
 	return sceneOrder;
 }
 
+obs_data_array_t *OBSBasic::SaveProjectors()
+{
+	obs_data_array_t *saveProjector = obs_data_array_create();
+
+	for (size_t i = 0; i < projectorArray.size(); i++) {
+		obs_data_t *data = obs_data_create();
+		obs_data_set_string(data, "saved_projectors",
+			projectorArray.at(i).c_str());
+		obs_data_array_push_back(saveProjector, data);
+		obs_data_release(data);
+	}
+
+	return saveProjector;
+}
+
+obs_data_array_t *OBSBasic::SavePreviewProjectors()
+{
+	obs_data_array_t *saveProjector = obs_data_array_create();
+
+	for (size_t i = 0; i < previewProjectorArray.size(); i++) {
+		obs_data_t *data = obs_data_create();
+		obs_data_set_int(data, "saved_preview_projectors",
+			previewProjectorArray.at(i));
+		obs_data_array_push_back(saveProjector, data);
+		obs_data_release(data);
+	}
+
+	return saveProjector;
+}
+
 void OBSBasic::Save(const char *file)
 {
 	OBSScene scene = GetCurrentScene();
@@ -370,9 +408,12 @@ void OBSBasic::Save(const char *file)
 	obs_data_array_t *sceneOrder = SaveSceneListOrder();
 	obs_data_array_t *transitions = SaveTransitions();
 	obs_data_array_t *quickTrData = SaveQuickTransitions();
+	obs_data_array_t *savedProjectorList = SaveProjectors();
+	obs_data_array_t *savedPreviewProjectorList = SavePreviewProjectors();
 	obs_data_t *saveData  = GenerateSaveData(sceneOrder, quickTrData,
 			ui->transitionDuration->value(), transitions,
-			scene, curProgramScene);
+			scene, curProgramScene, savedProjectorList,
+			savedPreviewProjectorList);
 
 	obs_data_set_bool(saveData, "preview_locked", ui->preview->Locked());
 	obs_data_set_int(saveData, "scaling_mode",
@@ -392,6 +433,8 @@ void OBSBasic::Save(const char *file)
 	obs_data_array_release(sceneOrder);
 	obs_data_array_release(quickTrData);
 	obs_data_array_release(transitions);
+	obs_data_array_release(savedProjectorList);
+	obs_data_array_release(savedPreviewProjectorList);
 }
 
 static void LoadAudioDevice(const char *name, int channel, obs_data_t *parent)
@@ -486,6 +529,32 @@ void OBSBasic::LoadSceneListOrder(obs_data_array_t *array)
 		const char *name = obs_data_get_string(data, "name");
 
 		ReorderItemByName(ui->scenes, name, (int)i);
+
+		obs_data_release(data);
+	}
+}
+
+void OBSBasic::LoadSavedProjectors(obs_data_array_t *array)
+{
+	size_t num = obs_data_array_count(array);
+
+	for (size_t i = 0; i < num; i++) {
+		obs_data_t *data = obs_data_array_item(array, i);
+		projectorArray.at(i) = obs_data_get_string(data,
+				"saved_projectors");
+
+		obs_data_release(data);
+	}
+}
+
+void OBSBasic::LoadSavedPreviewProjectors(obs_data_array_t *array)
+{
+	size_t num = obs_data_array_count(array);
+
+	for (size_t i = 0; i < num; i++) {
+		obs_data_t *data = obs_data_array_item(array, i);
+		previewProjectorArray.at(i) = obs_data_get_int(data,
+				"saved_preview_projectors");
 
 		obs_data_release(data);
 	}
@@ -617,6 +686,23 @@ void OBSBasic::Load(const char *file)
 
 	ui->transitionDuration->setValue(newDuration);
 	SetTransition(curTransition);
+
+	obs_data_array_t *savedProjectors = obs_data_get_array(data,
+			"saved_projectors");
+
+	if (savedProjectors)
+		LoadSavedProjectors(savedProjectors);
+
+	obs_data_array_release(savedProjectors);
+
+	obs_data_array_t *savedPreviewProjectors = obs_data_get_array(data,
+			"saved_preview_projectors");
+
+	if (savedPreviewProjectors)
+		LoadSavedPreviewProjectors(savedPreviewProjectors);
+
+	obs_data_array_release(savedPreviewProjectors);
+
 
 retryScene:
 	curScene = obs_get_source_by_name(sceneName);
@@ -1259,6 +1345,8 @@ void OBSBasic::OBSInit()
 	ui->mainSplitter->setSizes(defSizes);
 
 	SystemTray(true);
+
+	OpenSavedProjectors();
 }
 
 void OBSBasic::InitHotkeys()
@@ -1889,6 +1977,14 @@ void OBSBasic::RenameSources(QString newName, QString prevName)
 	for (size_t i = 0; i < volumes.size(); i++) {
 		if (volumes[i]->GetName().compare(prevName) == 0)
 			volumes[i]->SetName(newName);
+	}
+
+	std::string newText = newName.toUtf8().constData();
+	std::string prevText = prevName.toUtf8().constData();
+
+	for (size_t j = 0; j < projectorArray.size(); j++) {
+		if (projectorArray.at(j) == prevText)
+			projectorArray.at(j) = newText;
 	}
 
 	SaveProject();
@@ -4725,15 +4821,30 @@ void OBSBasic::NudgeRight()    {Nudge(1,  MoveDir::Right);}
 void OBSBasic::OpenProjector(obs_source_t *source, int monitor)
 {
 	/* seriously?  10 monitors? */
-	if (monitor > 9)
+	if (monitor > 9 || monitor > QGuiApplication::screens().size() - 1)
 		return;
+
+	bool isPreview = false;
+
+	if (source == nullptr)
+		isPreview = true;
 
 	delete projectors[monitor];
 	projectors[monitor].clear();
 
-	OBSProjector *projector = new OBSProjector(nullptr, source);
-	projector->Init(monitor);
+	RemoveSavedProjectors(monitor);
 
+	OBSProjector *projector = new OBSProjector(nullptr, source);
+
+	const char *name = obs_source_get_name(source);
+
+	if (isPreview) {
+		previewProjectorArray.at((size_t)monitor) = 1;
+	} else {
+		projectorArray.at((size_t)monitor) = name;
+	}
+
+	projector->Init(monitor);
 	projectors[monitor] = projector;
 }
 
@@ -4761,6 +4872,42 @@ void OBSBasic::OpenSceneProjector()
 		return;
 
 	OpenProjector(obs_scene_get_source(scene), monitor);
+}
+
+void OBSBasic::OpenSavedProjectors()
+{
+	bool projectorSave = config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "SaveProjectors");
+
+	if (projectorSave) {
+		for (size_t i = 0; i < projectorArray.size(); i++) {
+			if (projectorArray.at(i).empty() == false) {
+				OBSSource source = obs_get_source_by_name(
+					projectorArray.at(i).c_str());
+
+				if (!source) {
+					RemoveSavedProjectors((int)i);
+					obs_source_release(source);
+					continue;
+				}
+
+				OpenProjector(source, (int)i);
+				obs_source_release(source);
+			}
+		}
+
+		for (size_t i = 0; i < previewProjectorArray.size(); i++) {
+			if (previewProjectorArray.at(i) == 1) {
+				OpenProjector(nullptr, (int)i);
+			}
+		}
+	}
+}
+
+void OBSBasic::RemoveSavedProjectors(int monitor)
+{
+	previewProjectorArray.at((size_t)monitor) = 0;
+	projectorArray.at((size_t)monitor) = "";
 }
 
 void OBSBasic::UpdateTitleBar()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -110,6 +110,9 @@ private:
 
 	std::vector<OBSSignal> signalHandlers;
 
+	std::vector<std::string> projectorArray;
+	std::vector<int> previewProjectorArray;
+
 	bool loaded = false;
 	long disableSaving = 1;
 	bool projectChanged = false;
@@ -321,6 +324,13 @@ private:
 
 	void ReplayBufferClicked();
 
+	obs_data_array_t *SaveProjectors();
+	void LoadSavedProjectors(obs_data_array_t *savedProjectors);
+
+	obs_data_array_t *SavePreviewProjectors();
+	void LoadSavedPreviewProjectors(
+		obs_data_array_t *savedPreviewProjectors);
+
 public slots:
 	void StartStreaming();
 	void StopStreaming();
@@ -479,6 +489,9 @@ public:
 
 	void SystemTrayInit();
 	void SystemTray(bool firstStarted);
+
+	void OpenSavedProjectors();
+	void RemoveSavedProjectors(int monitor);
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -281,6 +281,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->keepRecordStreamStops,CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayEnabled,    CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->systemTrayWhenStarted,CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->saveProjectors,       CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->snappingEnabled,      CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->screenSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->centerSnapping,       CHECK_CHANGED,  GENERAL_CHANGED);
@@ -890,6 +891,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool systemTrayWhenStarted = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SysTrayWhenStarted");
 	ui->systemTrayWhenStarted->setChecked(systemTrayWhenStarted);
+
+	bool saveProjectors = config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "SaveProjectors");
+	ui->saveProjectors->setChecked(saveProjectors);
 
 	bool snappingEnabled = config_get_bool(GetGlobalConfig(),
 			"BasicWindow", "SnappingEnabled");
@@ -2341,6 +2346,11 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(GetGlobalConfig(), "BasicWindow",
 				"SysTrayWhenStarted",
 				ui->systemTrayWhenStarted->isChecked());
+	
+	if (WidgetChanged(ui->saveProjectors))
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"SaveProjectors",
+				ui->saveProjectors->isChecked());
 }
 
 void OBSBasicSettings::SaveStream1Settings()

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -50,6 +50,7 @@ OBSProjector::~OBSProjector()
 void OBSProjector::Init(int monitor)
 {
 	QScreen *screen = QGuiApplication::screens()[monitor];
+
 	setGeometry(screen->geometry());
 
 	bool alwaysOnTop = config_get_bool(GetGlobalConfig(),
@@ -67,6 +68,8 @@ void OBSProjector::Init(int monitor)
 	addAction(action);
 
 	connect(action, SIGNAL(triggered()), this, SLOT(EscapeTriggered()));
+
+	savedMonitor = monitor;
 }
 
 void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
@@ -111,6 +114,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 void OBSProjector::OBSSourceRemoved(void *data, calldata_t *params)
 {
 	OBSProjector *window = reinterpret_cast<OBSProjector*>(data);
+
 	window->deleteLater();
 
 	UNUSED_PARAMETER(params);
@@ -129,5 +133,8 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 
 void OBSProjector::EscapeTriggered()
 {
+	OBSBasic *main = reinterpret_cast<OBSBasic*>(App()->GetMainWindow());
+	main->RemoveSavedProjectors(savedMonitor);
+
 	deleteLater();
 }

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -2,6 +2,7 @@
 
 #include <obs.hpp>
 #include "qt-display.hpp"
+#include "window-basic-main.hpp"
 
 class QMouseEvent;
 
@@ -16,6 +17,8 @@ private:
 	static void OBSSourceRemoved(void *data, calldata_t *params);
 
 	void mousePressEvent(QMouseEvent *event) override;
+
+	int savedMonitor = 0;
 
 private slots:
 	void EscapeTriggered();


### PR DESCRIPTION
This adds an option to the general settings to save the opened projectors on exit. I have only one external monitor, so I don't know how well this would work on several of them. At least with one monitor, it works very well.