### PR TITLE
CI: Various AppVeyor build speed improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,10 @@ environment:
 
 install:
   - git submodule update --init --recursive
-  - git clone https://github.com/videolan/vlc.git
   - curl -kLO https://obsproject.com/downloads/dependencies2015.zip -f --retry 5 -C -
+  - curl -kLO https://obsproject.com/downloads/vlc.zip -f --retry 5 -C -
   - 7z x dependencies2015.zip -odependencies2015
+  - 7z x vlc.zip -ovlc
   - set DepsPath32=%CD%\dependencies2015\win32
   - set DepsPath64=%CD%\dependencies2015\win64
   - set VLCPath=%CD%\vlc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,3 +33,5 @@ before_deploy:
 
 deploy_script:
   - ps: Push-AppveyorArtifact "build.zip" -FileName "$(git describe).zip"
+
+test: off


### PR DESCRIPTION
Downloading the VLC repo as zip and extracting it is a good amount faster than cloning the git repo.

Also disable test discovery in AppVeyor. We aren't using it and this will also take a few seconds.