### PR TITLE
rtmp-services: Update ingest list for Restream.io

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 52,
+	"version": 53,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 52
+			"version": 53
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -637,6 +637,10 @@
                     "url": "rtmp://singapore.restream.io/live"
                 },
                 {
+                    "name": "Asia (Seoul, South Korea)",
+                    "url": "rtmp://seoul.restream.io/live"
+                },
+                {
                     "name": "Australia (Sydney)",
                     "url": "rtmp://au.restream.io/live"
                 }


### PR DESCRIPTION
Update ingest list for Restream.io:
- add new Restream server: Asia (Seoul, South Korea)
- update rtmp-services version

Restream ingests could be checked at: https://restream.io/ingests
