### PR TITLE
Remove compiler warnings.

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1257,20 +1257,6 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	profiler_start();
 	profile_register_root(run_program_init, 0);
 
-	auto PrintInitProfile = [&]()
-	{
-		auto snap = GetSnapshot();
-
-		profiler_snapshot_filter_roots(snap.get(), [](void *data,
-					const char *name, bool *remove)
-		{
-			*remove = (*static_cast<const char**>(data)) != name;
-			return true;
-		}, static_cast<void*>(&run_program_init));
-
-		profiler_print(snap.get());
-	};
-
 	ScopeProfiler prof{run_program_init};
 
 	QCoreApplication::addLibraryPath(".");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1535,7 +1535,6 @@ OBSBasic::~OBSBasic()
 	config_set_int(App()->GlobalConfig(), "General", "LastVersion",
 			LIBOBS_API_VER);
 
-	QRect lastGeom = normalGeometry();
 	QList<int> splitterSizes = ui->mainSplitter->sizes();
 	bool alwaysOnTop = IsAlwaysOnTop(this);
 

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -70,11 +70,10 @@ struct color_correction_filter_data {
 	struct vec3                     half_unit;
 };
 
-const static float root3 = 0.57735f;
-const static float red_weight = 0.299f;
-const static float green_weight = 0.587f;
-const static float blue_weight = 0.114f;
-
+static const float root3 = 0.57735f;
+static const float red_weight = 0.299f;
+static const float green_weight = 0.587f;
+static const float blue_weight = 0.114f;
 
 /*
  * As the functions' namesake, this provides the internal name of your Filter,


### PR DESCRIPTION
There are many "deprecated" warnings to be removed, but I'm not sure if it's safe.

The deprecated items come from ffmpeg such as:

- ‘codec’ is deprecated
- ‘data’ is deprecated
- and others

Any tip to fix these I'll appreciate.

It would be nice to have zero warnings.

