### PR TITLE
UI: Add HEVC support and don't silently fail

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -667,8 +667,11 @@ void OBSBasicSettings::LoadEncoderTypes()
 		const char *codec = obs_get_encoder_codec(type);
 		uint32_t caps = obs_get_encoder_caps(type);
 
-		if (strcmp(codec, "h264") != 0)
+		if ((strcmp(codec, "h264") != 0)
+			&& (strcmp(codec, "h265") != 0)) {
+			blog(LOG_DEBUG, "Hiding encoder '%s' due to use of unsupported codec '%s'.", name, codec);
 			continue;
+		}
 		if ((caps & OBS_ENCODER_CAP_DEPRECATED) != 0)
 			continue;
 


### PR DESCRIPTION
HEVC seems to work perfectly fine when muxed with ffmpeg into mp4 or mkv (both as standalone and when using as a dedicated muxer/demuxer), so there shouldn't be a reason to hide it except for certain formats and streaming.

