### PR TITLE
Removed code that prevented OBS Browser from receiving flags

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1807,11 +1807,6 @@ int main(int argc, char *argv[])
 				App()->GetVersionString() << "\n";
 			exit(0);
 
-		} else {
-			std::cout << 
-				"Invalid arguments. Use --help or -h to get " << 
-				"a list of available command line arguments.\n";
-			exit(0);
 		}
 	}
 


### PR DESCRIPTION
Command line argument handling added to UI/obs-app.cpp would do a hard exit if it was given a flag it didn't recognize. This would prevent the Browser Source from receiving switches, such as "--enable-gpu" and result in OBS failing to start.