### PR TITLE
CMAKE: Enable COPY_DEPENDENCIES by default on Windows

### DIFF
--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -8,7 +8,7 @@ if(COPIED_DEPENDENCIES)
 	return()
 endif()
 
-option(COPY_DEPENDENCIES "Automaticaly try copying all dependencies" OFF)
+option(COPY_DEPENDENCIES "Automaticaly try copying all dependencies" ON)
 if(NOT COPY_DEPENDENCIES)
 	return()
 endif()


### PR DESCRIPTION
This change makes it so you no longer have to run cmake twice on Windows, checking the COPY_DEPENDENCIES box after the first time. It's unclear exactly why this option was not enabled by default. While OBS Studio will sucessfully build, it can not be run without the proper dependencies.