### PR TITLE
UI: Fix segfault when no system tray exists

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2918,6 +2918,7 @@ void OBSBasic::changeEvent(QEvent *event)
 {
 	if (event->type() == QEvent::WindowStateChange &&
 	    isMinimized() &&
+	    trayIcon &&
 	    trayIcon->isVisible() &&
 	    sysTrayMinimizeToTray()) {
 


### PR DESCRIPTION
Previously, minimizing obs-studio in any linux window manager without a system tray resulted in a segfault! This simple fix changes that.

also happens when switching workspaces in a tiling wm like xmonad

Bug introduced as of abe4bfd