### PR TITLE
UI: Remove unused defines from old updater code

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2219,14 +2219,6 @@ void OBSBasic::CheckForUpdates(bool manualUpdate)
 #endif
 }
 
-#ifdef __APPLE__
-#define VERSION_ENTRY "mac"
-#elif _WIN32
-#define VERSION_ENTRY "windows"
-#else
-#define VERSION_ENTRY "other"
-#endif
-
 void OBSBasic::updateCheckFinished()
 {
 	ui->actionCheckForUpdates->setEnabled(true);


### PR DESCRIPTION
This commit removes some define statements that were used in the updater code before OBS Studio 18.0.0 (see [UI/window-basic-main.cpp from 17.0.2](https://github.com/jp9000/obs-studio/blob/17.0.2/UI/window-basic-main.cpp#L2056)).  They are no longer used, so they should be safe to remove.  Of course, I would understand if they were left in place to be used by something else later.