### PR TITLE
libobs: Link with m and dl to fix underlinking

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -168,6 +168,11 @@ elseif(UNIX)
 		${libobs_PLATFORM_DEPS}
 		${X11_XCB_LIBRARIES})
 
+	set(libobs_PLATFORM_DEPS
+		${libobs_PLATFORM_DEPS}
+		m
+		dl)
+
 	if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 		# use the sysinfo compatibility library on bsd
 		find_package(Libsysinfo REQUIRED)


### PR DESCRIPTION
libobs uses symbols from libm (powf, asinf, atan2f, etc) and libdl (dlopen and friends), but it is not linked to them.