### PR TITLE
obs-ffmpeg-nvenc: remove "default" preset

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -384,7 +384,7 @@ static void nvenc_defaults(obs_data_t *settings)
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "cqp", 23);
 	obs_data_set_default_string(settings, "rate_control", "CBR");
-	obs_data_set_default_string(settings, "preset", "default");
+	obs_data_set_default_string(settings, "preset", "hq");
 	obs_data_set_default_string(settings, "profile", "main");
 	obs_data_set_default_string(settings, "level", "auto");
 	obs_data_set_default_bool(settings, "2pass", true);
@@ -448,7 +448,6 @@ static obs_properties_t *nvenc_properties(void *unused)
 #define add_preset(val) \
 	obs_property_list_add_string(p, obs_module_text("NVENC.Preset." val), \
 			val)
-	add_preset("default");
 	add_preset("hq");
 	add_preset("hp");
 	add_preset("bd");


### PR DESCRIPTION
The "default" preset is not an actual default, but something Nvidia decided to just call that way.
It yields the worst quality per bitrate out of all the presets, for no actual benefits.
The actual ffmpeg default is the hq one, which yields the best quality, specially when twopass mode is enabled.

I can't think of a way to keep the "default"-Preset in a non-confusing way, and as it gives no known benefits, might as well just remove it entirely.