### PR TITLE
fix bug: some Chinese font would not render

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -288,6 +288,7 @@ void TextSource::UpdateFont()
 	lf.lfUnderline = underline;
 	lf.lfStrikeOut = strikeout;
 	lf.lfQuality = ANTIALIASED_QUALITY;
+	lf.lfCharSet = DEFAULT_CHARSET;
 
 	if (!face.empty()) {
 		wcscpy(lf.lfFaceName, face.c_str());


### PR DESCRIPTION
Some Chinese font for example "STHupo" ( 华文琥珀 ) won't render any character in GDI+ text source.