### PR TITLE
win-capture: Window capture priority fix

### DIFF
--- a/plugins/win-capture/window-helpers.c
+++ b/plugins/win-capture/window-helpers.c
@@ -349,7 +349,7 @@ static int window_rating(HWND window,
 	struct dstr cur_exe   = {0};
 	int         class_val = 1;
 	int         title_val = 1;
-	int         exe_val   = 0;
+	int         exe_val   = 1;
 	int         total     = 0;
 
 	if (!get_window_exe(&cur_exe, window))
@@ -381,7 +381,11 @@ static int window_rating(HWND window,
 	dstr_free(&cur_title);
 	dstr_free(&cur_exe);
 
-	return total;
+	/*
+	 * If we don't have a total of at least 4 (1 base + 3 selected priority),
+	 * then the window is a partial match of the non-selected priority.
+	 */
+	return total < 4 ? 0 : total;
 }
 
 HWND find_window(enum window_search_mode mode,


### PR DESCRIPTION
With the current implementation of `window_rating`, it is possible for a window capture to select another window with only a partial match (a match of the non-selected `Window Match Priority`).

This is counter-intuitive behavior and allows for unintended windows to be captured.

In my specific situation, I had a cmd window I wanted to capture. It had a title of `file:///...some.exe`. I created a Window Capture, selected a `Window Match Priority` of `Window Title`.

I also have numerous other unrelated cmd windows open.

When the captured window closed, despite having `Window Title` selected as the `Window Match Priority`, it chose to capture one of the random unrelated cmd windows (because the `Window Class` of `ConsoleWindowClass` matched on them).

The commits change this to require that a match of the selected `Window Match Priority` for the window to be considered at all.

If partial matches should be allowed, an option to enable the old behavior (or enable the new behavior) could be added. But I really don't feel that's intended.

Here are some posts I found when I originally tried to find out why this was happening:
* https://obsproject.com/forum/threads/wrong-window-capture-on-scene-load.54450/
* https://obsproject.com/forum/threads/window-capture-refocuses-on-wrong-window-if-original-window-is-closed-with-some-software.40435/
* https://obsproject.com/forum/threads/obs-shows-wrong-window-in-stream.29122/