### PR TITLE
Frontend API: add functions to get, set and save RTMP settings

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -354,6 +354,21 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		App()->PopUITranslation();
 	}
 
+	void obs_frontend_set_streaming_service(obs_service_t *service) override
+	{
+		main->SetService(service);
+	}
+	
+	obs_service_t *obs_frontend_get_streaming_service(void) override
+	{
+		return main->GetService();
+	}
+	
+	void obs_frontend_save_streaming_service(void) override
+	{
+		main->SaveService();
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (auto cb : saveCallbacks)

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -317,3 +317,22 @@ void obs_frontend_pop_ui_translation(void)
 	if (callbacks_valid())
 		c->obs_frontend_pop_ui_translation();
 }
+
+void obs_frontend_set_streaming_service(obs_service_t *service)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_streaming_service(service);
+}
+
+obs_service_t* obs_frontend_get_streaming_service(void)
+{
+	return !!callbacks_valid()
+		? c->obs_frontend_get_streaming_service()
+		: nullptr;
+}
+
+void obs_frontend_save_streaming_service(void)
+{
+	if (callbacks_valid())
+		c->obs_frontend_save_streaming_service();
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -137,6 +137,11 @@ EXPORT void obs_frontend_push_ui_translation(
 		obs_frontend_translate_ui_cb translate);
 EXPORT void obs_frontend_pop_ui_translation(void);
 
+EXPORT void obs_frontend_set_streaming_service(
+		obs_service_t *service);
+EXPORT obs_service_t* obs_frontend_get_streaming_service(void);
+EXPORT void obs_frontend_save_streaming_service(void);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -70,6 +70,11 @@ struct obs_frontend_callbacks {
 			obs_frontend_translate_ui_cb translate)=0;
 	virtual void obs_frontend_pop_ui_translation(void)=0;
 
+	virtual void obs_frontend_set_streaming_service(
+			obs_service_t *service)=0;
+	virtual obs_service_t *obs_frontend_get_streaming_service(void)=0;
+	virtual void obs_frontend_save_streaming_service()=0;
+
 	virtual void on_load(obs_data_t *settings)=0;
 	virtual void on_save(obs_data_t *settings)=0;
 	virtual void on_event(enum obs_frontend_event event)=0;


### PR DESCRIPTION
This Pull Request aims to add three new functions to the Frontend API that add the ability to control the RTMP settings from code : 

`void obs_frontend_set_streaming_service(obs_service_t *service)`
This function changes the current service (set of RTMP settings and credentials) to the specified one.

`obs_service_t* obs_frontend_get_streaming_service(void)`
This function return the current service.

`void obs_frontend_save_streaming_service()`
This function saves to disk the current service. This would usually be done after calling `obs_frontend_set_streaming_service`