### PR TITLE
rtmp-services: Update Twitch ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 56,
+	"version": 57,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 56
+			"version": 57
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -95,11 +95,11 @@
                 },
                 {
                     "name": "South America: Rio de Janeiro, Brazil",
-                    "url": "rtmp://live-gig.twitch.tv/app"
+                    "url": "rtmp://live-rio.twitch.tv/app"
                 },
                 {
                     "name": "South America: Sao Paulo, Brazil",
-                    "url": "rtmp://live-gru.twitch.tv/app"
+                    "url": "rtmp://live-sao.twitch.tv/app"
                 },
                 {
                     "name": "US Central: Dallas, TX",


### PR DESCRIPTION
Updated Sao Paulo and Rio de Janeiro ingest URLs

Might be worth asking twitch if the intention is to replace the old ones or offer additional ones since the old ones are still in the API response (kraken/ingests).