### PR TITLE
UI: Fix ffmpeg output file extension

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2603,7 +2603,7 @@ void OBSBasicSettings::SaveFormat(QComboBox *combo)
 
 		char *comma = strchr(&extStr[0], ',');
 		if (comma)
-			comma = 0;
+			*comma = 0;
 
 		config_set_string(main->Config(), "AdvOut", "FFExtension",
 				extStr.c_str());


### PR DESCRIPTION
Trying to output to a container with multiple extensions currently results in the container having all file extensions  (e.g. mpegts results in the file extension being `.ts,m2t,m2ts,mts`).

This just fixes that by adding a missing `*`.