### PR TITLE
Fix GameCapture incompatibility with theHunter: Call of the Wild

### DIFF
--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -38,7 +38,8 @@ static bool setup_dxgi(IDXGISwapChain *swap)
 	 * quite know. */
 	if (_strcmpi(process_name, "iw6sp64_ship.exe") == 0 ||
 	    _strcmpi(process_name, "iw6mp64_ship.exe") == 0 ||
-	    _strcmpi(process_name, "justcause3.exe") == 0) {
+	    _strcmpi(process_name, "justcause3.exe") == 0 ||
+	    _strcmpi(process_name, "theHunterCotW_F.exe") == 0) {
 		ignore_d3d10 = true;
 	}
 


### PR DESCRIPTION
Adds an exception to skip d3d10 checks for theHunter: Call of the Wild, which fixes the incompatibility with the Game Capture plugin.