### PR TITLE
obs-outputs: reset status of RTMP when connect

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -861,6 +861,9 @@ static bool rtmp_stream_start(void *data)
 {
 	struct rtmp_stream *stream = data;
 
+	RTMP_Close(&stream->rtmp);
+	RTMP_Init(&stream->rtmp);
+
 	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
 	if (!obs_output_initialize_encoders(stream->output, 0))


### PR DESCRIPTION
When connect to the RTMP server for the second time,
obs reuse the previous created RTMP instance.
It will lose synchronization of internal status with server.

For example, RTMP server requested to change chunk size to 60000
while the default value is 128. When connecting for the second time,
The RTMP instance will assume the chunk size is 60000 instead of 128
and RTMP packet data will fail to parse.