### PR TITLE
CI: Move browser source before building app

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -3,7 +3,11 @@ export FILE_DATE=$(date +%Y-%m-%d.%H:%M:%S)
 export FILENAME=$FILE_DATE-$GIT_HASH-osx.pkg
 mkdir nightly
 cd ./build
+mv ./rundir/RelWithDebInfo/obs-plugins/CEF.app ./
+mv ./rundir/RelWithDebInfo/obs-plugins/obs-browser.so ./
 sudo python ../CI/install/osx/build_app.py
+mv ./CEF.app ./rundir/RelWithDebInfo/obs-plugins/
+mv ./obs-browser.so ./rundir/RelWithDebInfo/obs-plugins/
 packagesbuild ../CI/install/osx/CMakeLists.pkgproj
 
 sudo cp OBS.pkg ./$FILENAME


### PR DESCRIPTION
The buildapp.py script was modifying the CEF.app when we don't want it to. It was also packaging the plugin inside the OBS.app so the app was not using the one under /Library