### PR TITLE
obs-x264: ignore opencl param

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -300,7 +300,8 @@ static inline void set_param(struct obs_x264 *obsx264, const char *param)
 		    strcmp(name, "fps")       != 0 &&
 		    strcmp(name, "force-cfr") != 0 &&
 		    strcmp(name, "width")     != 0 &&
-		    strcmp(name, "height")    != 0) {
+		    strcmp(name, "height")    != 0 &&
+		    strcmp(name, "opencl")    != 0) {
 			if (x264_param_parse(&obsx264->params, name, val) != 0)
 				warn("x264 param: %s failed", param);
 		}


### PR DESCRIPTION
Silently ignores `opencl` parameter for x264 to protect users following bad youtube guides.