### PR TITLE
UI: Adding two new command line argument

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -69,6 +69,10 @@ bool opt_start_recording = false;
 bool opt_studio_mode = false;
 bool opt_start_replaybuffer = false;
 bool opt_minimize_tray = false;
+
+bool opt_lessui = false;
+bool opt_always_on_top = false;
+
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
@@ -1755,7 +1759,7 @@ int main(int argc, char *argv[])
 
 		} else if (arg_is(argv[i], "--verbose", nullptr)) {
 			log_verbose = true;
-			
+
 		} else if (arg_is(argv[i], "--always-on-top", nullptr)) {
 			opt_always_on_top = true;
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -70,7 +70,7 @@ bool opt_studio_mode = false;
 bool opt_start_replaybuffer = false;
 bool opt_minimize_tray = false;
 
-bool opt_lessui = false;
+bool opt_minimal = false;
 bool opt_always_on_top = false;
 
 string opt_starting_collection;
@@ -1763,8 +1763,8 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--always-on-top", nullptr)) {
 			opt_always_on_top = true;
 
-		} else if (arg_is(argv[i], "--less-ui", nullptr)) {
-			opt_lessui = true;
+		} else if (arg_is(argv[i], "--minimal", nullptr)) {
+			opt_minimal = true;
 
 		} else if (arg_is(argv[i], "--unfiltered_log", nullptr)) {
 			unfiltered_log = true;
@@ -1808,7 +1808,7 @@ int main(int argc, char *argv[])
 			"--portable, -p: Use portable mode.\n\n" <<
 			"--verbose: Make log more verbose.\n" <<
 			"--unfiltered_log: Make log unfiltered.\n" <<
-			"--less-ui: Show less UI.\n" <<
+			"--minimal: Show less UI.\n" <<
 			"--always-on-top: Show the UI always on top.\n\n" <<
 			"--version, -V: Get current version.\n";
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1755,6 +1755,12 @@ int main(int argc, char *argv[])
 
 		} else if (arg_is(argv[i], "--verbose", nullptr)) {
 			log_verbose = true;
+			
+		} else if (arg_is(argv[i], "--always-on-top", nullptr)) {
+			opt_always_on_top = true;
+
+		} else if (arg_is(argv[i], "--less-ui", nullptr)) {
+			opt_lessui = true;
 
 		} else if (arg_is(argv[i], "--unfiltered_log", nullptr)) {
 			unfiltered_log = true;
@@ -1785,7 +1791,7 @@ int main(int argc, char *argv[])
 
 		} else if (arg_is(argv[i], "--help", "-h")) {
 			std::cout <<
-			"--help, -h: Get list of available commands.\n\n" << 
+			"--help, -h: Get list of available commands.\n\n" <<
 			"--startstreaming: Automatically start streaming.\n" <<
 			"--startrecording: Automatically start recording.\n" <<
 			"--startreplaybuffer: Start replay buffer.\n\n" <<
@@ -1797,13 +1803,15 @@ int main(int argc, char *argv[])
 			"--minimize-to-tray: Minimize to system tray.\n" <<
 			"--portable, -p: Use portable mode.\n\n" <<
 			"--verbose: Make log more verbose.\n" <<
-			"--unfiltered_log: Make log unfiltered.\n\n" <<
+			"--unfiltered_log: Make log unfiltered.\n" <<
+			"--less-ui: Show less UI.\n" <<
+			"--always-on-top: Show the UI always on top.\n\n" <<
 			"--version, -V: Get current version.\n";
 
 			exit(0);
 
 		} else if (arg_is(argv[i], "--version", "-V")) {
-			std::cout << "OBS Studio - " << 
+			std::cout << "OBS Studio - " <<
 				App()->GetVersionString() << "\n";
 			exit(0);
 		}

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -182,3 +182,6 @@ extern bool opt_start_replaybuffer;
 extern bool opt_minimize_tray;
 extern bool opt_studio_mode;
 extern std::string opt_starting_scene;
+extern bool opt_lessui; // Customer requirement for some company requirement
+extern bool opt_always_on_top;
+

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -182,6 +182,5 @@ extern bool opt_start_replaybuffer;
 extern bool opt_minimize_tray;
 extern bool opt_studio_mode;
 extern std::string opt_starting_scene;
-extern bool opt_lessui; // Customer requirement for some company requirement
+extern bool opt_minimal; // Customer requirement for some company requirement
 extern bool opt_always_on_top;
-

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -319,7 +319,7 @@ void OBSBasic::SetTransition(OBSSource transition)
 		obs_source_release(oldTransition);
 
 	bool fixed = transition ? obs_transition_fixed(transition) : false;
-	if(opt_lessui) {
+	if(opt_minimal) {
 		// Customer requirement for some company requirement
 	} else {
 		ui->transitionDurationLabel->setVisible(!fixed);

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -250,7 +250,7 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force)
 		return;
 
 	OBSWeakSource lastProgramScene;
-	
+
 	if (usingPreviewProgram) {
 		lastProgramScene = programScene;
 		programScene = OBSGetWeakRef(source);
@@ -319,8 +319,12 @@ void OBSBasic::SetTransition(OBSSource transition)
 		obs_source_release(oldTransition);
 
 	bool fixed = transition ? obs_transition_fixed(transition) : false;
-	ui->transitionDurationLabel->setVisible(!fixed);
-	ui->transitionDuration->setVisible(!fixed);
+	if(opt_lessui) {
+		// Customer requirement for some company requirement
+	} else {
+		ui->transitionDurationLabel->setVisible(!fixed);
+		ui->transitionDuration->setVisible(!fixed);
+	}
 
 	bool configurable = obs_source_configurable(transition);
 	ui->transitionRemove->setEnabled(configurable);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -813,6 +813,27 @@ retryScene:
 		opt_start_replaybuffer = false;
 	}
 
+	if(opt_lessui) {
+		ui->scenesLabel->setVisible(false);
+		ui->scenes->setVisible(false);
+		ui->scenesToolbar->setVisible(false);
+		ui->scenesFrame->setVisible(false);
+		ui->sceneTransitionsLabel->setVisible(false);
+		ui->transitions->setVisible(false);
+		ui->transitionAdd->setVisible(false);
+		ui->transitionRemove->setVisible(false);
+		ui->transitionProps->setVisible(false);
+		ui->transitionDurationLabel->setVisible(false);
+		ui->transitionDuration->setVisible(false);
+		ui->settingsButton->setVisible(false);
+		ui->modeSwitch->setVisible(false);
+	}
+
+	if (opt_always_on_top) {
+		SetAlwaysOnTop(this, true);
+		ui->actionAlwaysOnTop->setChecked(true);
+	}
+
 	LogScenes();
 
 	disableSaving--;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -813,7 +813,7 @@ retryScene:
 		opt_start_replaybuffer = false;
 	}
 
-	if(opt_lessui) {
+	if(opt_minimal) {
 		ui->scenesLabel->setVisible(false);
 		ui->scenes->setVisible(false);
 		ui->scenesToolbar->setVisible(false);


### PR DESCRIPTION
Two new command line argument is applied for example:

```
./obs --less-ui --always-on-top
```

**--less-ui**: is a custom requirement for a project i am working on where i need to show less UI
**--always-on-top**: is an option to set the UI always on top, such as in kiosk usage

I have already tested in OSX, Windows 10, CentOS 7 and had no issues. Please let me know if its accepted and implemented.


