### PR TITLE
Add Web.TV streaming service

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -346,6 +346,21 @@
             ]
         },
         {
+            "name": "Web.TV",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://live3.origins.web.tv/liveext"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "main",
+                "max video bitrate": 3500,
+                "max audio bitrate": 160
+            }
+        },
+        {
             "name": "Switchboard Live (Joicaster)",
             "servers": [
                 {


### PR DESCRIPTION
Web.TV is a social video platform. Users can create public, private and hidden channels and share video or live streaming (with free or paid) in that channels.

[https://web.tv](https://web.tv)