### PR TITLE
Fix various typos across multiple modules

### DIFF
--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -108,7 +108,7 @@ public:
 	/* use libobs allocator for alignment because the matrices itemToScreen
 	 * and screenToItem may contain SSE data, which will cause SSE
 	 * instructions to crash if the data is not aligned to at least a 16
-	 * byte boundry. */
+	 * byte boundary. */
 	static inline void* operator new(size_t size) {return bmalloc(size);}
 	static inline void operator delete(void* ptr) {bfree(ptr);}
 };

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -253,7 +253,7 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 	if (FAILED(hr))
 		throw UnsupportedHWError("Failed to create device", hr);
 
-	blog(LOG_INFO, "D3D11 loaded sucessfully, feature level used: %u",
+	blog(LOG_INFO, "D3D11 loaded successfully, feature level used: %u",
 			(unsigned int)levelUsed);
 }
 
@@ -514,7 +514,7 @@ static inline void EnumD3DAdapters(
 		if (FAILED(hr))
 			continue;
 
-		/* ignore microsoft's 'basic' renderer' */
+		/* ignore Microsoft's 'basic' renderer' */
 		if (desc.VendorId == 0x1414 && desc.DeviceId == 0x8c)
 			continue;
 
@@ -586,7 +586,7 @@ static inline void LogD3DAdapters()
 		if (FAILED(hr))
 			continue;
 
-		/* ignore microsoft's 'basic' renderer' */
+		/* ignore Microsoft's 'basic' renderer' */
 		if (desc.VendorId == 0x1414 && desc.DeviceId == 0x8c)
 			continue;
 
@@ -608,7 +608,7 @@ int device_create(gs_device_t **p_device, uint32_t adapter)
 
 	try {
 		blog(LOG_INFO, "---------------------------------");
-		blog(LOG_INFO, "Initializing D3D11..");
+		blog(LOG_INFO, "Initializing D3D11...");
 		LogD3DAdapters();
 
 		device = new gs_device(adapter);

--- a/libobs-opengl/gl-stagesurf.c
+++ b/libobs-opengl/gl-stagesurf.c
@@ -29,7 +29,7 @@ static bool create_pixel_pack_buffer(struct gs_stage_surface *surf)
 		return false;
 
 	size  = surf->width * surf->bytes_per_pixel;
-	size  = (size+3) & 0xFFFFFFFC; /* align width to 4-byte boundry */
+	size  = (size+3) & 0xFFFFFFFC; /* align width to 4-byte boundary */
 	size *= surf->height;
 
 	glBufferData(GL_PIXEL_PACK_BUFFER, size, 0, GL_DYNAMIC_READ);
@@ -109,7 +109,7 @@ static bool can_stage(struct gs_stage_surface *dst, struct gs_texture_2d *src)
 #ifdef __APPLE__
 
 /* Apparently for mac, PBOs won't do an asynchronous transfer unless you use
- * FBOs aong with glReadPixels, which is really dumb. */
+ * FBOs along with glReadPixels, which is really dumb. */
 void device_stage_texture(gs_device_t *device, gs_stagesurf_t *dst,
 		gs_texture_t *src)
 {

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -69,7 +69,7 @@ static inline int get_stencil_format_bits(enum gs_zstencil_format zsformat)
 	}
 }
 
-/* would use designated initializers but microsoft sort of sucks */
+/* would use designated initializers but Microsoft sort of sucks */
 static inline void init_dummy_pixel_format(PIXELFORMATDESCRIPTOR *pfd)
 {
 	memset(pfd, 0, sizeof(PIXELFORMATDESCRIPTOR));

--- a/libobs/callback/calldata.h
+++ b/libobs/callback/calldata.h
@@ -89,7 +89,7 @@ static inline void calldata_clear(struct calldata *data)
 }
 
 /* ------------------------------------------------------------------------- */
-/* NOTE: 'get' functions return true only if paramter exists, and is the
+/* NOTE: 'get' functions return true only if parameter exists, and is the
  *       same type.  They return false otherwise. */
 
 static inline bool calldata_get_int(const calldata_t *data, const char *name,

--- a/libobs/callback/decl.c
+++ b/libobs/callback/decl.c
@@ -109,7 +109,7 @@ static int parse_param(struct cf_parser *cfp, struct decl_info *decl)
 	int                code;
 	struct decl_param  param = {0};
 
-	/* get stprage specifiers */
+	/* get storage specifiers */
 	code = cf_next_name_ref(cfp, &ref, TYPE_OR_STORAGE, ",");
 	if (code != PARSE_SUCCESS)
 		return code;
@@ -120,7 +120,7 @@ static int parse_param(struct cf_parser *cfp, struct decl_info *decl)
 			return code;
 	}
 
-	/* parameters not marked with specifers are input parameters */
+	/* parameters not marked with specifiers are input parameters */
 	if (param.flags == 0)
 		param.flags = CALL_PARAM_IN;
 
@@ -198,7 +198,7 @@ bool parse_decl_string(struct decl_info *decl, const char *decl_string)
 	ret_param.flags = CALL_PARAM_OUT;
 
 	cf_parser_init(&cfp);
-	if (!cf_parser_parse(&cfp, decl_string, "declaraion"))
+	if (!cf_parser_parse(&cfp, decl_string, "declaration"))
 		goto fail;
 
 	code = cf_get_name_ref(&cfp, &ret_type, "return type", NULL);

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -519,7 +519,7 @@ EXPORT uint8_t *gs_create_texture_file_data(const char *file,
  * Draws a 2D sprite
  *
  *   If width or height is 0, the width or height of the texture will be used.
- * The flip value specifies whether the texture shoudl be flipped on the U or V
+ * The flip value specifies whether the texture should be flipped on the U or V
  * axis with GS_FLIP_U and GS_FLIP_V.
  */
 EXPORT void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width,
@@ -534,7 +534,7 @@ EXPORT void gs_draw_cube_backdrop(gs_texture_t *cubetex, const struct quat *rot,
 /** sets the viewport to current swap chain size */
 EXPORT void gs_reset_viewport(void);
 
-/** sets default screen-sized orthographich mode */
+/** sets default screen-sized orthographic mode */
 EXPORT void gs_set_2d_mode(void);
 /** sets default screen-sized perspective mode */
 EXPORT void gs_set_3d_mode(double fovy, double znear, double zvar);

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -189,7 +189,7 @@ static inline void discard_audio(struct obs_core_audio *audio,
 		if (start_point == AUDIO_OUTPUT_FRAMES) {
 #if DEBUG_AUDIO == 1
 			if (is_audio_source)
-				blog(LOG_DEBUG, "can't dicard, start point is "
+				blog(LOG_DEBUG, "can't discard, start point is "
 						"at audio frame count");
 #endif
 			return;

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -184,7 +184,7 @@ struct obs_encoder_info {
 
 	/**
 	 * Updates the settings for this encoder (usually used for things like
-	 * changeing birate while active)
+	 * changing bitrate while active)
 	 *
 	 * @param  data      Data associated with this encoder context
 	 * @param  settings  New settings for this encoder

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -112,7 +112,7 @@ struct obs_hotkeys_translations {
  * that may not have translations.  If the operating system can provide
  * translations for these keys, it will use the operating system's translation
  * over these translations.  If no translations are specified, it will use
- * the default english translations for that specific operating system. */
+ * the default English translations for that specific operating system. */
 EXPORT void obs_hotkeys_set_translations_s(
 		struct obs_hotkeys_translations *translations, size_t size);
 

--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -90,7 +90,7 @@ bool obs_module_load(void)
  * may need loading.
  *
  * @return           Return true to continue loading the module, otherwise
- *                   false to indcate failure and unload the module
+ *                   false to indicate failure and unload the module
  */
 MODULE_EXPORT bool obs_module_load(void);
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1013,7 +1013,7 @@ static inline void send_interleaved(struct obs_output *output)
 	struct encoder_packet out = output->interleaved_packets.array[0];
 
 	/* do not send an interleaved packet if there's no packet of the
-	 * opposing type of a higher timstamp in the interleave buffer.
+	 * opposing type of a higher timestamp in the interleave buffer.
 	 * this ensures that the timestamps are monotonic */
 	if (!has_higher_opposing_ts(output, &out))
 		return;
@@ -2069,7 +2069,7 @@ void obs_output_output_caption_text1(obs_output_t *output, const char *text)
 	if (!active(output))
 		return;
 
-	// split text into  32 charcter strings
+	// split text into 32 character strings
 	int size = (int)strlen(text);
 	int r;
 	size_t char_count;

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -49,7 +49,7 @@ struct obs_scene_item {
 	uint32_t              align;
 
 	/* last width/height of the source, this is used to check whether
-	 * ths transform needs updating */
+	 * the transform needs updating */
 	uint32_t              last_width;
 	uint32_t              last_height;
 

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -173,7 +173,7 @@ struct obs_source_info {
 	 * Creates the source data for the source
 	 *
 	 * @param  settings  Settings to initialize the source with
-	 * @param  source    Source that this data is assoicated with
+	 * @param  source    Source that this data is associated with
 	 * @return           The data associated with this source
 	 */
 	void *(*create)(obs_data_t *settings, obs_source_t *source);
@@ -259,7 +259,7 @@ struct obs_source_info {
 	 * If the source output flags do not include SOURCE_CUSTOM_DRAW, all
 	 * a source needs to do is set the "image" parameter of the effect to
 	 * the desired texture, and then draw.  If the output flags include
-	 * SOURCE_COLOR_MATRIX, you may optionally set the the "color_matrix"
+	 * SOURCE_COLOR_MATRIX, you may optionally set the "color_matrix"
 	 * parameter of the effect to a custom 4x4 conversion matrix (by
 	 * default it will be set to an YUV->RGB conversion matrix)
 	 *
@@ -431,7 +431,7 @@ EXPORT void obs_register_source_s(const struct obs_source_info *info,
 		size_t size);
 
 /**
- * Regsiters a source definition to the current obs context.  This should be
+ * Registers a source definition to the current obs context.  This should be
  * used in obs_module_load.
  *
  * @param  info  Pointer to the source definition structure

--- a/libobs/obs-ui.h
+++ b/libobs/obs-ui.h
@@ -71,7 +71,7 @@ struct obs_modal_ui {
 };
 
 /**
- * Regsiters a modal UI definition to the current obs context.  This should be
+ * Registers a modal UI definition to the current obs context.  This should be
  * used in obs_module_load.
  *
  * @param  info  Pointer to the modal definition structure

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -279,15 +279,15 @@ EXPORT const char *obs_get_locale(void);
 EXPORT profiler_name_store_t *obs_get_profiler_name_store(void);
 
 /**
- * Sets base video ouput base resolution/fps/format.
+ * Sets base video output base resolution/fps/format.
  *
- * @note This data cannot be changed if an output is corrently active.
+ * @note This data cannot be changed if an output is currently active.
  * @note The graphics module cannot be changed without fully destroying the
  *       OBS context.
  *
  * @param   ovi  Pointer to an obs_video_info structure containing the
  *               specification of the graphics subsystem,
- * @return       OBS_VIDEO_SUCCESS if sucessful
+ * @return       OBS_VIDEO_SUCCESS if successful
  *               OBS_VIDEO_NOT_SUPPORTED if the adapter lacks capabilities
  *               OBS_VIDEO_INVALID_PARAM if a parameter is invalid
  *               OBS_VIDEO_CURRENTLY_ACTIVE if video is currently active
@@ -335,7 +335,7 @@ EXPORT int obs_open_module(obs_module_t **module, const char *path,
 
 /**
  * Initializes the module, which calls its obs_module_load export.  If the
- * module is alrady loaded, then this function does nothing and returns
+ * module is already loaded, then this function does nothing and returns
  * successful.
  */
 EXPORT bool obs_init_module(obs_module_t *module);
@@ -1171,7 +1171,7 @@ EXPORT void obs_transition_swap_end(obs_source_t *tr_dest,
  * Creates a scene.
  *
  *   A scene is a source which is a container of other sources with specific
- * display oriantations.  Scenes can also be used like any other source.
+ * display orientations.  Scenes can also be used like any other source.
  */
 EXPORT obs_scene_t *obs_scene_create(const char *name);
 
@@ -1233,7 +1233,7 @@ EXPORT obs_source_t *obs_sceneitem_get_source(const obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_select(obs_sceneitem_t *item, bool select);
 EXPORT bool obs_sceneitem_selected(const obs_sceneitem_t *item);
 
-/* Functions for gettings/setting specific orientation of a scene item */
+/* Functions for getting/setting specific orientation of a scene item */
 EXPORT void obs_sceneitem_set_pos(obs_sceneitem_t *item, const struct vec2 *pos);
 EXPORT void obs_sceneitem_set_rot(obs_sceneitem_t *item, float rot_deg);
 EXPORT void obs_sceneitem_set_scale(obs_sceneitem_t *item,

--- a/libobs/util/base.h
+++ b/libobs/util/base.h
@@ -49,13 +49,13 @@ enum {
 	 * Use if a problem occurs that doesn't affect the program and is
 	 * recoverable.
 	 *
-	 * Use in places where where failure isn't entirely unexpected, and can
+	 * Use in places where failure isn't entirely unexpected, and can
 	 * be handled safely.
 	 */
 	LOG_WARNING = 200,
 
 	/**
-	 * Informative essage to be displayed in the log.
+	 * Informative message to be displayed in the log.
 	 */
 	LOG_INFO    = 300,
 

--- a/libobs/util/c99defs.h
+++ b/libobs/util/c99defs.h
@@ -39,7 +39,7 @@
  * incredibly inept moron could possibly be managing the visual C compiler
  * project.  They should be fired, and legally forbidden to have a job in
  * ANYTHING even REMOTELY related to programming.  FOREVER.  This should also
- * apply to the next 10 generations all of their descendents. */
+ * apply to the next 10 generations all of their descendants. */
 #ifndef __cplusplus
 #define inline __inline
 #endif

--- a/libobs/util/cf-lexer.h
+++ b/libobs/util/cf-lexer.h
@@ -162,7 +162,7 @@ static inline void cf_def_free(struct cf_def *cfd)
  *   + option to exclude features such as #import, variadic macros, and other
  *     features for certain language implementations
  *   + macro parameter string operator #
- *   + macro parameter token concactenation operator ##
+ *   + macro parameter token concatenation operator ##
  *   + predefined macros
  *   + restricted macros
  */

--- a/libobs/util/config-file.h
+++ b/libobs/util/config-file.h
@@ -88,7 +88,7 @@ EXPORT bool config_remove_value(config_t *config, const char *section,
  * These do *not* actually set any values, they only set what values will be
  * returned for config_get_* if the specified variable does not exist.
  *
- * You can initialize the defaults programmitically using config_set_default_*
+ * You can initialize the defaults programmatically using config_set_default_*
  * functions (recommended for most cases), or you can initialize it via a file
  * with config_open_defaults.
  */

--- a/libobs/util/darray.h
+++ b/libobs/util/darray.h
@@ -33,7 +33,7 @@ extern "C" {
  * NOTE: Not type-safe when using directly.
  *       Specifying size per call with inline maximizes compiler optimizations
  *
- *       See DARRAY macro at the bottom of thhe file for slightly safer usage.
+ *       See DARRAY macro at the bottom of the file for slightly safer usage.
  */
 
 #define DARRAY_INVALID ((size_t)-1)
@@ -438,7 +438,7 @@ static inline void darray_swap(const size_t element_size,
  *       Makes it a little easier to use as well.
  *
  *       I did -not- want to use a gigantic macro to generate a crapload of
- *       typsafe inline functions per type.  It just feels like a mess to me.
+ *       typesafe inline functions per type.  It just feels like a mess to me.
  */
 
 #define DARRAY(type)                     \

--- a/libobs/util/text-lookup.h
+++ b/libobs/util/text-lookup.h
@@ -19,7 +19,7 @@
 /*
  * Text Lookup interface
  *
- *   Used for storing and looking up localized strings.  Stores locazation
+ *   Used for storing and looking up localized strings.  Stores localization
  * strings in a radix/trie tree to efficiently look up associated strings via a
  * unique string identifier name.
  */
@@ -30,7 +30,7 @@
 extern "C" {
 #endif
 
-/* opaque typdef */
+/* opaque typedef */
 struct text_lookup;
 typedef struct text_lookup lookup_t;
 

--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -362,7 +362,7 @@ size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 
 		/*
 		 * NOTE: do not check here for forbidden UTF-8 characters.
-		 * They cannot appear here because we do proper convertion.
+		 * They cannot appear here because we do proper conversion.
 		 */
 
 		p += n;

--- a/libobs/util/vc/vc_stdint.h
+++ b/libobs/util/vc/vc_stdint.h
@@ -172,7 +172,7 @@ typedef unsigned __int64   uintmax_t;
 
 /* 7.18.4.1  Macros for minimum-width integer constants
 
-    Accoding to Douglas Gwyn <gwyn@arl.mil>:
+    According to Douglas Gwyn <gwyn@arl.mil>:
 	"This spec was changed in ISO/IEC 9899:1999 TC1; in ISO/IEC
 	9899:1999 as initially published, the expansion was required
 	to be an integer constant of precisely matching type, which

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -208,7 +208,7 @@ static void flv_video(struct serializer *s, struct encoder_packet *packet,
 	s_wb24(s, get_ms_time(packet, offset));
 	s_write(s, packet->data, packet->size);
 
-	/* write tag size (starting byte doesnt count) */
+	/* write tag size (starting byte doesn't count) */
 	s_wb32(s, (uint32_t)serializer_get_pos(s) + 4 - 1);
 }
 
@@ -241,7 +241,7 @@ static void flv_audio(struct serializer *s, struct encoder_packet *packet,
 	s_w8(s, is_header ? 0 : 1);
 	s_write(s, packet->data, packet->size);
 
-	/* write tag size (starting byte doesnt count) */
+	/* write tag size (starting byte doesn't count) */
 	s_wb32(s, (uint32_t)serializer_get_pos(s) + 4 - 1);
 }
 

--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -223,6 +223,6 @@ enum qsv_cpu_platform qsv_get_cpu_platform()
 		return QSV_CPU_PLATFORM_HSW;
 	}
 
-	//assume newer revisions are at least as capable as haswell
+	//assume newer revisions are at least as capable as Haswell
 	return QSV_CPU_PLATFORM_INTEL;
 }

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -534,7 +534,7 @@ mfxStatus QSV_Encoder_Internal::Encode(uint64_t ts, uint8_t *pDataY,
 	}
 
 	for (;;) {
-		// Encode a frame asychronously (returns immediately)
+		// Encode a frame asynchronously (returns immediately)
 		sts = m_pmfxENC->EncodeFrameAsync(NULL, pSurface,
 				&m_pTaskPool[nTaskIdx].mfxBS,
 				&m_pTaskPool[nTaskIdx].syncp);

--- a/plugins/obs-qsv11/common_directx11.cpp
+++ b/plugins/obs-qsv11/common_directx11.cpp
@@ -351,7 +351,7 @@ mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
     } else {
         pSurface->GetDesc(&desc);
 
-        // copy data only in case of user wants o read from stored surface
+        // copy data only in case of user wants to read from stored surface
         if (memId->rw & WILL_READ)
             g_pD3D11Ctx->CopySubresourceRegion(pStage, 0, 0, 0, 0, pSurface, 0, NULL);
 

--- a/plugins/obs-qsv11/common_directx9.h
+++ b/plugins/obs-qsv11/common_directx9.h
@@ -22,7 +22,7 @@ Copyright(c) 2011-2014 Intel Corporation. All Rights Reserved.
 class IGFXS3DControl;
 
 /** Direct3D 9 device implementation.
-@note Can be initilized for only 1 or two 2 views. Handle to
+@note Can be initialized for only 1 or two 2 views. Handle to
 MFX_HANDLE_GFXS3DCONTROL must be set prior if initializing for 2 views.
 
 @note Device always set D3DPRESENT_PARAMETERS::Windowed to TRUE.

--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -62,7 +62,7 @@ mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse* response);
 void PrintErrString(int err,const char* filestr,int line);
 
 // LoadRawFrame: Reads raw frame from YUV file (YV12) into NV12 surface
-// - YV12 is a more common format for for YUV files than NV12 (therefore the conversion during read and write)
+// - YV12 is a more common format for YUV files than NV12 (therefore the conversion during read and write)
 // - For the simulation case (fSource = NULL), the surface is filled with default image data
 // LoadRawRGBFrame: Reads raw RGB32 frames from file into RGB32 surface
 // - For the simulation case (fSource = NULL), the surface is filled with default image data

--- a/plugins/obs-qsv11/device_directx9.cpp
+++ b/plugins/obs-qsv11/device_directx9.cpp
@@ -12,7 +12,7 @@ Copyright(c) 2011-2015 Intel Corporation. All Rights Reserved.
 
 #if defined(WIN32) || defined(WIN64)
 
-//prefast singnature used in combaseapi.h
+//prefast signature used in combaseapi.h
 #ifndef _PREFAST_
     #pragma warning(disable:4068)
 #endif

--- a/plugins/obs-qsv11/device_directx9.h
+++ b/plugins/obs-qsv11/device_directx9.h
@@ -58,7 +58,7 @@ enum {
 }; //mfxHandleType
 
 /** Direct3D 9 device implementation.
-@note Can be initilized for only 1 or two 2 views. Handle to
+@note Can be initialized for only 1 or two 2 views. Handle to
 MFX_HANDLE_GFXS3DCONTROL must be set prior if initializing for 2 views.
 
 @note Device always set D3DPRESENT_PARAMETERS::Windowed to TRUE.

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -635,7 +635,7 @@ static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, 
 	//int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
 	//int64_t interval = obsqsv->params.nbFrames + 1;
 
-	// In case MSDK does't support automatic DecodeTimeStamp, do manual
+	// In case MSDK doesn't support automatic DecodeTimeStamp, do manual
 	// calculation
 	if (g_pts2dtsShift >= 0)
 	{

--- a/plugins/win-capture/graphics-hook/d3d8-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d8-capture.cpp
@@ -142,7 +142,7 @@ static bool d3d8_shmem_init(IDirect3DDevice8 *device)
 		return false;
 	}
 
-	hlog("d3d8 memory capture successfull");
+	hlog("d3d8 memory capture successful");
 	return true;
 }
 

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -351,7 +351,7 @@ void WASAPISource::Reconnect()
 
 	if (!reconnectThread.Valid())
 		blog(LOG_WARNING, "[WASAPISource::Reconnect] "
-		                "Failed to intiialize reconnect thread: %lu",
+		                "Failed to initialize reconnect thread: %lu",
 		                 GetLastError());
 }
 


### PR DESCRIPTION
Discussed with @jp9000 in IRC.  Presenting these fixes as a single commit.  This should fix 32 typos in comments, 4 typos in log messages, and 1 typo in code.  The one typo in code was in libobs/callback/decl.c.