### PR TITLE
CI: Build Windows version and upload artifacts

### DIFF
--- a/CI/before-deploy-win.cmd
+++ b/CI/before-deploy-win.cmd
@@ -1,0 +1,3 @@
+xcopy /e C:\projects\obs-studio\build32\rundir\RelWithDebInfo C:\projects\obs-studio\build\
+robocopy C:\projects\obs-studio\build64\rundir\RelWithDebInfo C:\projects\obs-studio\build\ /E /XC /XN /XO
+7z a build.zip C:\projects\obs-studio\build\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,34 @@
 environment:
-  FFMPEG_VERSION: 3.0.1
   CURL_VERSION: 7.39.0
-  matrix:
-    - VSVER: Visual Studio 14 2015 Win64  
-
-platform: x64
-configuration: Debug
 
 install:
   - git submodule update --init --recursive
+  - git clone https://github.com/videolan/vlc.git
   - curl -kLO https://obsproject.com/downloads/dependencies2015.zip
   - 7z x dependencies2015.zip -odependencies2015
-  - set DepsPath=%CD%\dependencies2015\win64
-  - set QTDIR=C:\Qt\5.7\msvc2015_64
+  - set DepsPath32=%CD%\dependencies2015\win32
+  - set DepsPath64=%CD%\dependencies2015\win64
+  - set VLCPath=%CD%\vlc
+  - set QTDIR32=C:\Qt\5.7\msvc2015
+  - set QTDIR64=C:\Qt\5.7\msvc2015_64
+  - set build_config=RelWithDebInfo
+  - move "C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\um\d3d11on12*" "C:\Program Files (x86)\Windows Kits\8.1\Include\um"
+  - move "C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\um\d3d12*" "C:\Program Files (x86)\Windows Kits\8.1\Include\um"
+  - move "C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\dxgi*" "C:\Program Files (x86)\Windows Kits\8.1\Include\shared"
   - mkdir build
-  - cd ./build
-  - cmake -G "Visual Studio 14 2015 Win64" ..
+  - mkdir build32
+  - mkdir build64
+  - cd ./build32
+  - cmake -G "Visual Studio 14 2015" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true ..
+  - cd ../build64
+  - cmake -G "Visual Studio 14 2015 Win64" -DCOPIED_DEPENDENCIES=false -DCOPY_DEPENDENCIES=true -DBUILD_CAPTIONS=true -DCOMPILE_D3D12_HOOK=true ..
 
-build:
-  project: C:\projects\obs-studio\build\obs-studio.sln
+build_script:
+  - call msbuild /p:Configuration=%build_config% C:\projects\obs-studio\build32\obs-studio.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - call msbuild /p:Configuration=%build_config% C:\projects\obs-studio\build64\obs-studio.sln /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+before_deploy:
+  - C:\projects\obs-studio\CI\before-deploy-win.cmd
+
+deploy_script:
+  - ps: Push-AppveyorArtifact "build.zip" -FileName "$(git describe).zip"


### PR DESCRIPTION
Currently this build is still missing the following plugins:
enc-amf
obs-browser
win-ivcam

Artifacts for successful builds get stored on AppVeyor as zip and can also be downloaded from there.
AppVeyor doesn't appear to have a storage limit right now (don't quote me on that) but this might change in the future.

For setting this up in AppVeyor do the following:

1. Create a free Account on AppVeyor
2. Create a new project (Blue text that says NEW PROJECT)
3. Select GitHub as repository, check Public repositories only (this is enough for FLOSS) and click "Authorize GitHub"
4. On the new page that opened click the green "Authorize application" button
5. AppVeyor should now list all repositories you have write access to. Select the right one and click ADD (this will automatically create the necessary Webhooks)
6. In the newly created Project click the link that says SETTINGS
7. Change the "Build version format" to `#{build}`
8. Click the blue Save button
9. The project should be now set up and you can trigger the first build if you want (NEW BUILD button on the project page)




