### PR TITLE
OBSBasic as native window.

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -123,6 +123,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	: OBSMainWindow  (parent),
 	  ui             (new Ui::OBSBasic)
 {
+	setAttribute(Qt::WA_NativeWindow);
 	setAcceptDrops(true);
 
 	ui->setupUi(this);


### PR DESCRIPTION
This fix the error QObject::connect: invalid null parameter on Linux.