### PR TITLE
rtmp-services: Update Picarto maximum bitrates

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 55,
+	"version": 56,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 55
+			"version": 56
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -842,8 +842,8 @@
             "recommended": {
                 "keyint": 2,
                 "profile": "main",
-                "max video bitrate": 2000,
-                "max audio bitrate": 160
+                "max video bitrate": 3500,
+                "max audio bitrate": 128
             }
         },
         {


### PR DESCRIPTION
Update maximum video bitrate for Picarto from 2000 to 3500 and maximum audio bitrate from 160 to 128.

See http://help.picarto.tv/knowledge_base/topics/how-to-configure-open-broadcaster-software:

> **2. Max bitrate should be set according to our streaming standards. But not more than 3500. Also it is very important that your bitrate is not higher than your own internet upload speed, otherwise you will suffer frame drops.**

> **3. Settings for Audio Encoding section:**
> 
> - Codec to: **AAC**
> - Format to: **48kHz**
> - Bitrate between **64 - 128** depending on your personal preference and internet bandwidth. (128 recommended)
> - Channel to: **stereo**

As always, feedback is appreciated.