### PR TITLE
UI, obs-ffmpeg: Add support for other codecs

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -673,15 +673,32 @@ void OBSBasicSettings::LoadEncoderTypes()
 		const char *codec = obs_get_encoder_codec(type);
 		uint32_t caps = obs_get_encoder_caps(type);
 
-		if (strcmp(codec, "h264") != 0)
+		if (obs_get_encoder_type(type) != OBS_ENCODER_VIDEO)
 			continue;
+
+		const char* streaming_codecs[] = {
+			"h264",
+			//"hevc", // This probably needs WebRTC or a similar format
+			// Add more in the future if their AVCodec name is known.
+		};
+		bool is_streaming_codec = false;
+		for (const char* test_codec : streaming_codecs) {
+			if (strcmp(codec, test_codec) == 0) {
+				is_streaming_codec = true;
+				break;
+			}
+		}
 		if ((caps & OBS_ENCODER_CAP_DEPRECATED) != 0)
 			continue;
 
 		QString qName = QT_UTF8(name);
 		QString qType = QT_UTF8(type);
 
-		ui->advOutEncoder->addItem(qName, qType);
+		if (is_streaming_codec) {
+			ui->advOutEncoder->addItem(qName, qType);
+		} else {
+			blog(LOG_DEBUG, "Encoder '%s' with codec '%s' is not yet supported for streaming and will be hidden.", name, codec);
+		}
 		ui->advOutRecEncoder->addItem(qName, qType);
 	}
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -145,7 +145,7 @@ static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 	obs_data_release(settings);
 
 	dstr_catf(cmd, "%s %d %d %d %d %d ",
-			"h264",
+			obs_encoder_get_codec(vencoder),
 			bitrate,
 			obs_output_get_width(stream->output),
 			obs_output_get_height(stream->output),


### PR DESCRIPTION
This will make the encoder shown in the recording tab, but stay hidden in the streaming tab until it is officially supported by a streaming format. WebRTC seems to be the only one that is capable of this, even if not officially.
The recording tab will also now show all encoders that get listed, so if someone ever adds VP8 or VP9, it'll be there and work (given that the codec field matches the ffmpeg AVCodec name).