### PR TITLE
UI: Fix drag & drop bug

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -66,12 +66,22 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	switch (image) {
 	case DropType_RawText:
 		obs_data_set_string(settings, "text", data);
+#ifdef _WIN32
 		type = "text_gdiplus";
+#else
+		type = "text_ft2_source";
+#endif
 		break;
 	case DropType_Text:
+#ifdef _WIN32
 		obs_data_set_bool(settings, "read_from_file", true);
 		obs_data_set_string(settings, "file", data);
 		type = "text_gdiplus";
+#else
+		obs_data_set_bool(settings, "from_file", true);
+		obs_data_set_string(settings, "text_file", data);
+		type = "text_ft2_source";
+#endif
 		break;
 	case DropType_Image:
 		obs_data_set_string(settings, "file", data);


### PR DESCRIPTION
If user drags and drops text files on Mac & Linux, a segfault would happen because gdi would be selected instead of freetype.