### PR TITLE
CI: Use ccache to speed up the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+cache:
+  ccache: true
+
 env:
   global:
   # AWS S3 creds
@@ -7,6 +10,12 @@ env:
   - secure: "MfhOg+84yb4ZHB2tM8PIPFQX2Y+WLN0I0iiAgyLC4KaHPUoNOyloe9yk6OjV7Lj7SZWqTlQUsqHa8S9mOUswGIody1Ydglo4RvyGOKCd8I6b2ri/jE8qHVuD9sO+sNlIxq4YqqG/qReTsbSs2YEgLneZUCYLCk/fihl8L6eVuSc="
   # secret
   - secure: "JRQVU2zgC3hY6CEY+Crmh/upp93En0BzKaLcsuBT538johNlK7m5hn3m2UOw63seLvBvVaKKWUDj9N986a3DwcXxWPMyF/9ctXgNWy39WzaVWxrbVR5nQB1fdiRp5YEgkoVN+gEm3OVF7sV5AGzh5/8CvEdRCoTLIGgMGHxW9mc="
+
+  # ccache
+  - USE_CCACHE=1
+  - CCACHE_COMPRESS=1
+  - CCACHE_MAXSIZE=200M
+  - CCACHE_CPP2=1
 
 matrix:
   include:

--- a/CI/before-script-linux.sh
+++ b/CI/before-script-linux.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -ex
 
+ccache -s || echo "CCache is not available."
 mkdir build && cd build
 cmake ..

--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -1,3 +1,6 @@
+# Make sure ccache is found
+export PATH=/usr/local/opt/ccache/libexec:$PATH
+
 mkdir build
 cd build
 cmake -DENABLE_SPARKLE_UPDATER=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DDepsPath=/tmp/obsdeps -DVLCPath=$PWD/../../vlc-master -DBUILD_BROWSER=ON -DCEF_ROOT_DIR=$PWD/../../cef_binary_${CEF_BUILD_VERSION}_macosx64 ..

--- a/CI/install-dependencies-osx.sh
+++ b/CI/install-dependencies-osx.sh
@@ -13,8 +13,11 @@ sudo installer -pkg ./Packages.pkg -target /
 
 brew update
 
-#Base OBS Deps
-brew install qt5 jack speexdsp
+#Base OBS Deps and ccache
+brew install qt5 jack speexdsp ccache
+
+export PATH=/usr/local/opt/ccache/libexec:$PATH
+ccache -s || echo "CCache is not available."
 
 # Fetch and untar prebuilt OBS deps that are compatible with older versions of OSX
 curl -L -O https://s3-us-west-2.amazonaws.com/obs-nightly/osx-deps.tar.gz -f --retry 5 -C -


### PR DESCRIPTION
Uses [ccache](https://ccache.samba.org/manual.html#_description) to speed up recompilation.