### PR TITLE
Audio-monitoring: Add ability to monitor Outputs.

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2599,6 +2599,22 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	QString newDevice = ui->monitoringDevice->currentData().toString();
 
 	if (lastMonitoringDevice != newDevice) {
+		QString desktopAudio = ui->desktopAudioDevice1->currentData().toString();
+		obs_source_t *source = nullptr;
+		if (desktopAudio == newDevice) {
+			source = obs_get_output_source(1);
+			obs_source_set_monitoring_type(source, OBS_MONITORING_TYPE_NONE);
+		}
+
+		desktopAudio = ui->desktopAudioDevice2->currentData().toString();
+		if (desktopAudio == newDevice) {
+			source = obs_get_output_source(2);
+			obs_source_set_monitoring_type(source, OBS_MONITORING_TYPE_NONE);
+		}
+
+		if (source)
+			obs_source_release(source);
+
 		obs_set_audio_monitoring_device(
 				QT_TO_UTF8(ui->monitoringDevice->currentText()),
 				QT_TO_UTF8(newDevice));

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3997,8 +3997,15 @@ void obs_source_set_monitoring_type(obs_source_t *source,
 
 	if (!obs_source_valid(source, "obs_source_set_monitoring_type"))
 		return;
-	if (source->info.output_flags & OBS_SOURCE_DO_NOT_MONITOR)
-		return;
+
+	if (source->info.output_flags & OBS_SOURCE_DO_NOT_SELF_MONITOR) {
+		obs_data_t* settings = obs_source_get_settings(source);
+		const char *curId = obs_data_get_string(settings, "device_id");
+		obs_data_release(settings);
+
+		if (strcmp(curId, obs->audio.monitoring_device_id) == 0)
+			return;
+	}
 	if (source->monitoring_type == type)
 		return;
 

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -123,10 +123,12 @@ enum obs_source_type {
 /**
  * Source cannot have its audio monitored
  *
- * Specifies that this source may cause a feedback loop if audio is monitored.
+ * Specifies that this source may cause a feedback loop if audio is monitored
+ * with a device selected as desktop audio.
+ *
  * This is used primarily with desktop audio capture sources.
  */
-#define OBS_SOURCE_DO_NOT_MONITOR (1<<9)
+#define OBS_SOURCE_DO_NOT_SELF_MONITOR (1<<9)
 
 /** @} */
 

--- a/plugins/linux-pulseaudio/pulse-input.c
+++ b/plugins/linux-pulseaudio/pulse-input.c
@@ -538,7 +538,7 @@ struct obs_source_info pulse_output_capture = {
 	.type           = OBS_SOURCE_TYPE_INPUT,
 	.output_flags   = OBS_SOURCE_AUDIO |
 	                  OBS_SOURCE_DO_NOT_DUPLICATE |
-	                  OBS_SOURCE_DO_NOT_MONITOR,
+	                  OBS_SOURCE_DO_NOT_SELF_MONITOR,
 	.get_name       = pulse_output_getname,
 	.create         = pulse_create,
 	.destroy        = pulse_destroy,

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -798,7 +798,7 @@ struct obs_source_info coreaudio_output_capture_info = {
 	.type           = OBS_SOURCE_TYPE_INPUT,
 	.output_flags   = OBS_SOURCE_AUDIO |
 	                  OBS_SOURCE_DO_NOT_DUPLICATE |
-	                  OBS_SOURCE_DO_NOT_MONITOR,
+	                  OBS_SOURCE_DO_NOT_SELF_MONITOR,
 	.get_name       = coreaudio_output_getname,
 	.create         = coreaudio_create_output_capture,
 	.destroy        = coreaudio_destroy,

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -590,7 +590,7 @@ void RegisterWASAPIOutput()
 	info.type            = OBS_SOURCE_TYPE_INPUT;
 	info.output_flags    = OBS_SOURCE_AUDIO |
 	                       OBS_SOURCE_DO_NOT_DUPLICATE |
-	                       OBS_SOURCE_DO_NOT_MONITOR;
+	                       OBS_SOURCE_DO_NOT_SELF_MONITOR;
 	info.get_name        = GetWASAPIOutputName;
 	info.create          = CreateWASAPIOutput;
 	info.destroy         = DestroyWASAPISource;


### PR DESCRIPTION
Do not prevent the targeted output device from being monitored if the selected monitor output device is a different one.