### PR TITLE
UI: Ctrl+E to "Edit Transform"

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1188,6 +1188,9 @@
    <property name="text">
     <string>Basic.MainMenu.Edit.Transform.EditTransform</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
+   </property>
   </action>
   <action name="actionCopyTransform">
    <property name="text">

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1187,7 +1187,7 @@
   <action name="actionEditTransform">
    <property name="text">
     <string>Basic.MainMenu.Edit.Transform.EditTransform</string>
-  </property>
+   </property>
    <property name="shortcut">
     <string>Ctrl+E</string>
    </property> 

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1188,9 +1188,6 @@
    <property name="text">
     <string>Basic.MainMenu.Edit.Transform.EditTransform</string>
    </property>
-   <property name="shortcut">
-    <string>Ctrl+E</string>
-   </property>
   </action>
   <action name="actionCopyTransform">
    <property name="text">

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1187,7 +1187,10 @@
   <action name="actionEditTransform">
    <property name="text">
     <string>Basic.MainMenu.Edit.Transform.EditTransform</string>
-   </property>
+  </property>
+   <property name="shortcut">
+    <string>Ctrl+E</string>
+   </property> 
   </action>
   <action name="actionCopyTransform">
    <property name="text">


### PR DESCRIPTION
Added a shortcut to "Edit Transform", with Ctrl+E (lines 1191-1193). Editing was very easy in OBS Classic, and I could not find the option for stretching a source to bounds in OBS Studio, so the "Edit Transform" dialogue should be more user-facing. Giving it a keyboard shortcut denotes that it is important enough to have a shortcut, as opposed to the myriad options with no shortcut.