### PR TITLE
libobs: Add source callback create2

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -597,10 +597,19 @@ void obs_register_source_s(const struct obs_source_info *info, size_t size)
 		}
 	}
 
+
+	if (((offsetof(struct obs_source_info, create) + sizeof(info->create) > size)
+	        || !info->create)
+	     && ((offsetof(struct obs_source_info, create2) + sizeof(info->create2) > size)
+	        || !info->create2)) {
+			blog(LOG_ERROR, "Required value 'create' or 'create2' for "
+			                "'%s' not found.  obs_register_source"
+			                " failed.", info->id);
+			goto error;
+	}
 #define CHECK_REQUIRED_VAL_(info, val, func) \
 	CHECK_REQUIRED_VAL(struct obs_source_info, info, val, func)
 	CHECK_REQUIRED_VAL_(info, get_name, obs_register_source);
-	CHECK_REQUIRED_VAL_(info, create,   obs_register_source);
 	CHECK_REQUIRED_VAL_(info, destroy,  obs_register_source);
 
 	if (info->type != OBS_SOURCE_TYPE_FILTER         &&

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -332,9 +332,14 @@ static obs_source_t *obs_source_create_internal(const char *id,
 
 	/* allow the source to be created even if creation fails so that the
 	 * user's data doesn't become lost */
-	if (info)
-		source->context.data = info->create(source->context.settings,
-				source);
+	if (info) {
+		if(info->create2) /* alow plugins to use type data during creation */
+			source->context.data = info->create2(source->context.settings,
+			                                     source, info->type_data);
+		else
+			source->context.data = info->create(source->context.settings,
+			                                    source);
+	}
 	if (!source->context.data)
 		blog(LOG_ERROR, "Failed to create source '%s'!", name);
 

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -423,6 +423,16 @@ struct obs_source_info {
 	void (*enum_all_sources)(void *data,
 			obs_source_enum_proc_t enum_callback,
 			void *param);
+
+	/**
+	 * Creates the source data for the source with type data.
+	 *
+	 * @param  settings  Settings to initialize the source with
+	 * @param  source    Source that this data is assoicated with
+	 * @param  type_data Data associated with this type of source
+	 * @return           The data associated with this source
+	 */
+	void *(*create2)(obs_data_t *settings, obs_source_t *source, void *type_data);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info,


### PR DESCRIPTION
Add an alternate create function for sources that will includes type
data for the source.