### PR TITLE
Return the correct amount of memory on x86 applications.

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -162,9 +162,16 @@ static void log_available_memory(void)
 
 	GlobalMemoryStatusEx(&ms);
 
-	blog(LOG_INFO, "Physical Memory: %luMB Total, %luMB Free",
+#ifdef _WIN64
+	const char *note = "";
+#else
+	const char *note = " (NOTE: 32 bit OS may not use more than 3 GB due limitations)";
+#endif
+
+	blog(LOG_INFO, "Physical Memory: %luMB Total, %luMB Free%s",
 			(DWORD)(ms.ullTotalPhys / 1048576),
-			(DWORD)(ms.ullAvailPhys / 1048576));
+			(DWORD)(ms.ullAvailPhys / 1048576),
+			note);
 }
 
 static void log_windows_version(void)

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -157,19 +157,14 @@ static void log_processor_cores(void)
 
 static void log_available_memory(void)
 {
-	MEMORYSTATUS ms;
-	GlobalMemoryStatus(&ms);
+	MEMORYSTATUSEX ms;
+	ms.dwLength = sizeof(ms);
 
-#ifdef _WIN64
-	const char *note = "";
-#else
-	const char *note = " (NOTE: 2 or 4 gigs max is normal for 32bit programs)";
-#endif
+	GlobalMemoryStatusEx(&ms);
 
-	blog(LOG_INFO, "Physical Memory: %luMB Total, %luMB Free%s",
-			(DWORD)(ms.dwTotalPhys / 1048576),
-			(DWORD)(ms.dwAvailPhys / 1048576),
-			note);
+	blog(LOG_INFO, "Physical Memory: %luMB Total, %luMB Free",
+			(DWORD)(ms.ullTotalPhys / 1048576),
+			(DWORD)(ms.ullAvailPhys / 1048576));
 }
 
 static void log_windows_version(void)


### PR DESCRIPTION
This is a fix for issue [781](https://obsproject.com/mantis/view.php?id=781).