### PR TITLE
image-source: Move file modification check before animation processing

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -162,6 +162,17 @@ static void image_source_tick(void *data, float seconds)
 	struct image_source *context = data;
 	uint64_t frame_time = obs_get_video_frame_time();
 
+	context->update_time_elapsed += seconds;
+
+	if (context->update_time_elapsed >= 1.0f) {
+		time_t t = get_modified_timestamp(context->file);
+		context->update_time_elapsed = 0.0f;
+
+		if (context->file_timestamp != t) {
+			image_source_load(context);
+		}
+	}
+
 	if (obs_source_active(context->source)) {
 		if (!context->active) {
 			if (context->image.is_animated_gif)
@@ -199,17 +210,6 @@ static void image_source_tick(void *data, float seconds)
 	}
 
 	context->last_time = frame_time;
-
-	context->update_time_elapsed += seconds;
-
-	if (context->update_time_elapsed >= 1.0f) {
-		time_t t = get_modified_timestamp(context->file);
-		context->update_time_elapsed = 0.0f;
-
-		if (context->file_timestamp != t) {
-			image_source_load(context);
-		}
-	}
 }
 
 


### PR DESCRIPTION
The code to process GIF animations contained a return statement that
will skip the modification check, if the image is not in an active
scene. Like that images in the preview scene of studio mode would never
update, when they get modified on disk.

Also reloading the image, if an animation file has been modified before
processing the old animation that will be replaced later anyway, seems
like a better way to do it.