### PR TITLE
Update Linux kernel coding style URL in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ Coding Guidelines
 
  - OBS Studio uses kernel normal form (linux variant), for more
    information, please read here:
-   https://www.kernel.org/doc/Documentation/CodingStyle
+   https://github.com/torvalds/linux/blob/master/Documentation/process/coding-style.rst
 
  - Avoid trailing spaces.  To view trailing spaces before making a
    commit, use "git diff" on your changes.  If colors are enabled for


### PR DESCRIPTION
When visiting https://www.kernel.org/doc/Documentation/CodingStyle, you see the message, "This file has moved to process/coding-style.rst".  I feel like linking to the old document just creates an extra step for users wanting to understand the coding style of this project.  This commit replaces the old URL with a version hosted on GitHub.