### PR TITLE
Fix OSX Post Install Script

### DIFF
--- a/CI/install/osx/post-install.sh
+++ b/CI/install/osx/post-install.sh
@@ -2,3 +2,4 @@
 
 # Fix permissions on CEF
 chmod 744 "/Library/Application Support/obs-studio/plugins/obs-browser/bin/CEF.app/Contents/Info.plist"
+chmod 744 "/Library/Application Support/obs-studio/plugins/obs-browser/bin/CEF.app/Contents/Frameworks/CEF Helper.app/Contents/Info.plist"


### PR DESCRIPTION
Fixed the permissions on the other `plist` file that's installed, so we don't get a rogue "CEF Helper" icon on OSX.