### PR TITLE
UI: Add window name to remux dialog

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -65,6 +65,7 @@ Copy="Copy"
 Paste="Paste"
 PasteReference="Paste (Reference)"
 PasteDuplicate="Paste (Duplicate)"
+RemuxRecordings="Remux Recordings"
 
 # copy filters
 Copy.Filters="Copy Filters"

--- a/UI/forms/OBSRemux.ui
+++ b/UI/forms/OBSRemux.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>RemuxRecordings</string>
   </property>
   <widget class="QProgressBar" name="progressBar">
    <property name="geometry">


### PR DESCRIPTION
Currently "Dialog" is the window name. This changes it to "Remux Recordings."