### PR TITLE
UI: Fix segfault in Linux when no system tray exists

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2916,13 +2916,15 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 
 void OBSBasic::changeEvent(QEvent *event)
 {
-	if (event->type() == QEvent::WindowStateChange &&
-	    isMinimized() &&
-	    trayIcon->isVisible() &&
-	    sysTrayMinimizeToTray()) {
+  if (trayIcon) {
+	  if (event->type() == QEvent::WindowStateChange &&
+	      isMinimized() &&
+	      trayIcon->isVisible() &&
+	      sysTrayMinimizeToTray()) {
 
-		ToggleShowHide();
-	}
+	  	ToggleShowHide();
+	  }
+  }
 }
 
 void OBSBasic::on_actionShow_Recordings_triggered()


### PR DESCRIPTION
previously, switching workspaces while obs-studio is running resulted in a
segfault if no system tray was available

introduced as of abe4bfd96ecb4716eee4484ed82f3d78c9579cc9