### PR TITLE
UI: Add warning if starting the output fails

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -111,6 +111,12 @@ ConfirmRemove.Title="Confirm Remove"
 ConfirmRemove.Text="Are you sure you wish to remove '$1'?"
 ConfirmRemove.TextMultiple="Are you sure you wish to remove %1 items?"
 
+# output start messages
+Output.StartStreamFailed="Failed to start streaming"
+Output.StartRecordingFailed="Failed to start recording"
+Output.StartReplayFailed="Failed to start replay buffer"
+Output.StartFailedGeneric="Starting the output failed. Please Check the log for details.\n\nNote: If you are using the NVENC or the AMF H.264 Encoder make sure your drivers are on the latest version."
+
 # output connect messages
 Output.ConnectFail.Title="Failed to connect"
 Output.ConnectFail.BadPath="Invalid Path or Connection URL.  Please check your settings to confirm that they are valid."

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -837,8 +837,13 @@ bool SimpleOutput::StartRecording()
 	UpdateRecording();
 	if (!ConfigureRecording(false))
 		return false;
-	if (!obs_output_start(fileOutput))
+	if (!obs_output_start(fileOutput))  {
+		QMessageBox::critical(main,
+				QTStr("Output.StartRecordingFailed"),
+				QTStr("Output.StartFailedGeneric"));
 		return false;
+	}
+
 	return true;
 }
 
@@ -847,8 +852,13 @@ bool SimpleOutput::StartReplayBuffer()
 	UpdateRecording();
 	if (!ConfigureRecording(true))
 		return false;
-	if (!obs_output_start(replayBuffer))
+	if (!obs_output_start(replayBuffer)) {
+		QMessageBox::critical(main,
+				QTStr("Output.StartReplayFailed"),
+				QTStr("Output.StartFailedGeneric"));
 		return false;
+	}
+
 	return true;
 }
 
@@ -1399,11 +1409,14 @@ bool AdvancedOutput::StartRecording()
 		obs_data_release(settings);
 	}
 
-	if (obs_output_start(fileOutput)) {
-		return true;
+	if (!obs_output_start(fileOutput)) {
+		QMessageBox::critical(main,
+				QTStr("Output.StartRecordingFailed"),
+				QTStr("Output.StartFailedGeneric"));
+		return false;
 	}
 
-	return false;
+	return true;
 }
 
 void AdvancedOutput::StopStreaming(bool force)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3871,6 +3871,11 @@ void OBSBasic::StartStreaming()
 			sysTrayStream->setText(ui->streamButton->text());
 			sysTrayStream->setEnabled(true);
 		}
+
+		QMessageBox::critical(this,
+				QTStr("Output.StartStreamFailed"),
+				QTStr("Output.StartFailedGeneric"));
+		return;
 	}
 
 	bool recordWhenStreaming = config_get_bool(GetGlobalConfig(),
@@ -3882,7 +3887,6 @@ void OBSBasic::StartStreaming()
 		"BasicWindow", "ReplayBufferWhileStreaming");
 	if (replayBufferWhileStreaming)
 		StartReplayBuffer();
-
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
This is intended to address https://obsproject.com/mantis/view.php?id=789

Currenlty obs fails silently which could go unnoticed for users who are using hotkeys as well as confuse users who are not trained to read their logs when issues occur. With this users will get audible and visual feedback that something went wrong.

Suggestions for better, perhaps more clearer, error messages are welcome.