### PR TITLE
CI: Retry failed downloads

### DIFF
--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -1,7 +1,10 @@
+# Exit if something fails
+set -e
+
 # Leave obs-studio folder
 cd ../
 
-curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg
+curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/Packages.pkg -f --retry 5 -C -
 sudo installer -pkg ./Packages.pkg -target /
 
 brew update
@@ -9,14 +12,14 @@ brew update
 #Base OBS Deps
 brew install qt5
 
-curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/osx-deps.tar.gz
+curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/osx-deps.tar.gz -f --retry 5 -C -
 tar -xf ./osx-deps.tar.gz -C /tmp
 
-curl -L -o vlc-master.zip https://github.com/videolan/vlc/archive/master.zip
+curl -L -o vlc-master.zip https://github.com/videolan/vlc/archive/master.zip -f --retry 5 -C -
 unzip -q ./vlc-master.zip
 
 # CEF Stuff
-curl -kLO http://opensource.spotify.com/cefbuilds/cef_binary_3.2883.1540.gedbfb20_macosx64.tar.bz2
+curl -kLO http://opensource.spotify.com/cefbuilds/cef_binary_3.2883.1540.gedbfb20_macosx64.tar.bz2 -f --retry 5 -C -
 tar -xf ./cef_binary_3.2883.1540.gedbfb20_macosx64.tar.bz2
 cd ./cef_binary_3.2883.1540.gedbfb20_macosx64
 mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
 install:
   - git submodule update --init --recursive
   - git clone https://github.com/videolan/vlc.git
-  - curl -kLO https://obsproject.com/downloads/dependencies2015.zip
+  - curl -kLO https://obsproject.com/downloads/dependencies2015.zip -f --retry 5 -C -
   - 7z x dependencies2015.zip -odependencies2015
   - set DepsPath32=%CD%\dependencies2015\win32
   - set DepsPath64=%CD%\dependencies2015\win64


### PR DESCRIPTION
Currently the build does not break if something goes wrong in the dependency installation phase. This leads to somewhat confusing error messages later on (e.g. [this build](https://travis-ci.org/jp9000/obs-studio/builds/202394716) could have been stopped [here](https://travis-ci.org/jp9000/obs-studio/builds/202394716#L918)).