### PR TITLE
rtmp-services: Update maximum bitrate for Twitch

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 53,
+	"version": 54,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 53
+			"version": 54
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -136,7 +136,7 @@
             ],
             "recommended": {
                 "keyint": 2,
-                "max video bitrate": 3500,
+                "max video bitrate": 6000,
                 "max audio bitrate": 160,
                 "x264opts": "scenecut=0"
             }


### PR DESCRIPTION
Updated max 3.5 to 6. See https://help.twitch.tv/customer/portal/articles/1253460-broadcast-requirements#Broadcast%20Requirements
> Recommended bitrate range - 3-6 megabits per second