### PR TITLE
libobs-opengl: Log OpenGL version on all systems

### DIFF
--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -207,6 +207,9 @@ int device_create(gs_device_t **p_device, uint32_t adapter)
 	struct gs_device *device = bzalloc(sizeof(struct gs_device));
 	int errorcode = GS_ERROR_FAIL;
 
+	blog(LOG_INFO, "---------------------------------");
+	blog(LOG_INFO, "Initializing OpenGL...");
+
 	device->plat = gl_platform_create(device, adapter);
 	if (!device->plat)
 		goto fail;
@@ -215,6 +218,8 @@ int device_create(gs_device_t **p_device, uint32_t adapter)
 		errorcode = GS_ERROR_NOT_SUPPORTED;
 		goto fail;
 	}
+
+	blog(LOG_INFO, "OpenGL version: %s", glGetString(GL_VERSION));
 	
 	gl_enable(GL_CULL_FACE);
 	

--- a/libobs-opengl/gl-x11.c
+++ b/libobs-opengl/gl-x11.c
@@ -366,8 +366,6 @@ extern struct gl_platform *gl_platform_create(gs_device_t *device,
 		goto fail_load_gl;
 	}
 
-	blog(LOG_INFO, "OpenGL version: %s\n", glGetString(GL_VERSION));
-
 	goto success;
 
 fail_make_current:


### PR DESCRIPTION
This commit logs the OpenGL version on all operating systems and brings the OpenGL subsystem's initialization logging more in line with the D3D11 logging to make logs more uniform.

The warning for selecting OpenGL on Windows systems will still occur.  This is largely to make the logs more uniform across systems/settings.  Hopefully we'll see this less on Windows anyway with fdc9c47875b6f583865a5dd6200d089d53774145 and 67e5f6c54e6cc3e6896768e297e881ee7f2e2797.

Compiled and tested on Windows 10 64-bit.