### PR TITLE
libobs: Remove unimplemented export in obs.h

### DIFF
--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1389,12 +1389,6 @@ EXPORT signal_handler_t *obs_output_get_signal_handler(
 EXPORT proc_handler_t *obs_output_get_proc_handler(const obs_output_t *output);
 
 /**
- * Sets the current video media context associated with this output,
- * required for non-encoded outputs
- */
-EXPORT void obs_output_set_video(obs_output_t *output, video_t *video);
-
-/**
  * Sets the current audio/video media contexts associated with this output,
  * required for non-encoded outputs.  Can be null.
  */


### PR DESCRIPTION
Removes obs_output_set_video which is not implemented and therefore not actually exported.

There is no obs_output_set_audio but there is an obs_output_set_media which takes an audio and video input. Not sure if both obs_output_set_media and this should go or if the obs_output_set_audio/video analog of obs_output_set_media should be implemented. But at the very least trying link against this function will fail.