### PR TITLE
Travis CI IRC Notifications fixing and reformatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,5 @@ notifications:
       - "%{message} %{build_url}"
     channels:
       - secure: k9j7+ogVODMlveZdd5pP73AVLCFl1VbzVaVon0ECn3EQcxnLSpiZbc6l+PnIUKgee5pRKtUB4breufgmr4puq3s69YeQiOVKk5gx2yJGZ5jGacbSne0xTspzPxapiEbVUkcJ2L7gKntDG4+SUiW67dtt4G26O7zsErDF/lY/woQ=
+    on_failure: always
+    on_success: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ notifications:
   irc:
     skip_join: false
     template:
-      - "%{message} %{build_url}"
+      - "[Travis CI|%{result}] %{repository_name}/%{branch} (%{author} - %{commit_subject}) %{build_url}"
     channels:
       - secure: k9j7+ogVODMlveZdd5pP73AVLCFl1VbzVaVon0ECn3EQcxnLSpiZbc6l+PnIUKgee5pRKtUB4breufgmr4puq3s69YeQiOVKk5gx2yJGZ5jGacbSne0xTspzPxapiEbVUkcJ2L7gKntDG4+SUiW67dtt4G26O7zsErDF/lY/woQ=
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ deploy:
 # The channel name "azubu.il.us.quakenet.org#obs-dev" is encrypted against jp9000/obs-studio to prevent IRC spam of forks
 notifications:
   irc:
-    skip_join: true
+    skip_join: false
     template:
       - "%{message} %{build_url}"
     channels:


### PR DESCRIPTION
This PR will:

- Disable skip_join This isn't working with obs-dev on QuakeNet because external messages aren't allowed.

- Always notify on failure and only on builds/commits that fixed the build.

- Reformat the IRC message to something like this:

[Travis CI|passed] obs-studio/master (Gol-D-Ace - Commit title) https://travis-ci.org/jp9000/obs-studio/builds/buildid

This is most likely only temporary until our bot OBScommits can handle it.