### PR TITLE
Enable COPY_DEPENDENCIES by default

### DIFF
--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -8,7 +8,7 @@ if(COPIED_DEPENDENCIES)
 	return()
 endif()
 
-option(COPY_DEPENDENCIES "Automaticaly try copying all dependencies" OFF)
+option(COPY_DEPENDENCIES "Automaticaly try copying all dependencies" ON)
 if(NOT COPY_DEPENDENCIES)
 	return()
 endif()


### PR DESCRIPTION
This changes makes it so you no longer have to run cmake twice on windows, checking the COPY_DEPENDENCIES box. It's unclear exactly why this option was not enabled by default, as it is required for a sucessful build.