### PR TITLE
UI: add different styles to main buttons

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -126,6 +126,9 @@
             <property name="checkable">
              <bool>false</bool>
             </property>
+            <property name="themeID" stdset="0">
+                <string notr="true">startStreaming</string>
+            </property>
            </widget>
           </item>
           <item>
@@ -147,6 +150,9 @@
             </property>
             <property name="text">
              <string>Basic.Main.StartRecording</string>
+            </property>
+            <property name="themeID" stdset="0">
+                <string notr="true">startRecording</string>
             </property>
            </widget>
           </item>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1189,6 +1189,10 @@ void OBSBasic::ResetOutputs()
 					&QPushButton::clicked,
 					this,
 					&OBSBasic::ReplayBufferClicked);
+			//use themeID="startReplayBuffer" property to customize button style
+			replayBufferButton->setProperty("themeID", "startReplayBuffer");
+			//update style cache by forcing setStyleSheet() with comment string inside
+			replayBufferButton->setStyleSheet("/**/");
 
 			ui->buttonsVLayout->insertWidget(2, replayBufferButton);
 		}
@@ -3854,6 +3858,10 @@ void OBSBasic::StartStreaming()
 
 	ui->streamButton->setEnabled(false);
 	ui->streamButton->setText(QTStr("Basic.Main.Connecting"));
+	//use themeID="Connecting" property to customize button style
+	ui->streamButton->setProperty("themeID", "Connecting");
+	//update style cache by forcing setStyleSheet() with comment string inside
+	ui->streamButton->setStyleSheet("/**/");
 
 	if (sysTrayStream) {
 		sysTrayStream->setEnabled(false);
@@ -3863,6 +3871,8 @@ void OBSBasic::StartStreaming()
 	if (!outputHandler->StartStreaming(service)) {
 		ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
 		ui->streamButton->setEnabled(true);
+		ui->streamButton->setProperty("themeID", "startStreaming");
+		ui->streamButton->setStyleSheet("/**/");
 
 		if (sysTrayStream) {
 			sysTrayStream->setText(ui->streamButton->text());
@@ -3983,6 +3993,8 @@ void OBSBasic::StreamDelayStarting(int sec)
 {
 	ui->streamButton->setText(QTStr("Basic.Main.StopStreaming"));
 	ui->streamButton->setEnabled(true);
+	ui->streamButton->setProperty("themeID", "stopStreaming");
+	ui->streamButton->setStyleSheet("/**/");
 
 	if (sysTrayStream) {
 		sysTrayStream->setText(ui->streamButton->text());
@@ -4008,6 +4020,8 @@ void OBSBasic::StreamDelayStopping(int sec)
 {
 	ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
 	ui->streamButton->setEnabled(true);
+	ui->streamButton->setProperty("themeID", "startStreaming");
+	ui->streamButton->setStyleSheet("/**/");
 
 	if (sysTrayStream) {
 		sysTrayStream->setText(ui->streamButton->text());
@@ -4031,6 +4045,8 @@ void OBSBasic::StreamingStart()
 {
 	ui->streamButton->setText(QTStr("Basic.Main.StopStreaming"));
 	ui->streamButton->setEnabled(true);
+	ui->streamButton->setProperty("themeID", "stopStreaming");
+	ui->streamButton->setStyleSheet("/**/");
 	ui->statusbar->StreamStarted(outputHandler->streamOutput);
 
 	if (sysTrayStream) {
@@ -4049,6 +4065,8 @@ void OBSBasic::StreamingStart()
 void OBSBasic::StreamStopping()
 {
 	ui->streamButton->setText(QTStr("Basic.Main.StoppingStreaming"));
+	ui->streamButton->setProperty("themeID", "stoppingStreaming");
+	ui->streamButton->setStyleSheet("/**/");
 
 	if (sysTrayStream)
 		sysTrayStream->setText(ui->streamButton->text());
@@ -4090,6 +4108,8 @@ void OBSBasic::StreamingStop(int code)
 
 	ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
 	ui->streamButton->setEnabled(true);
+	ui->streamButton->setProperty("themeID", "startStreaming");
+	ui->streamButton->setStyleSheet("/**/");
 
 	if (sysTrayStream) {
 		sysTrayStream->setText(ui->streamButton->text());
@@ -4134,6 +4154,10 @@ void OBSBasic::StartRecording()
 void OBSBasic::RecordStopping()
 {
 	ui->recordButton->setText(QTStr("Basic.Main.StoppingRecording"));
+	//use themeID="stoppingRecording" property to customize button style
+	ui->recordButton->setProperty("themeID", "stoppingRecording");
+	//update style cache by forcing setStyleSheet() with comment string inside
+	ui->recordButton->setStyleSheet("/**/");
 
 	if (sysTrayRecord)
 		sysTrayRecord->setText(ui->recordButton->text());
@@ -4157,6 +4181,8 @@ void OBSBasic::RecordingStart()
 {
 	ui->statusbar->RecordingStarted(outputHandler->fileOutput);
 	ui->recordButton->setText(QTStr("Basic.Main.StopRecording"));
+	ui->recordButton->setProperty("themeID", "stopRecording");
+	ui->recordButton->setStyleSheet("/**/");
 
 	if (sysTrayRecord)
 		sysTrayRecord->setText(ui->recordButton->text());
@@ -4174,6 +4200,8 @@ void OBSBasic::RecordingStop(int code)
 {
 	ui->statusbar->RecordingStopped();
 	ui->recordButton->setText(QTStr("Basic.Main.StartRecording"));
+	ui->recordButton->setProperty("themeID", "startRecording");
+	ui->recordButton->setStyleSheet("/**/");
 
 	if (sysTrayRecord)
 		sysTrayRecord->setText(ui->recordButton->text());
@@ -4252,6 +4280,8 @@ void OBSBasic::ReplayBufferStopping()
 		return;
 
 	replayBufferButton->setText(QTStr("Basic.Main.StoppingReplayBuffer"));
+	replayBufferButton->setProperty("themeID", "stoppingReplayBuffer");
+	replayBufferButton->setStyleSheet("/**/");
 
 	if (sysTrayReplayBuffer)
 		sysTrayReplayBuffer->setText(replayBufferButton->text());
@@ -4280,6 +4310,8 @@ void OBSBasic::ReplayBufferStart()
 		return;
 
 	replayBufferButton->setText(QTStr("Basic.Main.StopReplayBuffer"));
+	replayBufferButton->setProperty("themeID", "stopReplayBuffer");
+	replayBufferButton->setStyleSheet("/**/");
 
 	if (sysTrayReplayBuffer)
 		sysTrayReplayBuffer->setText(replayBufferButton->text());
@@ -4299,6 +4331,8 @@ void OBSBasic::ReplayBufferStop(int code)
 		return;
 
 	replayBufferButton->setText(QTStr("Basic.Main.StartReplayBuffer"));
+	replayBufferButton->setProperty("themeID", "startReplayBuffer");
+	replayBufferButton->setStyleSheet("/**/");
 
 	if (sysTrayReplayBuffer)
 		sysTrayReplayBuffer->setText(replayBufferButton->text());


### PR DESCRIPTION
Add support to use different styles for Streaming/Recording/ReplayBuffer buttons.
Each role of the button (Start/Connecting/Stopping/Stop) has different style property now.