### PR TITLE
obs-qsv11: Fix code style inconsistencies

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -98,7 +98,7 @@ qsv_t *qsv_encoder_open(qsv_param_t *pParams)
 }
 
 int qsv_encoder_headers(qsv_t *pContext, uint8_t **pSPS, uint8_t **pPPS,
-		uint16_t *pnSPS, uint16_t *pnPPS)
+	uint16_t *pnSPS, uint16_t *pnPPS)
 {
 	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
 	pEncoder->GetSPSPPS(pSPS, pPPS, pnSPS, pnPPS);
@@ -106,9 +106,9 @@ int qsv_encoder_headers(qsv_t *pContext, uint8_t **pSPS, uint8_t **pPPS,
 	return 0;
 }
 
-int qsv_encoder_encode(qsv_t * pContext, uint64_t ts, uint8_t *pDataY,
-		uint8_t *pDataUV, uint32_t strideY, uint32_t strideUV,
-		mfxBitstream **pBS)
+int qsv_encoder_encode(qsv_t *pContext, uint64_t ts, uint8_t *pDataY,
+	uint8_t *pDataUV, uint32_t strideY, uint32_t strideUV,
+	mfxBitstream **pBS)
 {
 	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
 	mfxStatus sts = MFX_ERR_NONE;
@@ -189,33 +189,27 @@ enum qsv_cpu_platform qsv_get_cpu_platform()
 	if (family != 6)
 		return QSV_CPU_PLATFORM_UNKNOWN;
 
-	switch (model)
-	{
+	switch (model) {
 	case 0x1C:
 	case 0x26:
 	case 0x27:
 	case 0x35:
 	case 0x36:
 		return QSV_CPU_PLATFORM_BNL;
-
 	case 0x2a:
 	case 0x2d:
 		return QSV_CPU_PLATFORM_SNB;
-
 	case 0x3a:
 	case 0x3e:
 		return QSV_CPU_PLATFORM_IVB;
-
 	case 0x37:
 	case 0x4A:
 	case 0x4D:
 	case 0x5A:
 	case 0x5D:
 		return QSV_CPU_PLATFORM_SLM;
-
 	case 0x4C:
 		return QSV_CPU_PLATFORM_CHT;
-
 	case 0x3c:
 	case 0x3f:
 	case 0x45:

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -80,13 +80,13 @@ static const struct qsv_rate_control_info qsv_ratecontrols[] = {
 	{"LA", true},
 	{0, false}
 };
-static const char * const qsv_profile_names[] = {
+static const char *const qsv_profile_names[] = {
 	"high",
 	"main",
 	"baseline",
 	0
 };
-static const char * const qsv_usage_names[] = {
+static const char *const qsv_usage_names[] = {
 	"quality",
 	"balanced",
 	"speed",
@@ -137,7 +137,7 @@ int qsv_param_default_preset(qsv_param_t *, const char *preset,
 		const char *tune);
 int qsv_encoder_reconfig(qsv_t *, qsv_param_t *);
 void qsv_encoder_version(unsigned short *major, unsigned short *minor);
-qsv_t *qsv_encoder_open( qsv_param_t * );
+qsv_t *qsv_encoder_open(qsv_param_t *);
 int qsv_encoder_encode(qsv_t *, uint64_t, uint8_t *, uint8_t *, uint32_t,
 		uint32_t, mfxBitstream **pBS);
 int qsv_encoder_headers(qsv_t *, uint8_t **pSPS, uint8_t **pPPS,

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -69,7 +69,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define info(format, ...)  do_log(LOG_INFO,    format, ##__VA_ARGS__)
 #define debug(format, ...) do_log(LOG_DEBUG,   format, ##__VA_ARGS__)
 
-QSV_Encoder_Internal::QSV_Encoder_Internal(mfxIMPL& impl, mfxVersion& version) :
+QSV_Encoder_Internal::QSV_Encoder_Internal(mfxIMPL &impl, mfxVersion &version) :
 	m_pmfxENC(NULL),
 	m_nSPSBufferSize(100),
 	m_nPPSBufferSize(100),
@@ -107,8 +107,7 @@ QSV_Encoder_Internal::QSV_Encoder_Internal(mfxIMPL& impl, mfxVersion& version) :
 			m_ver = version;
 			return;
 		}
-	}
-	else if (m_bD3D9HACK) {
+	} else if (m_bD3D9HACK) {
 		tempImpl = impl | MFX_IMPL_VIA_D3D9;
 		sts = m_session.Init(tempImpl, &version);
 		if (sts == MFX_ERR_NONE) {
@@ -137,7 +136,6 @@ QSV_Encoder_Internal::QSV_Encoder_Internal(mfxIMPL& impl, mfxVersion& version) :
 		m_impl = tempImpl;
 		m_ver = version;
 	}
-
 }
 
 QSV_Encoder_Internal::~QSV_Encoder_Internal()
@@ -146,19 +144,20 @@ QSV_Encoder_Internal::~QSV_Encoder_Internal()
 		ClearData();
 }
 
-mfxStatus QSV_Encoder_Internal::Open(qsv_param_t * pParams)
+mfxStatus QSV_Encoder_Internal::Open(qsv_param_t *pParams)
 {
 	mfxStatus sts = MFX_ERR_NONE;
 
 	if (m_bUseD3D11)
 		// Use D3D11 surface
-		sts = Initialize(m_impl, m_ver, &m_session, &m_mfxAllocator, false, false);
+		sts = Initialize(m_impl, m_ver, &m_session, &m_mfxAllocator,
+				false, false);
 	else if (m_bD3D9HACK)
 		// Use hack
-		sts = Initialize(m_impl, m_ver, &m_session, &m_mfxAllocator, false, true);
+		sts = Initialize(m_impl, m_ver, &m_session, &m_mfxAllocator,
+				false, true);
 	else
 		sts = Initialize(m_impl, m_ver, &m_session, NULL);
-
 
 	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
@@ -186,7 +185,7 @@ mfxStatus QSV_Encoder_Internal::Open(qsv_param_t * pParams)
 }
 
 
-bool QSV_Encoder_Internal::InitParams(qsv_param_t * pParams)
+bool QSV_Encoder_Internal::InitParams(qsv_param_t *pParams)
 {
 	memset(&m_mfxEncParams, 0, sizeof(m_mfxEncParams));
 
@@ -243,7 +242,7 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t * pParams)
 	m_mfxEncParams.mfx.GopPicSize = (mfxU16)(pParams->nKeyIntSec *
 			pParams->nFpsNum / (float)pParams->nFpsDen);
 
-	static mfxExtBuffer* extendedBuffers[2];
+	static mfxExtBuffer *extendedBuffers[2];
 	int iBuffers = 0;
 	if (pParams->nAsyncDepth == 1) {
 		m_mfxEncParams.mfx.NumRefFrame = 1;
@@ -254,13 +253,12 @@ bool QSV_Encoder_Internal::InitParams(qsv_param_t * pParams)
 		m_co.Header.BufferSz = sizeof(mfxExtCodingOption);
 		m_co.MaxDecFrameBuffering = 1;
 		extendedBuffers[iBuffers++] = (mfxExtBuffer*)&m_co;
-	}
-	else
+	} else {
 		m_mfxEncParams.mfx.GopRefDist = pParams->nbFrames + 1;
+	}
 
 	if (pParams->nRateControl == MFX_RATECONTROL_LA_ICQ ||
 	    pParams->nRateControl == MFX_RATECONTROL_LA) {
-
 		memset(&m_co2, 0, sizeof(mfxExtCodingOption2));
 		m_co2.Header.BufferId = MFX_EXTBUFF_CODING_OPTION;
 		m_co2.Header.BufferSz = sizeof(m_co2);
@@ -319,8 +317,7 @@ mfxStatus QSV_Encoder_Internal::AllocateSurfaces()
 					sizeof(mfxFrameInfo));
 			m_pmfxSurfaces[i]->Data.MemId = m_mfxResponse.mids[i];
 		}
-	}
-	else {
+	} else {
 		mfxU16 width = (mfxU16)MSDK_ALIGN32(EncRequest.Info.Width);
 		mfxU16 height = (mfxU16)MSDK_ALIGN32(EncRequest.Info.Height);
 		mfxU8  bitsPerPixel = 12;
@@ -335,7 +332,7 @@ mfxStatus QSV_Encoder_Internal::AllocateSurfaces()
 					&(m_mfxEncParams.mfx.FrameInfo),
 					sizeof(mfxFrameInfo));
 
-			mfxU8* pSurface = (mfxU8*) new mfxU8[surfaceSize];
+			mfxU8 *pSurface = (mfxU8*) new mfxU8[surfaceSize];
 			m_pmfxSurfaces[i]->Data.Y = pSurface;
 			m_pmfxSurfaces[i]->Data.U = pSurface + width * height;
 			m_pmfxSurfaces[i]->Data.V = pSurface + width * height + 1;
@@ -356,7 +353,7 @@ mfxStatus QSV_Encoder_Internal::GetVideoParam()
 	opt.Header.BufferId = MFX_EXTBUFF_CODING_OPTION_SPSPPS;
 	opt.Header.BufferSz = sizeof(mfxExtCodingOptionSPSPPS);
 
-	static mfxExtBuffer* extendedBuffers[1];
+	static mfxExtBuffer *extendedBuffers[1];
 	extendedBuffers[0] = (mfxExtBuffer*)& opt;
 	m_parameter.ExtParam = extendedBuffers;
 	m_parameter.NumExtParam = 1;
@@ -420,17 +417,14 @@ mfxStatus QSV_Encoder_Internal::LoadNV12(mfxFrameSurface1 *pSurface,
 		uint32_t strideUV)
 {
 	mfxU16 w, h, i, pitch;
-	mfxU8* ptr;
-	mfxFrameInfo* pInfo = &pSurface->Info;
-	mfxFrameData* pData = &pSurface->Data;
+	mfxU8 *ptr;
+	mfxFrameInfo *pInfo = &pSurface->Info;
+	mfxFrameData *pData = &pSurface->Data;
 
-	if (pInfo->CropH > 0 && pInfo->CropW > 0)
-	{
+	if (pInfo->CropH > 0 && pInfo->CropW > 0) {
 		w = pInfo->CropW;
 		h = pInfo->CropH;
-	}
-	else
-	{
+	} else {
 		w = pInfo->Width;
 		h = pInfo->Height;
 	}
@@ -452,7 +446,7 @@ mfxStatus QSV_Encoder_Internal::LoadNV12(mfxFrameSurface1 *pSurface,
 	return MFX_ERR_NONE;
 }
 
-int QSV_Encoder_Internal::GetFreeTaskIndex(Task* pTaskPool, mfxU16 nPoolSize)
+int QSV_Encoder_Internal::GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize)
 {
 	if (pTaskPool)
 		for (int i = 0; i < nPoolSize; i++)
@@ -542,15 +536,18 @@ mfxStatus QSV_Encoder_Internal::Encode(uint64_t ts, uint8_t *pDataY,
 		if (MFX_ERR_NONE < sts && !m_pTaskPool[nTaskIdx].syncp) {
 			// Repeat the call if warning and no output
 			if (MFX_WRN_DEVICE_BUSY == sts)
-				MSDK_SLEEP(1);  // Wait if device is busy, then repeat the same call
+				// Wait if device is busy, then repeat the same call
+				MSDK_SLEEP(1);
 		} else if (MFX_ERR_NONE < sts && m_pTaskPool[nTaskIdx].syncp) {
-			sts = MFX_ERR_NONE;     // Ignore warnings if output is available
+			// Ignore warnings if output is available
+			sts = MFX_ERR_NONE;
 			break;
 		} else if (MFX_ERR_NOT_ENOUGH_BUFFER == sts) {
 			// Allocate more bitstream buffer memory here if needed...
 			break;
-		} else
+		} else {
 			break;
+		}
 	}
 
 	return sts;
@@ -561,7 +558,8 @@ mfxStatus QSV_Encoder_Internal::Drain()
 	mfxStatus sts = MFX_ERR_NONE;
 
 	while (m_pTaskPool && m_pTaskPool[m_nFirstSyncTask].syncp) {
-		sts = m_session.SyncOperation(m_pTaskPool[m_nFirstSyncTask].syncp, 60000);
+		sts = m_session.SyncOperation(m_pTaskPool[m_nFirstSyncTask].syncp,
+				60000);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
 		m_pTaskPool[m_nFirstSyncTask].syncp = NULL;

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -62,10 +62,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 class QSV_Encoder_Internal
 {
 public:
-	QSV_Encoder_Internal(mfxIMPL& impl, mfxVersion& version);
+	QSV_Encoder_Internal(mfxIMPL &impl, mfxVersion &version);
 	~QSV_Encoder_Internal();
 
-	mfxStatus    Open(qsv_param_t * pParams);
+	mfxStatus    Open(qsv_param_t *pParams);
 	void         GetSPSPPS(mfxU8 **pSPSBuf, mfxU8 **pPPSBuf,
 			mfxU16 *pnSPSBuf, mfxU16 *pnPPSBuf);
 	mfxStatus    Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pDataUV,
@@ -75,14 +75,14 @@ public:
 	mfxStatus    Reset(qsv_param_t *pParams);
 
 protected:
-	bool         InitParams(qsv_param_t * pParams);
+	bool         InitParams(qsv_param_t *pParams);
 	mfxStatus    AllocateSurfaces();
 	mfxStatus    GetVideoParam();
 	mfxStatus    InitBitstream();
 	mfxStatus    LoadNV12(mfxFrameSurface1 *pSurface, uint8_t *pDataY,
 			uint8_t *pDataUV, uint32_t strideY, uint32_t strideUV);
 	mfxStatus    Drain();
-	int          GetFreeTaskIndex(Task* pTaskPool, mfxU16 nPoolSize);
+	int          GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize);
 
 private:
 	mfxIMPL                        m_impl;
@@ -91,9 +91,9 @@ private:
 	mfxFrameAllocator              m_mfxAllocator;
 	mfxVideoParam                  m_mfxEncParams;
 	mfxFrameAllocResponse          m_mfxResponse;
-	mfxFrameSurface1**             m_pmfxSurfaces;
+	mfxFrameSurface1             **m_pmfxSurfaces;
 	mfxU16                         m_nSurfNum;
-	MFXVideoENCODE*                m_pmfxENC;
+	MFXVideoENCODE                *m_pmfxENC;
 	mfxU8                          m_SPSBuffer[100];
 	mfxU8                          m_PPSBuffer[100];
 	mfxU16                         m_nSPSBufferSize;
@@ -102,7 +102,7 @@ private:
 	mfxExtCodingOption2            m_co2;
 	mfxExtCodingOption             m_co;
 	mfxU16                         m_nTaskPool;
-	Task*                          m_pTaskPool;
+	Task                          *m_pTaskPool;
 	int                            m_nTaskIdx;
 	int                            m_nFirstSyncTask;
 	mfxBitstream                   m_outBitstream;
@@ -110,4 +110,3 @@ private:
 	bool                           m_bUseD3D11;
 	bool                           m_bD3D9HACK;
 };
-

--- a/plugins/obs-qsv11/common_directx11.cpp
+++ b/plugins/obs-qsv11/common_directx11.cpp
@@ -10,31 +10,31 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 
 #include "common_directx11.h"
 
-#include<map>
+#include <map>
 
-ID3D11Device*							g_pD3D11Device;
-ID3D11DeviceContext*					g_pD3D11Ctx;
-IDXGIFactory2*							g_pDXGIFactory;
-IDXGIAdapter*                           g_pAdapter;
+ID3D11Device                           *g_pD3D11Device;
+ID3D11DeviceContext                    *g_pD3D11Ctx;
+IDXGIFactory2                          *g_pDXGIFactory;
+IDXGIAdapter                           *g_pAdapter;
 
 std::map<mfxMemId*, mfxHDL>             allocResponses;
 std::map<mfxHDL, mfxFrameAllocResponse> allocDecodeResponses;
 std::map<mfxHDL, int>                   allocDecodeRefCount;
 
 typedef struct {
-    mfxMemId    memId;
-    mfxMemId    memIdStage;
-    mfxU16      rw;
+	mfxMemId memId;
+	mfxMemId memIdStage;
+	mfxU16   rw;
 } CustomMemId;
 
 const struct {
-    mfxIMPL impl;       // actual implementation
-    mfxU32  adapterID;  // device adapter number
+	mfxIMPL impl;       // actual implementation
+	mfxU32  adapterID;  // device adapter number
 } implTypes[] = {
-    {MFX_IMPL_HARDWARE, 0},
-    {MFX_IMPL_HARDWARE2, 1},
-    {MFX_IMPL_HARDWARE3, 2},
-    {MFX_IMPL_HARDWARE4, 3}
+	{MFX_IMPL_HARDWARE, 0},
+	{MFX_IMPL_HARDWARE2, 1},
+	{MFX_IMPL_HARDWARE3, 2},
+	{MFX_IMPL_HARDWARE4, 3}
 };
 
 // =================================================================
@@ -43,107 +43,108 @@ const struct {
 
 IDXGIAdapter* GetIntelDeviceAdapterHandle(mfxSession session)
 {
-    mfxU32  adapterNum = 0;
-    mfxIMPL impl;
+	mfxU32  adapterNum = 0;
+	mfxIMPL impl;
 
-    MFXQueryIMPL(session, &impl);
+	MFXQueryIMPL(session, &impl);
 
-    mfxIMPL baseImpl = MFX_IMPL_BASETYPE(impl); // Extract Media SDK base implementation type
+	// Extract Media SDK base implementation type
+	mfxIMPL baseImpl = MFX_IMPL_BASETYPE(impl);
 
-    // get corresponding adapter number
-    for (mfxU8 i = 0; i < sizeof(implTypes)/sizeof(implTypes[0]); i++) {
-        if (implTypes[i].impl == baseImpl) {
-            adapterNum = implTypes[i].adapterID;
-            break;
-        }
-    }
+	// get corresponding adapter number
+	for (mfxU8 i = 0; i < sizeof(implTypes) / sizeof(implTypes[0]); i++) {
+		if (implTypes[i].impl == baseImpl) {
+			adapterNum = implTypes[i].adapterID;
+			break;
+		}
+	}
 
-    HRESULT hres = CreateDXGIFactory(__uuidof(IDXGIFactory2), (void**)(&g_pDXGIFactory) );
-    if (FAILED(hres)) return NULL;
+	HRESULT hres = CreateDXGIFactory(__uuidof(IDXGIFactory2),
+			(void**)(&g_pDXGIFactory));
+	if (FAILED(hres))
+		return NULL;
 
 	IDXGIAdapter* adapter;
-    hres = g_pDXGIFactory->EnumAdapters(adapterNum, &adapter);
-    if (FAILED(hres)) return NULL;
+	hres = g_pDXGIFactory->EnumAdapters(adapterNum, &adapter);
+	if (FAILED(hres))
+		return NULL;
 
-    return adapter;
+	return adapter;
 }
 
 // Create HW device context
-mfxStatus CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND hWnd, bool bCreateSharedHandles)
+mfxStatus CreateHWDevice(mfxSession session, mfxHDL *deviceHandle, HWND hWnd,
+	bool bCreateSharedHandles)
 {
-    //Note: not using bCreateSharedHandles for DX11 -- for API consistency only
-    hWnd; // Window handle not required by DX11 since we do not showcase rendering.
-    bCreateSharedHandles; // For rendering, not used here. Just for consistencies sake.
+	//Note: not using bCreateSharedHandles for DX11 -- for API consistency only
+	hWnd; // Window handle not required by DX11 since we do not showcase rendering.
+	bCreateSharedHandles; // For rendering, not used here. Just for consistencies sake.
 
-    HRESULT hres = S_OK;
+	HRESULT hres = S_OK;
 
-    static D3D_FEATURE_LEVEL FeatureLevels[] = {
-        D3D_FEATURE_LEVEL_11_1,
-        D3D_FEATURE_LEVEL_11_0,
-        D3D_FEATURE_LEVEL_10_1,
-        D3D_FEATURE_LEVEL_10_0
-    };
-    D3D_FEATURE_LEVEL pFeatureLevelsOut;
+	static D3D_FEATURE_LEVEL FeatureLevels[] = {
+		D3D_FEATURE_LEVEL_11_1,
+		D3D_FEATURE_LEVEL_11_0,
+		D3D_FEATURE_LEVEL_10_1,
+		D3D_FEATURE_LEVEL_10_0
+	};
+	D3D_FEATURE_LEVEL pFeatureLevelsOut;
 
-    g_pAdapter = GetIntelDeviceAdapterHandle(session);
-    if (NULL == g_pAdapter)
-        return MFX_ERR_DEVICE_FAILED;
+	g_pAdapter = GetIntelDeviceAdapterHandle(session);
+	if (NULL == g_pAdapter)
+		return MFX_ERR_DEVICE_FAILED;
 
-    UINT dxFlags = 0;
-    //UINT dxFlags = D3D11_CREATE_DEVICE_DEBUG;
+	UINT dxFlags = 0;
+	//UINT dxFlags = D3D11_CREATE_DEVICE_DEBUG;
 
-    hres =  D3D11CreateDevice(  g_pAdapter,
-                                D3D_DRIVER_TYPE_UNKNOWN,
-                                NULL,
-                                dxFlags,
-                                FeatureLevels,
-                                (sizeof(FeatureLevels) / sizeof(FeatureLevels[0])),
-                                D3D11_SDK_VERSION,
-                                &g_pD3D11Device,
-                                &pFeatureLevelsOut,
-                                &g_pD3D11Ctx);
-    if (FAILED(hres))
-        return MFX_ERR_DEVICE_FAILED;
+	hres = D3D11CreateDevice(g_pAdapter,
+			D3D_DRIVER_TYPE_UNKNOWN,
+			NULL,
+			dxFlags,
+			FeatureLevels,
+			(sizeof(FeatureLevels) / sizeof(FeatureLevels[0])),
+			D3D11_SDK_VERSION,
+			&g_pD3D11Device,
+			&pFeatureLevelsOut,
+			&g_pD3D11Ctx);
+	if (FAILED(hres))
+		return MFX_ERR_DEVICE_FAILED;
 
-    // turn on multithreading for the DX11 context
-    CComQIPtr<ID3D10Multithread> p_mt(g_pD3D11Ctx);
-    if (p_mt)
-        p_mt->SetMultithreadProtected(true);
-    else
-        return MFX_ERR_DEVICE_FAILED;
+	// turn on multithreading for the DX11 context
+	CComQIPtr<ID3D10Multithread> p_mt(g_pD3D11Ctx);
+	if (p_mt)
+		p_mt->SetMultithreadProtected(true);
+	else
+		return MFX_ERR_DEVICE_FAILED;
 
-    *deviceHandle = (mfxHDL)g_pD3D11Device;
+	*deviceHandle = (mfxHDL)g_pD3D11Device;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
 
 void SetHWDeviceContext(CComPtr<ID3D11DeviceContext> devCtx)
 {
-    g_pD3D11Ctx = devCtx;
-    devCtx->GetDevice(&g_pD3D11Device);
+	g_pD3D11Ctx = devCtx;
+	devCtx->GetDevice(&g_pD3D11Device);
 }
 
 // Free HW device context
 void CleanupHWDevice()
 {
-	if (g_pAdapter)
-	{
+	if (g_pAdapter) {
 		g_pAdapter->Release();
 		g_pAdapter = NULL;
 	}
-	if (g_pD3D11Device)
-	{
+	if (g_pD3D11Device) {
 		g_pD3D11Device->Release();
 		g_pD3D11Device = NULL;
 	}
-	if (g_pD3D11Ctx)
-	{
+	if (g_pD3D11Ctx) {
 		g_pD3D11Ctx->Release();
 		g_pD3D11Ctx = NULL;
 	}
-	if (g_pDXGIFactory)
-	{
+	if (g_pDXGIFactory) {
 		g_pDXGIFactory->Release();
 		g_pDXGIFactory = NULL;
 	}
@@ -151,337 +152,359 @@ void CleanupHWDevice()
 
 CComPtr<ID3D11DeviceContext> GetHWDeviceContext()
 {
-    return g_pD3D11Ctx;
+	return g_pD3D11Ctx;
 }
 
 /* (Hugh) Functions currently unused */
 #if 0
 void ClearYUVSurfaceD3D(mfxMemId memId)
 {
-    // TBD
+	// TBD
 }
 
 void ClearRGBSurfaceD3D(mfxMemId memId)
 {
-    // TBD
+	// TBD
 }
 #endif
 
 //
-// Intel Media SDK memory allocator entrypoints....
+// Intel Media SDK memory allocator entrypoints...
 //
-mfxStatus _simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse* response)
+mfxStatus _simple_alloc(mfxFrameAllocRequest *request,
+	mfxFrameAllocResponse *response)
 {
-    HRESULT hRes;
+	HRESULT hRes;
 
-    // Determine surface format
-    DXGI_FORMAT format;
-    if (MFX_FOURCC_NV12 == request->Info.FourCC)
-        format = DXGI_FORMAT_NV12;
-    else if (MFX_FOURCC_RGB4 == request->Info.FourCC)
-        format = DXGI_FORMAT_B8G8R8A8_UNORM;
-    else if (MFX_FOURCC_YUY2== request->Info.FourCC)
-        format = DXGI_FORMAT_YUY2;
-    else if (MFX_FOURCC_P8 == request->Info.FourCC ) //|| MFX_FOURCC_P8_TEXTURE == request->Info.FourCC
-        format = DXGI_FORMAT_P8;
-    else
-        format = DXGI_FORMAT_UNKNOWN;
+	// Determine surface format
+	DXGI_FORMAT format;
+	if (MFX_FOURCC_NV12 == request->Info.FourCC)
+		format = DXGI_FORMAT_NV12;
+	else if (MFX_FOURCC_RGB4 == request->Info.FourCC)
+		format = DXGI_FORMAT_B8G8R8A8_UNORM;
+	else if (MFX_FOURCC_YUY2== request->Info.FourCC)
+		format = DXGI_FORMAT_YUY2;
+	else if (MFX_FOURCC_P8 == request->Info.FourCC) //|| MFX_FOURCC_P8_TEXTURE == request->Info.FourCC
+		format = DXGI_FORMAT_P8;
+	else
+		format = DXGI_FORMAT_UNKNOWN;
 
-    if (DXGI_FORMAT_UNKNOWN == format)
-        return MFX_ERR_UNSUPPORTED;
-
-
-    // Allocate custom container to keep texture and stage buffers for each surface
-    // Container also stores the intended read and/or write operation.
-    CustomMemId** mids = (CustomMemId**)calloc(request->NumFrameSuggested, sizeof(CustomMemId*));
-    if (!mids) return MFX_ERR_MEMORY_ALLOC;
-
-    for (int i=0; i<request->NumFrameSuggested; i++) {
-        mids[i] = (CustomMemId*)calloc(1, sizeof(CustomMemId));
-        if (!mids[i]) {
-            return MFX_ERR_MEMORY_ALLOC;
-        }
-        mids[i]->rw = request->Type & 0xF000; // Set intended read/write operation
-    }
-
-    request->Type = request->Type & 0x0FFF;
-
-    // because P8 data (bitstream) for h264 encoder should be allocated by CreateBuffer()
-    // but P8 data (MBData) for MPEG2 encoder should be allocated by CreateTexture2D()
-    if (request->Info.FourCC == MFX_FOURCC_P8) {
-        D3D11_BUFFER_DESC desc = { 0 };
-
-        if (!request->NumFrameSuggested) return MFX_ERR_MEMORY_ALLOC;
-
-        desc.ByteWidth           = request->Info.Width * request->Info.Height;
-        desc.Usage               = D3D11_USAGE_STAGING;
-        desc.BindFlags           = 0;
-        desc.CPUAccessFlags      = D3D11_CPU_ACCESS_READ;
-        desc.MiscFlags           = 0;
-        desc.StructureByteStride = 0;
-
-        ID3D11Buffer* buffer = 0;
-        hRes = g_pD3D11Device->CreateBuffer(&desc, 0, &buffer);
-        if (FAILED(hRes))
-            return MFX_ERR_MEMORY_ALLOC;
-
-        mids[0]->memId = reinterpret_cast<ID3D11Texture2D*>(buffer);
-    } else {
-        D3D11_TEXTURE2D_DESC desc = {0};
-
-        desc.Width              = request->Info.Width;
-        desc.Height             = request->Info.Height;
-        desc.MipLevels          = 1;
-        desc.ArraySize          = 1; // number of subresources is 1 in this case
-        desc.Format             = format;
-        desc.SampleDesc.Count   = 1;
-        desc.Usage              = D3D11_USAGE_DEFAULT;
-        desc.BindFlags          = D3D11_BIND_DECODER;
-        desc.MiscFlags          = 0;
-        //desc.MiscFlags            = D3D11_RESOURCE_MISC_SHARED;
-
-        if ( (MFX_MEMTYPE_FROM_VPPIN & request->Type) &&
-             (DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format) ) {
-            desc.BindFlags = D3D11_BIND_RENDER_TARGET;
-            if (desc.ArraySize > 2)
-                return MFX_ERR_MEMORY_ALLOC;
-        }
-
-        if ( (MFX_MEMTYPE_FROM_VPPOUT & request->Type) ||
-             (MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET & request->Type)) {
-            desc.BindFlags = D3D11_BIND_RENDER_TARGET;
-            if (desc.ArraySize > 2)
-                return MFX_ERR_MEMORY_ALLOC;
-        }
-
-        if ( DXGI_FORMAT_P8 == desc.Format )
-            desc.BindFlags = 0;
-
-        ID3D11Texture2D* pTexture2D;
-
-        // Create surface textures
-        for (size_t i = 0; i < request->NumFrameSuggested / desc.ArraySize; i++) {
-            hRes = g_pD3D11Device->CreateTexture2D(&desc, NULL, &pTexture2D);
-
-            if (FAILED(hRes))
-                return MFX_ERR_MEMORY_ALLOC;
-
-            mids[i]->memId = pTexture2D;
-        }
-
-        desc.ArraySize      = 1;
-        desc.Usage          = D3D11_USAGE_STAGING;
-        desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;// | D3D11_CPU_ACCESS_WRITE;
-        desc.BindFlags      = 0;
-        desc.MiscFlags      = 0;
-        //desc.MiscFlags        = D3D11_RESOURCE_MISC_SHARED;
-
-        // Create surface staging textures
-        for (size_t i = 0; i < request->NumFrameSuggested; i++) {
-            hRes = g_pD3D11Device->CreateTexture2D(&desc, NULL, &pTexture2D);
-
-            if (FAILED(hRes))
-                return MFX_ERR_MEMORY_ALLOC;
-
-            mids[i]->memIdStage = pTexture2D;
-        }
-    }
+	if (DXGI_FORMAT_UNKNOWN == format)
+		return MFX_ERR_UNSUPPORTED;
 
 
-    response->mids = (mfxMemId*)mids;
-    response->NumFrameActual = request->NumFrameSuggested;
+	/*
+	 * Allocate custom container to keep texture and stage buffers for each
+	 * surface. Container also stores the intended read and/or write
+	 * operation.
+	 */
+	CustomMemId **mids = (CustomMemId**)calloc(request->NumFrameSuggested,
+			sizeof(CustomMemId*));
+	if (!mids)
+		return MFX_ERR_MEMORY_ALLOC;
 
-    return MFX_ERR_NONE;
+	for (int i=0; i<request->NumFrameSuggested; i++) {
+		mids[i] = (CustomMemId*)calloc(1, sizeof(CustomMemId));
+		if (!mids[i]) {
+			return MFX_ERR_MEMORY_ALLOC;
+		}
+		// Set intended read/write operation
+		mids[i]->rw = request->Type & 0xF000;
+	}
+
+	request->Type = request->Type & 0x0FFF;
+
+	// because P8 data (bitstream) for h264 encoder should be allocated by CreateBuffer()
+	// but P8 data (MBData) for MPEG2 encoder should be allocated by CreateTexture2D()
+	if (request->Info.FourCC == MFX_FOURCC_P8) {
+		D3D11_BUFFER_DESC desc = { 0 };
+
+		if (!request->NumFrameSuggested)
+			return MFX_ERR_MEMORY_ALLOC;
+
+		desc.ByteWidth           = request->Info.Width * request->Info.Height;
+		desc.Usage               = D3D11_USAGE_STAGING;
+		desc.BindFlags           = 0;
+		desc.CPUAccessFlags      = D3D11_CPU_ACCESS_READ;
+		desc.MiscFlags           = 0;
+		desc.StructureByteStride = 0;
+
+		ID3D11Buffer *buffer = 0;
+		hRes = g_pD3D11Device->CreateBuffer(&desc, 0, &buffer);
+		if (FAILED(hRes))
+			return MFX_ERR_MEMORY_ALLOC;
+
+		mids[0]->memId = reinterpret_cast<ID3D11Texture2D*>(buffer);
+	} else {
+		D3D11_TEXTURE2D_DESC desc = {0};
+
+		desc.Width              = request->Info.Width;
+		desc.Height             = request->Info.Height;
+		desc.MipLevels          = 1;
+		desc.ArraySize          = 1; // number of subresources is 1 in this case
+		desc.Format             = format;
+		desc.SampleDesc.Count   = 1;
+		desc.Usage              = D3D11_USAGE_DEFAULT;
+		desc.BindFlags          = D3D11_BIND_DECODER;
+		desc.MiscFlags          = 0;
+		//desc.MiscFlags          = D3D11_RESOURCE_MISC_SHARED;
+
+		if ((MFX_MEMTYPE_FROM_VPPIN & request->Type) &&
+			(DXGI_FORMAT_B8G8R8A8_UNORM == desc.Format)) {
+			desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+			if (desc.ArraySize > 2)
+				return MFX_ERR_MEMORY_ALLOC;
+		}
+
+		if ((MFX_MEMTYPE_FROM_VPPOUT & request->Type) ||
+			(MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET & request->Type)) {
+			desc.BindFlags = D3D11_BIND_RENDER_TARGET;
+			if (desc.ArraySize > 2)
+				return MFX_ERR_MEMORY_ALLOC;
+		}
+
+		if (DXGI_FORMAT_P8 == desc.Format)
+			desc.BindFlags = 0;
+
+		ID3D11Texture2D *pTexture2D;
+
+		// Create surface textures
+		for (size_t i = 0;
+			i < request->NumFrameSuggested / desc.ArraySize; i++) {
+			hRes = g_pD3D11Device->CreateTexture2D(&desc, NULL,
+					&pTexture2D);
+
+			if (FAILED(hRes))
+				return MFX_ERR_MEMORY_ALLOC;
+
+			mids[i]->memId = pTexture2D;
+		}
+
+		desc.ArraySize      = 1;
+		desc.Usage          = D3D11_USAGE_STAGING;
+		desc.CPUAccessFlags = D3D11_CPU_ACCESS_READ;// | D3D11_CPU_ACCESS_WRITE;
+		desc.BindFlags      = 0;
+		desc.MiscFlags      = 0;
+		//desc.MiscFlags      = D3D11_RESOURCE_MISC_SHARED;
+
+		// Create surface staging textures
+		for (size_t i = 0; i < request->NumFrameSuggested; i++) {
+			hRes = g_pD3D11Device->CreateTexture2D(&desc, NULL,
+					&pTexture2D);
+
+			if (FAILED(hRes))
+				return MFX_ERR_MEMORY_ALLOC;
+
+			mids[i]->memIdStage = pTexture2D;
+		}
+	}
+
+
+	response->mids = (mfxMemId*)mids;
+	response->NumFrameActual = request->NumFrameSuggested;
+
+	return MFX_ERR_NONE;
 }
 
-mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest* request, mfxFrameAllocResponse* response)
+mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request,
+	mfxFrameAllocResponse *response)
 {
-    mfxStatus sts = MFX_ERR_NONE;
+	mfxStatus sts = MFX_ERR_NONE;
 
-    if (request->Type & MFX_MEMTYPE_SYSTEM_MEMORY)
-        return MFX_ERR_UNSUPPORTED;
+	if (request->Type & MFX_MEMTYPE_SYSTEM_MEMORY)
+		return MFX_ERR_UNSUPPORTED;
 
-    if (allocDecodeResponses.find(pthis) != allocDecodeResponses.end() &&
-        MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
-        MFX_MEMTYPE_FROM_DECODE & request->Type) {
-        // Memory for this request was already allocated during manual allocation stage. Return saved response
-        //   When decode acceleration device (DXVA) is created it requires a list of d3d surfaces to be passed.
-        //   Therefore Media SDK will ask for the surface info/mids again at Init() stage, thus requiring us to return the saved response
-        //   (No such restriction applies to Encode or VPP)
-        *response = allocDecodeResponses[pthis];
-        allocDecodeRefCount[pthis]++;
-    } else {
-        sts = _simple_alloc(request, response);
+	if (allocDecodeResponses.find(pthis) != allocDecodeResponses.end() &&
+		MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
+		MFX_MEMTYPE_FROM_DECODE & request->Type) {
+		/*
+		 * Memory for this request was already allocated during manual
+		 * allocation stage. Return saved response.
+		 *   When decode acceleration device (DXVA) is created it
+		 *   requires a list of d3d surfaces to be passed. Therefore
+		 *   Media SDK will ask for the surface info/mids again at
+		 *   Init() stage, thus requiring us to return the saved
+		 *   response. (No such restriction applies to Encode or VPP)
+		 */
+		*response = allocDecodeResponses[pthis];
+		allocDecodeRefCount[pthis]++;
+	} else {
+		sts = _simple_alloc(request, response);
 
-        if (MFX_ERR_NONE == sts) {
-            if ( MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
-                 MFX_MEMTYPE_FROM_DECODE & request->Type) {
-                // Decode alloc response handling
-                allocDecodeResponses[pthis] = *response;
-                allocDecodeRefCount[pthis]++;
-            } else {
-                // Encode and VPP alloc response handling
-                allocResponses[response->mids] = pthis;
-            }
-        }
-    }
+		if (MFX_ERR_NONE == sts) {
+			if (MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
+				MFX_MEMTYPE_FROM_DECODE & request->Type) {
+				// Decode alloc response handling
+				allocDecodeResponses[pthis] = *response;
+				allocDecodeRefCount[pthis]++;
+			} else {
+				// Encode and VPP alloc response handling
+				allocResponses[response->mids] = pthis;
+			}
+		}
+	}
 
-    return sts;
+	return sts;
 }
 
-mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
+mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 {
-    pthis; // To suppress warning for this unused parameter
+	pthis; // To suppress warning for this unused parameter
 
-    HRESULT hRes = S_OK;
+	HRESULT hRes = S_OK;
 
-    D3D11_TEXTURE2D_DESC        desc = {0};
-    D3D11_MAPPED_SUBRESOURCE    lockedRect = {0};
+	D3D11_TEXTURE2D_DESC        desc = {0};
+	D3D11_MAPPED_SUBRESOURCE    lockedRect = {0};
 
-    CustomMemId*        memId       = (CustomMemId*)mid;
-    ID3D11Texture2D*    pSurface    = (ID3D11Texture2D*)memId->memId;
-    ID3D11Texture2D*    pStage      = (ID3D11Texture2D*)memId->memIdStage;
+	CustomMemId        *memId       = (CustomMemId*)mid;
+	ID3D11Texture2D    *pSurface    = (ID3D11Texture2D*)memId->memId;
+	ID3D11Texture2D    *pStage      = (ID3D11Texture2D*)memId->memIdStage;
 
-    D3D11_MAP   mapType  = D3D11_MAP_READ;
-    UINT        mapFlags = D3D11_MAP_FLAG_DO_NOT_WAIT;
+	D3D11_MAP   mapType  = D3D11_MAP_READ;
+	UINT        mapFlags = D3D11_MAP_FLAG_DO_NOT_WAIT;
 
-    if (NULL == pStage) {
-        hRes = g_pD3D11Ctx->Map(pSurface, 0, mapType, mapFlags, &lockedRect);
-        desc.Format = DXGI_FORMAT_P8;
-    } else {
-        pSurface->GetDesc(&desc);
+	if (NULL == pStage) {
+		hRes = g_pD3D11Ctx->Map(pSurface, 0, mapType, mapFlags,
+				&lockedRect);
+		desc.Format = DXGI_FORMAT_P8;
+	} else {
+		pSurface->GetDesc(&desc);
 
-        // copy data only in case of user wants to read from stored surface
-        if (memId->rw & WILL_READ)
-            g_pD3D11Ctx->CopySubresourceRegion(pStage, 0, 0, 0, 0, pSurface, 0, NULL);
+		// copy data only in case of user wants to read from stored surface
+		if (memId->rw & WILL_READ)
+			g_pD3D11Ctx->CopySubresourceRegion(pStage, 0, 0, 0, 0,
+					pSurface, 0, NULL);
 
-        do {
-            hRes = g_pD3D11Ctx->Map(pStage, 0, mapType, mapFlags, &lockedRect);
-            if (S_OK != hRes && DXGI_ERROR_WAS_STILL_DRAWING != hRes)
-                return MFX_ERR_LOCK_MEMORY;
-        } while (DXGI_ERROR_WAS_STILL_DRAWING == hRes);
-    }
+		do {
+			hRes = g_pD3D11Ctx->Map(pStage, 0, mapType, mapFlags,
+					&lockedRect);
+			if (S_OK != hRes &&
+				DXGI_ERROR_WAS_STILL_DRAWING != hRes)
+				return MFX_ERR_LOCK_MEMORY;
+		} while (DXGI_ERROR_WAS_STILL_DRAWING == hRes);
+	}
 
-    if (FAILED(hRes))
-        return MFX_ERR_LOCK_MEMORY;
+	if (FAILED(hRes))
+		return MFX_ERR_LOCK_MEMORY;
 
-    switch (desc.Format) {
-    case DXGI_FORMAT_NV12:
-        ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-        ptr->Y = (mfxU8*)lockedRect.pData;
-        ptr->U = (mfxU8*)lockedRect.pData + desc.Height * lockedRect.RowPitch;
-        ptr->V = ptr->U + 1;
-        break;
-    case DXGI_FORMAT_B8G8R8A8_UNORM :
-        ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-        ptr->B = (mfxU8*)lockedRect.pData;
-        ptr->G = ptr->B + 1;
-        ptr->R = ptr->B + 2;
-        ptr->A = ptr->B + 3;
-        break;
-    case DXGI_FORMAT_YUY2:
-        ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-        ptr->Y = (mfxU8*)lockedRect.pData;
-        ptr->U = ptr->Y + 1;
-        ptr->V = ptr->Y + 3;
-        break;
-    case DXGI_FORMAT_P8 :
-        ptr->Pitch = (mfxU16)lockedRect.RowPitch;
-        ptr->Y = (mfxU8*)lockedRect.pData;
-        ptr->U = 0;
-        ptr->V = 0;
-        break;
-    default:
-        return MFX_ERR_LOCK_MEMORY;
-    }
+	switch (desc.Format) {
+	case DXGI_FORMAT_NV12:
+		ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+		ptr->Y = (mfxU8*)lockedRect.pData;
+		ptr->U = (mfxU8*)lockedRect.pData + desc.Height * lockedRect.RowPitch;
+		ptr->V = ptr->U + 1;
+		break;
+	case DXGI_FORMAT_B8G8R8A8_UNORM :
+		ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+		ptr->B = (mfxU8*)lockedRect.pData;
+		ptr->G = ptr->B + 1;
+		ptr->R = ptr->B + 2;
+		ptr->A = ptr->B + 3;
+		break;
+	case DXGI_FORMAT_YUY2:
+		ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+		ptr->Y = (mfxU8*)lockedRect.pData;
+		ptr->U = ptr->Y + 1;
+		ptr->V = ptr->Y + 3;
+		break;
+	case DXGI_FORMAT_P8 :
+		ptr->Pitch = (mfxU16)lockedRect.RowPitch;
+		ptr->Y = (mfxU8*)lockedRect.pData;
+		ptr->U = 0;
+		ptr->V = 0;
+		break;
+	default:
+		return MFX_ERR_LOCK_MEMORY;
+	}
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
+mfxStatus simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 {
-    pthis; // To suppress warning for this unused parameter
+	pthis; // To suppress warning for this unused parameter
 
-    CustomMemId*        memId       = (CustomMemId*)mid;
-    ID3D11Texture2D*    pSurface    = (ID3D11Texture2D*)memId->memId;
-    ID3D11Texture2D*    pStage      = (ID3D11Texture2D*)memId->memIdStage;
+	CustomMemId        *memId       = (CustomMemId*)mid;
+	ID3D11Texture2D    *pSurface    = (ID3D11Texture2D*)memId->memId;
+	ID3D11Texture2D    *pStage      = (ID3D11Texture2D*)memId->memIdStage;
 
-    if (NULL == pStage) {
-        g_pD3D11Ctx->Unmap(pSurface, 0);
-    } else {
-        g_pD3D11Ctx->Unmap(pStage, 0);
-        // copy data only in case of user wants to write to stored surface
-        if (memId->rw & WILL_WRITE)
-            g_pD3D11Ctx->CopySubresourceRegion(pSurface, 0, 0, 0, 0, pStage, 0, NULL);
-    }
+	if (NULL == pStage) {
+		g_pD3D11Ctx->Unmap(pSurface, 0);
+	} else {
+		g_pD3D11Ctx->Unmap(pStage, 0);
+		// copy data only in case of user wants to write to stored surface
+		if (memId->rw & WILL_WRITE)
+			g_pD3D11Ctx->CopySubresourceRegion(pSurface, 0, 0, 0,
+					0, pStage, 0, NULL);
+	}
 
-    if (ptr) {
-        ptr->Pitch=0;
-        ptr->U=ptr->V=ptr->Y=0;
-        ptr->A=ptr->R=ptr->G=ptr->B=0;
-    }
+	if (ptr) {
+		ptr->Pitch=0;
+		ptr->U=ptr->V=ptr->Y=0;
+		ptr->A=ptr->R=ptr->G=ptr->B=0;
+	}
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL* handle)
+mfxStatus simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL *handle)
 {
-    pthis; // To suppress warning for this unused parameter
+	pthis; // To suppress warning for this unused parameter
 
-    if (NULL == handle)
-        return MFX_ERR_INVALID_HANDLE;
+	if (NULL == handle)
+		return MFX_ERR_INVALID_HANDLE;
 
-    mfxHDLPair*     pPair = (mfxHDLPair*)handle;
-    CustomMemId*    memId = (CustomMemId*)mid;
+	mfxHDLPair     *pPair = (mfxHDLPair*)handle;
+	CustomMemId    *memId = (CustomMemId*)mid;
 
-    pPair->first  = memId->memId; // surface texture
-    pPair->second = 0;
+	pPair->first  = memId->memId; // surface texture
+	pPair->second = 0;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
 
-mfxStatus _simple_free(mfxFrameAllocResponse* response)
+mfxStatus _simple_free(mfxFrameAllocResponse *response)
 {
-    if (response->mids) {
-        for (mfxU32 i = 0; i < response->NumFrameActual; i++) {
-            if (response->mids[i]) {
-                CustomMemId*        mid         = (CustomMemId*)response->mids[i];
-                ID3D11Texture2D*    pSurface    = (ID3D11Texture2D*)mid->memId;
-                ID3D11Texture2D*    pStage      = (ID3D11Texture2D*)mid->memIdStage;
+	if (response->mids) {
+		for (mfxU32 i = 0; i < response->NumFrameActual; i++) {
+			if (response->mids[i]) {
+				CustomMemId     *mid      = (CustomMemId*)response->mids[i];
+				ID3D11Texture2D *pSurface = (ID3D11Texture2D*)mid->memId;
+				ID3D11Texture2D *pStage   = (ID3D11Texture2D*)mid->memIdStage;
 
-                if (pSurface)
-                    pSurface->Release();
-                if (pStage)
-                    pStage->Release();
+				if (pSurface)
+					pSurface->Release();
+				if (pStage)
+					pStage->Release();
 
-                free(mid);
-            }
-        }
-        free(response->mids);
-        response->mids = NULL;
-    }
+				free(mid);
+			}
+		}
+		free(response->mids);
+		response->mids = NULL;
+	}
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse* response)
+mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse *response)
 {
-    if (NULL == response)
-        return MFX_ERR_NULL_PTR;
+	if (NULL == response)
+		return MFX_ERR_NULL_PTR;
 
-    if (allocResponses.find(response->mids) == allocResponses.end()) {
-        // Decode free response handling
-        if (--allocDecodeRefCount[pthis] == 0) {
-            _simple_free(response);
-            allocDecodeResponses.erase(pthis);
-            allocDecodeRefCount.erase(pthis);
-        }
-    } else {
-        // Encode and VPP free response handling
-        allocResponses.erase(response->mids);
-        _simple_free(response);
-    }
+	if (allocResponses.find(response->mids) == allocResponses.end()) {
+		// Decode free response handling
+		if (--allocDecodeRefCount[pthis] == 0) {
+			_simple_free(response);
+			allocDecodeResponses.erase(pthis);
+			allocDecodeRefCount.erase(pthis);
+		}
+	} else {
+		// Encode and VPP free response handling
+		allocResponses.erase(response->mids);
+		_simple_free(response);
+	}
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }

--- a/plugins/obs-qsv11/common_directx11.h
+++ b/plugins/obs-qsv11/common_directx11.h
@@ -31,7 +31,7 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 //     - Device must be active (but monitor does NOT have to be attached)
 //     - Device must be enabled in BIOS. Required for the case when used together with a discrete graphics card
 //     - For switchable graphics solutions (mobile) make sure that Intel device is the active device
-mfxStatus CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND hWnd, bool bCreateSharedHandles);
+mfxStatus CreateHWDevice(mfxSession session, mfxHDL *deviceHandle, HWND hWnd, bool bCreateSharedHandles);
 void CleanupHWDevice();
 void SetHWDeviceContext(CComPtr<ID3D11DeviceContext> devCtx);
 CComPtr<ID3D11DeviceContext> GetHWDeviceContext();

--- a/plugins/obs-qsv11/common_directx9.cpp
+++ b/plugins/obs-qsv11/common_directx9.cpp
@@ -24,7 +24,7 @@ HANDLE m_hDecoder;
 HANDLE m_hProcessor;
 DWORD m_surfaceUsage;
 
-CD3D9Device* g_hwdevice;
+CD3D9Device *g_hwdevice;
 
 const struct {
 	mfxIMPL impl;       // actual implementation
@@ -38,35 +38,35 @@ const struct {
 
 struct mfxAllocatorParams
 {
-    virtual ~mfxAllocatorParams(){};
+	virtual ~mfxAllocatorParams(){};
 };
 
 struct D3DAllocatorParams : mfxAllocatorParams
 {
-    IDirect3DDeviceManager9 *pManager;
-    DWORD surfaceUsage;
+	IDirect3DDeviceManager9 *pManager;
+	DWORD surfaceUsage;
 
-    D3DAllocatorParams()
-        : pManager()
-        , surfaceUsage()
-    {
-    }
+	D3DAllocatorParams()
+		: pManager()
+		, surfaceUsage()
+	{
+	}
 };
 
 mfxStatus DX9_Alloc_Init(D3DAllocatorParams *pParams)
 {
-    D3DAllocatorParams *pd3dParams = 0;
-    pd3dParams = dynamic_cast<D3DAllocatorParams *>(pParams);
-    if (!pd3dParams)
-        return MFX_ERR_NOT_INITIALIZED;
+	D3DAllocatorParams *pd3dParams = 0;
+	pd3dParams = dynamic_cast<D3DAllocatorParams *>(pParams);
+	if (!pd3dParams)
+		return MFX_ERR_NOT_INITIALIZED;
 
-    m_manager = pd3dParams->pManager;
-    m_surfaceUsage = pd3dParams->surfaceUsage;
+	m_manager = pd3dParams->pManager;
+	m_surfaceUsage = pd3dParams->surfaceUsage;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus DX9_CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND, bool)
+mfxStatus DX9_CreateHWDevice(mfxSession session, mfxHDL *deviceHandle, HWND, bool)
 {
 	mfxStatus result;
 
@@ -76,9 +76,10 @@ mfxStatus DX9_CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND, boo
 
 	MFXQueryIMPL(session, &impl);
 
-	mfxIMPL baseImpl = MFX_IMPL_BASETYPE(impl); // Extract Media SDK base implementation type
+	// Extract Media SDK base implementation type
+	mfxIMPL baseImpl = MFX_IMPL_BASETYPE(impl);
 
-						    // get corresponding adapter number
+	// get corresponding adapter number
 	for (mfxU8 i = 0; i < sizeof(implTypes) / sizeof(implTypes[0]); i++) {
 		if (implTypes[i].impl == baseImpl) {
 			adapterNum = implTypes[i].adapterID;
@@ -96,9 +97,9 @@ mfxStatus DX9_CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND, boo
 
 	g_hwdevice->GetHandle(MFX_HANDLE_D3D9_DEVICE_MANAGER, deviceHandle);
 
-
 	D3DAllocatorParams dx9_allocParam;
-	dx9_allocParam.pManager = reinterpret_cast<IDirect3DDeviceManager9 *>(*deviceHandle);
+	dx9_allocParam.pManager =
+			reinterpret_cast<IDirect3DDeviceManager9 *>(*deviceHandle);
 	DX9_Alloc_Init(&dx9_allocParam);
 	return MFX_ERR_NONE;
 }
@@ -115,18 +116,15 @@ void DX9_CleanupHWDevice()
 		m_manager = NULL;
 		m_hDecoder = NULL;
 	}
-
 	if (m_manager && m_hProcessor) {
 		m_manager->CloseDeviceHandle(m_hProcessor);
 		m_manager = NULL;
 		m_hProcessor = NULL;
 	}
-
 	if (m_decoderService) {
 		// delete m_decoderService;
 		m_decoderService = NULL;
 	}
-
 	if (m_processorService) {
 		// delete m_processorService;
 		m_processorService = NULL;
@@ -135,8 +133,7 @@ void DX9_CleanupHWDevice()
 
 D3DFORMAT ConvertMfxFourccToD3dFormat(mfxU32 fourcc)
 {
-	switch (fourcc)
-	{
+	switch (fourcc) {
 	case MFX_FOURCC_NV12:
 		return D3DFMT_NV12;
 	case MFX_FOURCC_YV12:
@@ -158,7 +155,7 @@ D3DFORMAT ConvertMfxFourccToD3dFormat(mfxU32 fourcc)
 	}
 }
 
-mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
+mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
 {
 	pthis; // To suppress warning for this unused parameter
 
@@ -166,7 +163,8 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
 		return MFX_ERR_NULL_PTR;
 
 	mfxHDLPair *dxmid = (mfxHDLPair*)mid;
-	IDirect3DSurface9 *pSurface = static_cast<IDirect3DSurface9*>(dxmid->first);
+	IDirect3DSurface9 *pSurface =
+			static_cast<IDirect3DSurface9*>(dxmid->first);
 	if (pSurface == 0)
 		return MFX_ERR_INVALID_HANDLE;
 
@@ -191,8 +189,7 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
 	if (FAILED(hr))
 		return MFX_ERR_LOCK_MEMORY;
 
-	switch ((DWORD)desc.Format)
-	{
+	switch ((DWORD)desc.Format) {
 	case D3DFMT_NV12:
 		ptr->Pitch = (mfxU16)locked.Pitch;
 		ptr->Y = (mfxU8 *)locked.pBits;
@@ -243,20 +240,20 @@ mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr)
 	return MFX_ERR_NONE;
 }
 
-mfxStatus dx9_simple_unlock(mfxHDL, mfxMemId mid, mfxFrameData* ptr)
+mfxStatus dx9_simple_unlock(mfxHDL, mfxMemId mid, mfxFrameData *ptr)
 {
 	if (!mid)
 		return MFX_ERR_NULL_PTR;
 
 	mfxHDLPair *dxmid = (mfxHDLPair*)mid;
-	IDirect3DSurface9 *pSurface = static_cast<IDirect3DSurface9*>(dxmid->first);
+	IDirect3DSurface9 *pSurface =
+			static_cast<IDirect3DSurface9*>(dxmid->first);
 	if (pSurface == 0)
 		return MFX_ERR_INVALID_HANDLE;
 
 	pSurface->UnlockRect();
 
-	if (NULL != ptr)
-	{
+	if (NULL != ptr) {
 		ptr->Pitch = 0;
 		ptr->Y = 0;
 		ptr->U = 0;
@@ -266,7 +263,7 @@ mfxStatus dx9_simple_unlock(mfxHDL, mfxMemId mid, mfxFrameData* ptr)
 	return MFX_ERR_NONE;
 }
 
-mfxStatus dx9_simple_gethdl(mfxHDL, mfxMemId mid, mfxHDL* handle)
+mfxStatus dx9_simple_gethdl(mfxHDL, mfxMemId mid, mfxHDL *handle)
 {
 	if (!mid || !handle)
 		return MFX_ERR_NULL_PTR;
@@ -276,7 +273,7 @@ mfxStatus dx9_simple_gethdl(mfxHDL, mfxMemId mid, mfxHDL* handle)
 	return MFX_ERR_NONE;
 }
 
-mfxStatus _dx9_simple_free(mfxFrameAllocResponse* response)
+mfxStatus _dx9_simple_free(mfxFrameAllocResponse *response)
 {
 	if (!response)
 		return MFX_ERR_NULL_PTR;
@@ -286,7 +283,8 @@ mfxStatus _dx9_simple_free(mfxFrameAllocResponse* response)
 	if (response->mids) {
 		for (mfxU32 i = 0; i < response->NumFrameActual; i++) {
 			if (response->mids[i]) {
-				mfxHDLPair *dxMids = (mfxHDLPair*)response->mids[i];
+				mfxHDLPair *dxMids =
+						(mfxHDLPair*)response->mids[i];
 				static_cast<IDirect3DSurface9*>(dxMids->first)->Release();
 			}
 		}
@@ -297,28 +295,29 @@ mfxStatus _dx9_simple_free(mfxFrameAllocResponse* response)
 	return sts;
 }
 
-mfxStatus dx9_simple_free(mfxHDL pthis, mfxFrameAllocResponse* response)
+mfxStatus dx9_simple_free(mfxHDL pthis, mfxFrameAllocResponse *response)
 {
-    if (NULL == response)
-        return MFX_ERR_NULL_PTR;
+	if (NULL == response)
+		return MFX_ERR_NULL_PTR;
 
-    if (dx9_allocResponses.find(response->mids) == dx9_allocResponses.end()) {
-        // Decode free response handling
-        if (--dx9_allocDecodeRefCount[pthis] == 0) {
-            _dx9_simple_free(response);
-            dx9_allocDecodeResponses.erase(pthis);
-            dx9_allocDecodeRefCount.erase(pthis);
-        }
-    } else {
-        // Encode and VPP free response handling
-        dx9_allocResponses.erase(response->mids);
-        _dx9_simple_free(response);
-    }
+	if (dx9_allocResponses.find(response->mids) == dx9_allocResponses.end()) {
+		// Decode free response handling
+		if (--dx9_allocDecodeRefCount[pthis] == 0) {
+			_dx9_simple_free(response);
+			dx9_allocDecodeResponses.erase(pthis);
+			dx9_allocDecodeRefCount.erase(pthis);
+		}
+	} else {
+		// Encode and VPP free response handling
+		dx9_allocResponses.erase(response->mids);
+		_dx9_simple_free(response);
+	}
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse* response)
+mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest *request,
+	mfxFrameAllocResponse *response)
 {
 	HRESULT hr;
 
@@ -331,20 +330,17 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 	if (format == D3DFMT_UNKNOWN)
 		return MFX_ERR_UNSUPPORTED;
 
-	DWORD   target;
+	DWORD target;
 
-	if (MFX_MEMTYPE_DXVA2_DECODER_TARGET & request->Type)
-	{
+	if (MFX_MEMTYPE_DXVA2_DECODER_TARGET & request->Type) {
 		target = DXVA2_VideoDecoderRenderTarget;
-	}
-	else if (MFX_MEMTYPE_DXVA2_PROCESSOR_TARGET & request->Type)
-	{
+	} else if (MFX_MEMTYPE_DXVA2_PROCESSOR_TARGET & request->Type) {
 		target = DXVA2_VideoProcessorRenderTarget;
-	}
-	else
+	} else {
 		return MFX_ERR_UNSUPPORTED;
+	}
 
-	IDirectXVideoAccelerationService* videoService = NULL;
+	IDirectXVideoAccelerationService *videoService = NULL;
 
 	if (target == DXVA2_VideoProcessorRenderTarget) {
 		if (!m_hProcessor) {
@@ -352,29 +348,34 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 			if (FAILED(hr))
 				return MFX_ERR_MEMORY_ALLOC;
 
-			hr = m_manager->GetVideoService(m_hProcessor, IID_IDirectXVideoProcessorService, (void**)&m_processorService);
+			hr = m_manager->GetVideoService(m_hProcessor,
+					IID_IDirectXVideoProcessorService,
+					(void**)&m_processorService);
 			if (FAILED(hr))
 				return MFX_ERR_MEMORY_ALLOC;
 		}
 		videoService = m_processorService;
-	}
-	else {
-		if (!m_hDecoder)
-		{
+	} else {
+		if (!m_hDecoder) {
 			hr = m_manager->OpenDeviceHandle(&m_hDecoder);
 			if (FAILED(hr))
 				return MFX_ERR_MEMORY_ALLOC;
 
-			hr = m_manager->GetVideoService(m_hDecoder, IID_IDirectXVideoDecoderService, (void**)&m_decoderService);
+			hr = m_manager->GetVideoService(m_hDecoder,
+					IID_IDirectXVideoDecoderService,
+					(void**)&m_decoderService);
 			if (FAILED(hr))
 				return MFX_ERR_MEMORY_ALLOC;
 		}
 		videoService = m_decoderService;
 	}
 
-	mfxHDLPair *dxMids = NULL, **dxMidPtrs = NULL;
-	dxMids = (mfxHDLPair*)calloc(request->NumFrameSuggested, sizeof(mfxHDLPair));
-	dxMidPtrs = (mfxHDLPair**)calloc(request->NumFrameSuggested, sizeof(mfxHDLPair*));
+	mfxHDLPair *dxMids = NULL;
+	mfxHDLPair **dxMidPtrs = NULL;
+	dxMids = (mfxHDLPair*)calloc(request->NumFrameSuggested,
+			sizeof(mfxHDLPair));
+	dxMidPtrs = (mfxHDLPair**)calloc(request->NumFrameSuggested,
+			sizeof(mfxHDLPair*));
 
 	if (!dxMids || !dxMidPtrs) {
 		MSDK_SAFE_FREE(dxMids);
@@ -387,8 +388,11 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 
 	if (request->Type & MFX_MEMTYPE_EXTERNAL_FRAME) {
 		for (int i = 0; i < request->NumFrameSuggested; i++) {
-			hr = videoService->CreateSurface(request->Info.Width, request->Info.Height, 0, format,
-				D3DPOOL_DEFAULT, m_surfaceUsage, target, (IDirect3DSurface9**)&dxMids[i].first, &dxMids[i].second);
+			hr = videoService->CreateSurface(request->Info.Width,
+					request->Info.Height, 0, format,
+					D3DPOOL_DEFAULT, m_surfaceUsage, target,
+					(IDirect3DSurface9**)&dxMids[i].first,
+					&dxMids[i].second);
 			if (FAILED(hr)) {
 				_dx9_simple_free(response);
 				MSDK_SAFE_FREE(dxMids);
@@ -396,22 +400,21 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 			}
 			dxMidPtrs[i] = &dxMids[i];
 		}
-	}
-	else {
+	} else {
 		safe_array<IDirect3DSurface9*> dxSrf(new IDirect3DSurface9*[request->NumFrameSuggested]);
-		if (!dxSrf.get())
-		{
+		if (!dxSrf.get()) {
 			MSDK_SAFE_FREE(dxMids);
 			return MFX_ERR_MEMORY_ALLOC;
 		}
-		hr = videoService->CreateSurface(request->Info.Width, request->Info.Height, request->NumFrameSuggested - 1, format,
-			D3DPOOL_DEFAULT, m_surfaceUsage, target, dxSrf.get(), NULL);
-		if (FAILED(hr))
-		{
+		hr = videoService->CreateSurface(request->Info.Width,
+				request->Info.Height,
+				request->NumFrameSuggested - 1, format,
+				D3DPOOL_DEFAULT, m_surfaceUsage, target,
+				dxSrf.get(), NULL);
+		if (FAILED(hr)) {
 			MSDK_SAFE_FREE(dxMids);
 			return MFX_ERR_MEMORY_ALLOC;
 		}
-
 
 		for (int i = 0; i < request->NumFrameSuggested; i++) {
 			dxMids[i].first = dxSrf.get()[i];
@@ -421,37 +424,43 @@ mfxStatus _dx9_simple_alloc(mfxFrameAllocRequest* request, mfxFrameAllocResponse
 	return MFX_ERR_NONE;
 }
 
-mfxStatus dx9_simple_alloc(mfxHDL pthis, mfxFrameAllocRequest* request, mfxFrameAllocResponse* response)
+mfxStatus dx9_simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request,
+	mfxFrameAllocResponse *response)
 {
-    mfxStatus sts = MFX_ERR_NONE;
+	mfxStatus sts = MFX_ERR_NONE;
 
-    if (request->Type & MFX_MEMTYPE_SYSTEM_MEMORY)
-        return MFX_ERR_UNSUPPORTED;
+	if (request->Type & MFX_MEMTYPE_SYSTEM_MEMORY)
+		return MFX_ERR_UNSUPPORTED;
 
-    if (dx9_allocDecodeResponses.find(pthis) != dx9_allocDecodeResponses.end() &&
-        MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
-        MFX_MEMTYPE_FROM_DECODE & request->Type) {
-        // Memory for this request was already allocated during manual allocation stage. Return saved response
-        //   When decode acceleration device (DXVA) is created it requires a list of d3d surfaces to be passed.
-        //   Therefore Media SDK will ask for the surface info/mids again at Init() stage, thus requiring us to return the saved response
-        //   (No such restriction applies to Encode or VPP)
-        *response = dx9_allocDecodeResponses[pthis];
-        dx9_allocDecodeRefCount[pthis]++;
-    } else {
-        sts = _dx9_simple_alloc(request, response);
+	if (dx9_allocDecodeResponses.find(pthis) != dx9_allocDecodeResponses.end() &&
+		MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
+		MFX_MEMTYPE_FROM_DECODE & request->Type) {
+		/*
+		 * Memory for this request was already allocated during manual
+		 * allocation stage. Return saved response.
+		 *   When decode acceleration device (DXVA) is created it
+		 *   requires a list of d3d surfaces to be passed. Therefore
+		 *   Media SDK will ask for the surface info/mids again at
+		 *   Init() stage, thus requiring us to return the saved
+		 *   response. (No such restriction applies to Encode or VPP)
+		 */
+		*response = dx9_allocDecodeResponses[pthis];
+		dx9_allocDecodeRefCount[pthis]++;
+	} else {
+		sts = _dx9_simple_alloc(request, response);
 
-        if (MFX_ERR_NONE == sts) {
-            if ( MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
-                 MFX_MEMTYPE_FROM_DECODE & request->Type) {
-                // Decode alloc response handling
-                dx9_allocDecodeResponses[pthis] = *response;
-                dx9_allocDecodeRefCount[pthis]++;
-            } else {
-                // Encode and VPP alloc response handling
-                dx9_allocResponses[response->mids] = pthis;
-            }
-        }
-    }
+		if (MFX_ERR_NONE == sts) {
+			if (MFX_MEMTYPE_EXTERNAL_FRAME & request->Type &&
+				MFX_MEMTYPE_FROM_DECODE & request->Type) {
+				// Decode alloc response handling
+				dx9_allocDecodeResponses[pthis] = *response;
+				dx9_allocDecodeRefCount[pthis]++;
+			} else {
+				// Encode and VPP alloc response handling
+				dx9_allocResponses[response->mids] = pthis;
+			}
+		}
+	}
 
-    return sts;
+	return sts;
 }

--- a/plugins/obs-qsv11/common_directx9.h
+++ b/plugins/obs-qsv11/common_directx9.h
@@ -27,44 +27,42 @@ MFX_HANDLE_GFXS3DCONTROL must be set prior if initializing for 2 views.
 
 @note Device always set D3DPRESENT_PARAMETERS::Windowed to TRUE.
 */
-    template <class T>
-    class safe_array
-    {
-    public:
-        safe_array(T *ptr = 0):m_ptr(ptr)
-        { // construct from object pointer
-        };
-        ~safe_array()
-        {
-            reset(0);
-        }
-        T* get()
-        { // return wrapped pointer
-            return m_ptr;
-        }
-        T* release()
-        { // return wrapped pointer and give up ownership
-            T* ptr = m_ptr;
-            m_ptr = 0;
-            return ptr;
-        }
-        void reset(T* ptr)
-        { // destroy designated object and store new pointer
-            if (m_ptr)
-            {
-                delete[] m_ptr;
-            }
-            m_ptr = ptr;
-        }
-    protected:
-        T* m_ptr; // the wrapped object pointer
-    };
+	template <class T>
+	class safe_array
+	{
+	public:
+		safe_array(T *ptr = 0):m_ptr(ptr)
+		{ // construct from object pointer
+		};
+		~safe_array()
+		{
+			reset(0);
+		}
+		T* get()
+		{ // return wrapped pointer
+			return m_ptr;
+		}
+		T* release()
+		{ // return wrapped pointer and give up ownership
+			T* ptr = m_ptr;
+			m_ptr = 0;
+			return ptr;
+		}
+		void reset(T* ptr)
+		{ // destroy designated object and store new pointer
+			if (m_ptr)
+				delete[] m_ptr;
+			m_ptr = ptr;
+		}
+	protected:
+		T* m_ptr; // the wrapped object pointer
+	};
 
-mfxStatus dx9_simple_alloc(mfxHDL pthis, mfxFrameAllocRequest* request, mfxFrameAllocResponse* response);
-mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr);
-mfxStatus dx9_simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr);
-mfxStatus dx9_simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL* handle);
-mfxStatus dx9_simple_free(mfxHDL pthis, mfxFrameAllocResponse* response);
+mfxStatus dx9_simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request, mfxFrameAllocResponse *response);
+mfxStatus dx9_simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr);
+mfxStatus dx9_simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr);
+mfxStatus dx9_simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL *handle);
+mfxStatus dx9_simple_free(mfxHDL pthis, mfxFrameAllocResponse *response);
 
-mfxStatus DX9_CreateHWDevice(mfxSession session, mfxHDL* deviceHandle, HWND hWnd, bool bCreateSharedHandles);
+mfxStatus DX9_CreateHWDevice(mfxSession session, mfxHDL *deviceHandle, HWND hWnd, bool bCreateSharedHandles);
 void DX9_CleanupHWDevice();

--- a/plugins/obs-qsv11/common_utils.cpp
+++ b/plugins/obs-qsv11/common_utils.cpp
@@ -15,292 +15,302 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 //
 
 
-void PrintErrString(int err,const char* filestr,int line)
+void PrintErrString(int err, const char *filestr, int line)
 {
-    switch (err) {
-    case   0:
-        printf("\n No error.\n");
-        break;
-    case  -1:
-        printf("\n Unknown error: %s %d\n",filestr,line);
-        break;
-    case  -2:
-        printf("\n Null pointer.  Check filename/path + permissions? %s %d\n",filestr,line);
-        break;
-    case  -3:
-        printf("\n Unsupported feature/library load error. %s %d\n",filestr,line);
-        break;
-    case  -4:
-        printf("\n Could not allocate memory. %s %d\n",filestr,line);
-        break;
-    case  -5:
-        printf("\n Insufficient IO buffers. %s %d\n",filestr,line);
-        break;
-    case  -6:
-        printf("\n Invalid handle. %s %d\n",filestr,line);
-        break;
-    case  -7:
-        printf("\n Memory lock failure. %s %d\n",filestr,line);
-        break;
-    case  -8:
-        printf("\n Function called before initialization. %s %d\n",filestr,line);
-        break;
-    case  -9:
-        printf("\n Specified object not found. %s %d\n",filestr,line);
-        break;
-    case -10:
-        printf("\n More input data expected. %s %d\n",filestr,line);
-        break;
-    case -11:
-        printf("\n More output surfaces expected. %s %d\n",filestr,line);
-        break;
-    case -12:
-        printf("\n Operation aborted. %s %d\n",filestr,line);
-        break;
-    case -13:
-        printf("\n HW device lost. %s %d\n",filestr,line);
-        break;
-    case -14:
-        printf("\n Incompatible video parameters. %s %d\n",filestr,line);
-        break;
-    case -15:
-        printf("\n Invalid video parameters. %s %d\n",filestr,line);
-        break;
-    case -16:
-        printf("\n Undefined behavior. %s %d\n",filestr,line);
-        break;
-    case -17:
-        printf("\n Device operation failure. %s %d\n",filestr,line);
-        break;
-    case -18:
-        printf("\n More bitstream data expected. %s %d\n",filestr,line);
-        break;
-    case -19:
-        printf("\n Incompatible audio parameters. %s %d\n",filestr,line);
-        break;
-    case -20:
-        printf("\n Invalid audio parameters. %s %d\n",filestr,line);
-        break;
-    default:
-        printf("\nError code %d,\t%s\t%d\n\n", err, filestr, line);
-    }
+	switch (err) {
+	case   0:
+		printf("\n No error.\n");
+		break;
+	case  -1:
+		printf("\n Unknown error: %s %d\n", filestr, line);
+		break;
+	case  -2:
+		printf("\n Null pointer.  Check filename/path + permissions? %s %d\n",
+				filestr, line);
+		break;
+	case  -3:
+		printf("\n Unsupported feature/library load error. %s %d\n",
+				filestr, line);
+		break;
+	case  -4:
+		printf("\n Could not allocate memory. %s %d\n", filestr, line);
+		break;
+	case  -5:
+		printf("\n Insufficient IO buffers. %s %d\n", filestr, line);
+		break;
+	case  -6:
+		printf("\n Invalid handle. %s %d\n", filestr, line);
+		break;
+	case  -7:
+		printf("\n Memory lock failure. %s %d\n", filestr, line);
+		break;
+	case  -8:
+		printf("\n Function called before initialization. %s %d\n",
+				filestr, line);
+		break;
+	case  -9:
+		printf("\n Specified object not found. %s %d\n", filestr, line);
+		break;
+	case -10:
+		printf("\n More input data expected. %s %d\n", filestr, line);
+		break;
+	case -11:
+		printf("\n More output surfaces expected. %s %d\n", filestr,
+				line);
+		break;
+	case -12:
+		printf("\n Operation aborted. %s %d\n", filestr, line);
+		break;
+	case -13:
+		printf("\n HW device lost. %s %d\n", filestr, line);
+		break;
+	case -14:
+		printf("\n Incompatible video parameters. %s %d\n", filestr,
+				line);
+		break;
+	case -15:
+		printf("\n Invalid video parameters. %s %d\n", filestr, line);
+		break;
+	case -16:
+		printf("\n Undefined behavior. %s %d\n", filestr, line);
+		break;
+	case -17:
+		printf("\n Device operation failure. %s %d\n", filestr, line);
+		break;
+	case -18:
+		printf("\n More bitstream data expected. %s %d\n", filestr,
+				line);
+		break;
+	case -19:
+		printf("\n Incompatible audio parameters. %s %d\n", filestr,
+				line);
+		break;
+	case -20:
+		printf("\n Invalid audio parameters. %s %d\n", filestr, line);
+		break;
+	default:
+		printf("\nError code %d,\t%s\t%d\n\n", err, filestr, line);
+	}
 }
 
-mfxStatus ReadPlaneData(mfxU16 w, mfxU16 h, mfxU8* buf, mfxU8* ptr,
-                        mfxU16 pitch, mfxU16 offset, FILE* fSource)
+mfxStatus ReadPlaneData(mfxU16 w, mfxU16 h, mfxU8 *buf, mfxU8 *ptr,
+	mfxU16 pitch, mfxU16 offset, FILE *fSource)
 {
-    mfxU32 nBytesRead;
-    for (mfxU16 i = 0; i < h; i++) {
-        nBytesRead = (mfxU32) fread(buf, 1, w, fSource);
-        if (w != nBytesRead)
-            return MFX_ERR_MORE_DATA;
-        for (mfxU16 j = 0; j < w; j++)
-            ptr[i * pitch + j * 2 + offset] = buf[j];
-    }
-    return MFX_ERR_NONE;
+	mfxU32 nBytesRead;
+	for (mfxU16 i = 0; i < h; i++) {
+		nBytesRead = (mfxU32) fread(buf, 1, w, fSource);
+		if (w != nBytesRead)
+			return MFX_ERR_MORE_DATA;
+		for (mfxU16 j = 0; j < w; j++)
+			ptr[i * pitch + j * 2 + offset] = buf[j];
+	}
+	return MFX_ERR_NONE;
 }
 
-mfxStatus LoadRawFrame(mfxFrameSurface1* pSurface, FILE* fSource)
+mfxStatus LoadRawFrame(mfxFrameSurface1 *pSurface, FILE *fSource)
 {
-    if (!fSource) {
-        // Simulate instantaneous access to 1000 "empty" frames.
-        static int frameCount = 0;
-        if (1000 == frameCount++)
-            return MFX_ERR_MORE_DATA;
-        else
-            return MFX_ERR_NONE;
-    }
+	if (!fSource) {
+		// Simulate instantaneous access to 1000 "empty" frames.
+		static int frameCount = 0;
+		if (1000 == frameCount++)
+			return MFX_ERR_MORE_DATA;
+		else
+			return MFX_ERR_NONE;
+	}
 
-    mfxStatus sts = MFX_ERR_NONE;
-    mfxU32 nBytesRead;
-    mfxU16 w, h, i, pitch;
-    mfxU8* ptr;
-    mfxFrameInfo* pInfo = &pSurface->Info;
-    mfxFrameData* pData = &pSurface->Data;
+	mfxStatus sts = MFX_ERR_NONE;
+	mfxU32 nBytesRead;
+	mfxU16 w, h, i, pitch;
+	mfxU8 *ptr;
+	mfxFrameInfo *pInfo = &pSurface->Info;
+	mfxFrameData *pData = &pSurface->Data;
 
-    if (pInfo->CropH > 0 && pInfo->CropW > 0) {
-        w = pInfo->CropW;
-        h = pInfo->CropH;
-    } else {
-        w = pInfo->Width;
-        h = pInfo->Height;
-    }
+	if (pInfo->CropH > 0 && pInfo->CropW > 0) {
+		w = pInfo->CropW;
+		h = pInfo->CropH;
+	} else {
+		w = pInfo->Width;
+		h = pInfo->Height;
+	}
 
-    pitch = pData->Pitch;
-    ptr = pData->Y + pInfo->CropX + pInfo->CropY * pData->Pitch;
+	pitch = pData->Pitch;
+	ptr = pData->Y + pInfo->CropX + pInfo->CropY * pData->Pitch;
 
-    // read luminance plane
-    for (i = 0; i < h; i++) {
-        nBytesRead = (mfxU32) fread(ptr + i * pitch, 1, w, fSource);
-        if (w != nBytesRead)
-            return MFX_ERR_MORE_DATA;
-    }
+	// read luminance plane
+	for (i = 0; i < h; i++) {
+		nBytesRead = (mfxU32) fread(ptr + i * pitch, 1, w, fSource);
+		if (w != nBytesRead)
+			return MFX_ERR_MORE_DATA;
+	}
 
-    mfxU8 buf[2048];        // maximum supported chroma width for nv12
-    w /= 2;
-    h /= 2;
-    ptr = pData->UV + pInfo->CropX + (pInfo->CropY / 2) * pitch;
-    if (w > 2048)
-        return MFX_ERR_UNSUPPORTED;
+	mfxU8 buf[2048]; // maximum supported chroma width for nv12
+	w /= 2;
+	h /= 2;
+	ptr = pData->UV + pInfo->CropX + (pInfo->CropY / 2) * pitch;
+	if (w > 2048)
+		return MFX_ERR_UNSUPPORTED;
 
-    // load U
-    sts = ReadPlaneData(w, h, buf, ptr, pitch, 0, fSource);
-    if (MFX_ERR_NONE != sts)
-        return sts;
-    // load V
-    sts = ReadPlaneData(w, h, buf, ptr, pitch, 1, fSource);
-    if (MFX_ERR_NONE != sts)
-        return sts;
+	// load U
+	sts = ReadPlaneData(w, h, buf, ptr, pitch, 0, fSource);
+	if (MFX_ERR_NONE != sts)
+		return sts;
+	// load V
+	sts = ReadPlaneData(w, h, buf, ptr, pitch, 1, fSource);
+	if (MFX_ERR_NONE != sts)
+		return sts;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus LoadRawRGBFrame(mfxFrameSurface1* pSurface, FILE* fSource)
+mfxStatus LoadRawRGBFrame(mfxFrameSurface1 *pSurface, FILE *fSource)
 {
-    if (!fSource) {
-        // Simulate instantaneous access to 1000 "empty" frames.
-        static int frameCount = 0;
-        if (1000 == frameCount++)
-            return MFX_ERR_MORE_DATA;
-        else
-            return MFX_ERR_NONE;
-    }
+	if (!fSource) {
+		// Simulate instantaneous access to 1000 "empty" frames.
+		static int frameCount = 0;
+		if (1000 == frameCount++)
+			return MFX_ERR_MORE_DATA;
+		else
+			return MFX_ERR_NONE;
+	}
 
-    size_t nBytesRead;
-    mfxU16 w, h;
-    mfxFrameInfo* pInfo = &pSurface->Info;
+	size_t nBytesRead;
+	mfxU16 w, h;
+	mfxFrameInfo *pInfo = &pSurface->Info;
 
-    if (pInfo->CropH > 0 && pInfo->CropW > 0) {
-        w = pInfo->CropW;
-        h = pInfo->CropH;
-    } else {
-        w = pInfo->Width;
-        h = pInfo->Height;
-    }
+	if (pInfo->CropH > 0 && pInfo->CropW > 0) {
+		w = pInfo->CropW;
+		h = pInfo->CropH;
+	} else {
+		w = pInfo->Width;
+		h = pInfo->Height;
+	}
 
-    for (mfxU16 i = 0; i < h; i++) {
-        nBytesRead = fread(pSurface->Data.B + i * pSurface->Data.Pitch,
-                           1, w * 4, fSource);
-        if ((size_t)(w * 4) != nBytesRead)
-            return MFX_ERR_MORE_DATA;
-    }
+	for (mfxU16 i = 0; i < h; i++) {
+		nBytesRead = fread(pSurface->Data.B + i * pSurface->Data.Pitch,
+				1, w * 4, fSource);
+		if ((size_t)(w * 4) != nBytesRead)
+			return MFX_ERR_MORE_DATA;
+	}
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus WriteBitStreamFrame(mfxBitstream* pMfxBitstream, FILE* fSink)
+mfxStatus WriteBitStreamFrame(mfxBitstream *pMfxBitstream, FILE *fSink)
 {
-    mfxU32 nBytesWritten =
-        (mfxU32) fwrite(pMfxBitstream->Data + pMfxBitstream->DataOffset, 1,
-                        pMfxBitstream->DataLength, fSink);
-    if (nBytesWritten != pMfxBitstream->DataLength)
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
+	mfxU32 nBytesWritten =
+		(mfxU32) fwrite(
+				pMfxBitstream->Data + pMfxBitstream->DataOffset,
+				1, pMfxBitstream->DataLength, fSink);
+	if (nBytesWritten != pMfxBitstream->DataLength)
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
 
-    pMfxBitstream->DataLength = 0;
+	pMfxBitstream->DataLength = 0;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus ReadBitStreamData(mfxBitstream* pBS, FILE* fSource)
+mfxStatus ReadBitStreamData(mfxBitstream *pBS, FILE *fSource)
 {
-    memmove(pBS->Data, pBS->Data + pBS->DataOffset, pBS->DataLength);
-    pBS->DataOffset = 0;
+	memmove(pBS->Data, pBS->Data + pBS->DataOffset, pBS->DataLength);
+	pBS->DataOffset = 0;
 
-    mfxU32 nBytesRead = (mfxU32) fread(pBS->Data + pBS->DataLength, 1,
-                                       pBS->MaxLength - pBS->DataLength,
-                                       fSource);
+	mfxU32 nBytesRead = (mfxU32) fread(pBS->Data + pBS->DataLength, 1,
+			pBS->MaxLength - pBS->DataLength, fSource);
 
-    if (0 == nBytesRead)
-        return MFX_ERR_MORE_DATA;
+	if (0 == nBytesRead)
+		return MFX_ERR_MORE_DATA;
 
-    pBS->DataLength += nBytesRead;
+	pBS->DataLength += nBytesRead;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus WriteSection(mfxU8* plane, mfxU16 factor, mfxU16 chunksize,
-                       mfxFrameInfo* pInfo, mfxFrameData* pData, mfxU32 i,
-                       mfxU32 j, FILE* fSink)
+mfxStatus WriteSection(mfxU8 *plane, mfxU16 factor, mfxU16 chunksize,
+	mfxFrameInfo *pInfo, mfxFrameData *pData, mfxU32 i,
+	mfxU32 j, FILE *fSink)
 {
-    if (chunksize !=
-        fwrite(plane +
-               (pInfo->CropY * pData->Pitch / factor + pInfo->CropX) +
-               i * pData->Pitch + j, 1, chunksize, fSink))
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
-    return MFX_ERR_NONE;
+	if (chunksize !=
+		fwrite(plane +
+			(pInfo->CropY * pData->Pitch / factor + pInfo->CropX) +
+			i * pData->Pitch + j, 1, chunksize, fSink))
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
+	return MFX_ERR_NONE;
 }
 
-mfxStatus WriteRawFrame(mfxFrameSurface1* pSurface, FILE* fSink)
+mfxStatus WriteRawFrame(mfxFrameSurface1 *pSurface, FILE *fSink)
 {
-    mfxFrameInfo* pInfo = &pSurface->Info;
-    mfxFrameData* pData = &pSurface->Data;
-    mfxU32 i, j, h, w;
-    mfxStatus sts = MFX_ERR_NONE;
+	mfxFrameInfo *pInfo = &pSurface->Info;
+	mfxFrameData *pData = &pSurface->Data;
+	mfxU32 i, j, h, w;
+	mfxStatus sts = MFX_ERR_NONE;
 
-    for (i = 0; i < pInfo->CropH; i++)
-        sts =
-            WriteSection(pData->Y, 1, pInfo->CropW, pInfo, pData, i, 0,
-                         fSink);
+	for (i = 0; i < pInfo->CropH; i++)
+		sts =
+			WriteSection(pData->Y, 1, pInfo->CropW, pInfo, pData, i,
+				0, fSink);
 
-    h = pInfo->CropH / 2;
-    w = pInfo->CropW;
-    for (i = 0; i < h; i++)
-        for (j = 0; j < w; j += 2)
-            sts =
-                WriteSection(pData->UV, 2, 1, pInfo, pData, i, j,
-                             fSink);
-    for (i = 0; i < h; i++)
-        for (j = 1; j < w; j += 2)
-            sts =
-                WriteSection(pData->UV, 2, 1, pInfo, pData, i, j,
-                             fSink);
+	h = pInfo->CropH / 2;
+	w = pInfo->CropW;
+	for (i = 0; i < h; i++)
+		for (j = 0; j < w; j += 2)
+			sts =
+				WriteSection(pData->UV, 2, 1, pInfo, pData, i,
+						j, fSink);
+	for (i = 0; i < h; i++)
+		for (j = 1; j < w; j += 2)
+			sts =
+				WriteSection(pData->UV, 2, 1, pInfo, pData, i,
+					j, fSink);
 
-    return sts;
+	return sts;
 }
 
-int GetFreeTaskIndex(Task* pTaskPool, mfxU16 nPoolSize)
+int GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize)
 {
-    if (pTaskPool)
-        for (int i = 0; i < nPoolSize; i++)
-            if (!pTaskPool[i].syncp)
-                return i;
-    return MFX_ERR_NOT_FOUND;
+	if (pTaskPool)
+		for (int i = 0; i < nPoolSize; i++)
+			if (!pTaskPool[i].syncp)
+				return i;
+	return MFX_ERR_NOT_FOUND;
 }
 
-void ClearYUVSurfaceSysMem(mfxFrameSurface1* pSfc, mfxU16 width, mfxU16 height)
+void ClearYUVSurfaceSysMem(mfxFrameSurface1 *pSfc, mfxU16 width, mfxU16 height)
 {
-    // In case simulating direct access to frames we initialize the allocated surfaces with default pattern
-    memset(pSfc->Data.Y, 100, width * height);  // Y plane
-    memset(pSfc->Data.U, 50, (width * height)/2);  // UV plane
+	/*
+	 * In case simulating direct access to frames we initialize the
+	 * allocated surfaces with default pattern
+	 */
+	memset(pSfc->Data.Y, 100, width * height);    // Y plane
+	memset(pSfc->Data.U, 50, (width * height)/2); // UV plane
 }
 
 
 // Get free raw frame surface
-int GetFreeSurfaceIndex(mfxFrameSurface1** pSurfacesPool, mfxU16 nPoolSize)
+int GetFreeSurfaceIndex(mfxFrameSurface1 **pSurfacesPool, mfxU16 nPoolSize)
 {
-    if (pSurfacesPool)
-        for (mfxU16 i = 0; i < nPoolSize; i++)
-            if (0 == pSurfacesPool[i]->Data.Locked)
-                return i;
-    return MFX_ERR_NOT_FOUND;
+	if (pSurfacesPool)
+		for (mfxU16 i = 0; i < nPoolSize; i++)
+			if (0 == pSurfacesPool[i]->Data.Locked)
+				return i;
+	return MFX_ERR_NOT_FOUND;
 }
 
 char mfxFrameTypeString(mfxU16 FrameType)
 {
-    mfxU8 FrameTmp = FrameType & 0xF;
-    char FrameTypeOut;
-    switch (FrameTmp) {
-    case MFX_FRAMETYPE_I:
-        FrameTypeOut = 'I';
-        break;
-    case MFX_FRAMETYPE_P:
-        FrameTypeOut = 'P';
-        break;
-    case MFX_FRAMETYPE_B:
-        FrameTypeOut = 'B';
-        break;
-    default:
-        FrameTypeOut = '*';
-    }
-    return FrameTypeOut;
+	mfxU8 FrameTmp = FrameType & 0xF;
+	char FrameTypeOut;
+	switch (FrameTmp) {
+	case MFX_FRAMETYPE_I:
+		FrameTypeOut = 'I';
+		break;
+	case MFX_FRAMETYPE_P:
+		FrameTypeOut = 'P';
+		break;
+	case MFX_FRAMETYPE_B:
+		FrameTypeOut = 'B';
+		break;
+	default:
+		FrameTypeOut = '*';
+	}
+	return FrameTypeOut;
 }

--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -47,11 +47,12 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 // =================================================================
 // Intel Media SDK memory allocator entrypoints....
 // Implementation of this functions is OS/Memory type specific.
-mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest* request, mfxFrameAllocResponse* response);
-mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr);
-mfxStatus simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData* ptr);
-mfxStatus simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL* handle);
-mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse* response);
+mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request,
+		mfxFrameAllocResponse *response);
+mfxStatus simple_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr);
+mfxStatus simple_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr);
+mfxStatus simple_gethdl(mfxHDL pthis, mfxMemId mid, mfxHDL *handle);
+mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse *response);
 
 
 
@@ -59,7 +60,7 @@ mfxStatus simple_free(mfxHDL pthis, mfxFrameAllocResponse* response);
 // Utility functions, not directly tied to Media SDK functionality
 //
 
-void PrintErrString(int err,const char* filestr,int line);
+void PrintErrString(int err, const char *filestr, int line);
 
 // LoadRawFrame: Reads raw frame from YUV file (YV12) into NV12 surface
 // - YV12 is a more common format for YUV files than NV12 (therefore the conversion during read and write)
@@ -67,35 +68,37 @@ void PrintErrString(int err,const char* filestr,int line);
 // LoadRawRGBFrame: Reads raw RGB32 frames from file into RGB32 surface
 // - For the simulation case (fSource = NULL), the surface is filled with default image data
 
-mfxStatus LoadRawFrame(mfxFrameSurface1* pSurface, FILE* fSource);
-mfxStatus LoadRawRGBFrame(mfxFrameSurface1* pSurface, FILE* fSource);
+mfxStatus LoadRawFrame(mfxFrameSurface1 *pSurface, FILE *fSource);
+mfxStatus LoadRawRGBFrame(mfxFrameSurface1 *pSurface, FILE *fSource);
 
 // Write raw YUV (NV12) surface to YUV (YV12) file
-mfxStatus WriteRawFrame(mfxFrameSurface1* pSurface, FILE* fSink);
+mfxStatus WriteRawFrame(mfxFrameSurface1 *pSurface, FILE *fSink);
 
 // Write bit stream data for frame to file
-mfxStatus WriteBitStreamFrame(mfxBitstream* pMfxBitstream, FILE* fSink);
+mfxStatus WriteBitStreamFrame(mfxBitstream *pMfxBitstream, FILE *fSink);
 // Read bit stream data from file. Stream is read as large chunks (= many frames)
-mfxStatus ReadBitStreamData(mfxBitstream* pBS, FILE* fSource);
+mfxStatus ReadBitStreamData(mfxBitstream *pBS, FILE *fSource);
 
-void ClearYUVSurfaceSysMem(mfxFrameSurface1* pSfc, mfxU16 width, mfxU16 height);
+void ClearYUVSurfaceSysMem(mfxFrameSurface1 *pSfc, mfxU16 width, mfxU16 height);
 void ClearYUVSurfaceVMem(mfxMemId memId);
 void ClearRGBSurfaceVMem(mfxMemId memId);
 
 // Get free raw frame surface
-int GetFreeSurfaceIndex(mfxFrameSurface1** pSurfacesPool, mfxU16 nPoolSize);
+int GetFreeSurfaceIndex(mfxFrameSurface1 **pSurfacesPool, mfxU16 nPoolSize);
 
 // For use with asynchronous task management
 typedef struct {
-    mfxBitstream mfxBS;
-    mfxSyncPoint syncp;
+	mfxBitstream mfxBS;
+	mfxSyncPoint syncp;
 } Task;
 
 // Get free task
-int GetFreeTaskIndex(Task* pTaskPool, mfxU16 nPoolSize);
+int GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize);
 
 // Initialize Intel Media SDK Session, device/display and memory manager
-mfxStatus Initialize(mfxIMPL impl, mfxVersion ver, MFXVideoSession* pSession, mfxFrameAllocator* pmfxAllocator, bool bCreateSharedHandles = false, bool dx9hack = false);
+mfxStatus Initialize(mfxIMPL impl, mfxVersion ver, MFXVideoSession *pSession,
+		mfxFrameAllocator *pmfxAllocator,
+		bool bCreateSharedHandles = false, bool dx9hack = false);
 
 // Release resources (device/display)
 void Release();
@@ -103,7 +106,7 @@ void Release();
 // Convert frame type to string
 char mfxFrameTypeString(mfxU16 FrameType);
 
-void mfxGetTime(mfxTime* timestamp);
+void mfxGetTime(mfxTime *timestamp);
 
 //void mfxInitTime();  might need this for Windows
 double TimeDiffMsec(mfxTime tfinish, mfxTime tstart);

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -10,7 +10,10 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
 
 #include "common_utils.h"
 
-// ATTENTION: If D3D surfaces are used, DX9_D3D or DX11_D3D must be set in project settings or hardcoded here
+/*
+ * ATTENTION: If D3D surfaces are used, DX9_D3D or DX11_D3D must be set in
+ * project settings or hard-coded here
+ */
 
 #ifdef DX9_D3D
 #include "common_directx.h"
@@ -23,93 +26,105 @@ Copyright(c) 2005-2014 Intel Corporation. All Rights Reserved.
  * Windows implementation of OS-specific utility functions
  */
 
-mfxStatus Initialize(mfxIMPL impl, mfxVersion ver, MFXVideoSession* pSession, mfxFrameAllocator* pmfxAllocator, bool bCreateSharedHandles, bool dx9hack)
+mfxStatus Initialize(mfxIMPL impl, mfxVersion ver, MFXVideoSession *pSession,
+	mfxFrameAllocator *pmfxAllocator, bool bCreateSharedHandles, bool dx9hack)
 {
-    bCreateSharedHandles; // (Hugh) Currently unused
-    pmfxAllocator; // (Hugh) Currently unused
+	bCreateSharedHandles; // (Hugh) Currently unused
+	pmfxAllocator; // (Hugh) Currently unused
 
-    mfxStatus sts = MFX_ERR_NONE;
+	mfxStatus sts = MFX_ERR_NONE;
 
-    // If mfxFrameAllocator is provided it means we need to setup DirectX device and memory allocator
-    if (pmfxAllocator && !dx9hack) {
-        // Initialize Intel Media SDK Session
-        sts = pSession->Init(impl, &ver);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	// If mfxFrameAllocator is provided it means we need to setup DirectX device and memory allocator
+	if (pmfxAllocator && !dx9hack) {
+		// Initialize Intel Media SDK Session
+		sts = pSession->Init(impl, &ver);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-        // Create DirectX device context
-        mfxHDL deviceHandle;
-        sts = CreateHWDevice(*pSession, &deviceHandle, NULL, bCreateSharedHandles);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+		// Create DirectX device context
+		mfxHDL deviceHandle;
+		sts = CreateHWDevice(*pSession, &deviceHandle, NULL,
+				bCreateSharedHandles);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-        // Provide device manager to Media SDK
-        sts = pSession->SetHandle(DEVICE_MGR_TYPE, deviceHandle);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+		// Provide device manager to Media SDK
+		sts = pSession->SetHandle(DEVICE_MGR_TYPE, deviceHandle);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-        pmfxAllocator->pthis  = *pSession; // We use Media SDK session ID as the allocation identifier
-        pmfxAllocator->Alloc  = simple_alloc;
-        pmfxAllocator->Free   = simple_free;
-        pmfxAllocator->Lock   = simple_lock;
-        pmfxAllocator->Unlock = simple_unlock;
-        pmfxAllocator->GetHDL = simple_gethdl;
+		// We use Media SDK session ID as the allocation identifier
+		pmfxAllocator->pthis  = *pSession;
+		pmfxAllocator->Alloc  = simple_alloc;
+		pmfxAllocator->Free   = simple_free;
+		pmfxAllocator->Lock   = simple_lock;
+		pmfxAllocator->Unlock = simple_unlock;
+		pmfxAllocator->GetHDL = simple_gethdl;
 
-        // Since we are using video memory we must provide Media SDK with an external allocator
-        sts = pSession->SetFrameAllocator(pmfxAllocator);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+		/*
+		 * Since we are using video memory we must provide Media SDK
+		 * with an external allocator
+		 */
+		sts = pSession->SetFrameAllocator(pmfxAllocator);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	} else if (pmfxAllocator && dx9hack) {
+		// Initialize Intel Media SDK Session
+		sts = pSession->Init(impl, &ver);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-    } else if (pmfxAllocator && dx9hack) {
-        // Initialize Intel Media SDK Session
-        sts = pSession->Init(impl, &ver);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+		// Create DirectX device context
+		mfxHDL deviceHandle;
+		sts = DX9_CreateHWDevice(*pSession, &deviceHandle, NULL,
+				bCreateSharedHandles);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-        // Create DirectX device context
-        mfxHDL deviceHandle;
-        sts = DX9_CreateHWDevice(*pSession, &deviceHandle, NULL, bCreateSharedHandles);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+		// Provide device manager to Media SDK
+		sts = pSession->SetHandle(MFX_HANDLE_D3D9_DEVICE_MANAGER,
+				deviceHandle);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-        // Provide device manager to Media SDK
-        sts = pSession->SetHandle(MFX_HANDLE_D3D9_DEVICE_MANAGER, deviceHandle);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+		// We use Media SDK session ID as the allocation identifier
+		pmfxAllocator->pthis  = *pSession;
+		pmfxAllocator->Alloc  = dx9_simple_alloc;
+		pmfxAllocator->Free   = dx9_simple_free;
+		pmfxAllocator->Lock   = dx9_simple_lock;
+		pmfxAllocator->Unlock = dx9_simple_unlock;
+		pmfxAllocator->GetHDL = dx9_simple_gethdl;
 
-        pmfxAllocator->pthis  = *pSession; // We use Media SDK session ID as the allocation identifier
-        pmfxAllocator->Alloc  = dx9_simple_alloc;
-        pmfxAllocator->Free   = dx9_simple_free;
-        pmfxAllocator->Lock   = dx9_simple_lock;
-        pmfxAllocator->Unlock = dx9_simple_unlock;
-        pmfxAllocator->GetHDL = dx9_simple_gethdl;
-
-        // Since we are using video memory we must provide Media SDK with an external allocator
-        sts = pSession->SetFrameAllocator(pmfxAllocator);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
-
-    } else {
-        // Initialize Intel Media SDK Session
-        sts = pSession->Init(impl, &ver);
-        MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
-    }
-    return sts;
+		/*
+		 * Since we are using video memory we must provide Media SDK
+		 * with an external allocator
+		 */
+		sts = pSession->SetFrameAllocator(pmfxAllocator);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	} else {
+		// Initialize Intel Media SDK Session
+		sts = pSession->Init(impl, &ver);
+		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	}
+	return sts;
 }
 
 void Release()
 {
 #if defined(DX9_D3D) || defined(DX11_D3D)
-    CleanupHWDevice();
-    DX9_CleanupHWDevice();
+	CleanupHWDevice();
+	DX9_CleanupHWDevice();
 #endif
 }
 
-void mfxGetTime(mfxTime* timestamp)
+void mfxGetTime(mfxTime *timestamp)
 {
-    QueryPerformanceCounter(timestamp);
+	QueryPerformanceCounter(timestamp);
 }
 
 double TimeDiffMsec(mfxTime tfinish, mfxTime tstart)
 {
-    static LARGE_INTEGER tFreq = { 0 };
+	static LARGE_INTEGER tFreq = { 0 };
 
-    if (!tFreq.QuadPart) QueryPerformanceFrequency(&tFreq);
+	if (!tFreq.QuadPart)
+		QueryPerformanceFrequency(&tFreq);
 
-    double freq = (double)tFreq.QuadPart;
-    return 1000.0 * ((double)tfinish.QuadPart - (double)tstart.QuadPart) / freq;
+	double freq = (double)tFreq.QuadPart;
+	return 1000.0 * ((double)tfinish.QuadPart - 
+			(double)tstart.QuadPart) / freq;
 }
 
 /* (Hugh) Functions currently unused */
@@ -117,14 +132,14 @@ double TimeDiffMsec(mfxTime tfinish, mfxTime tstart)
 void ClearYUVSurfaceVMem(mfxMemId memId)
 {
 #if defined(DX9_D3D) || defined(DX11_D3D)
-    ClearYUVSurfaceD3D(memId);
+	ClearYUVSurfaceD3D(memId);
 #endif
 }
 
 void ClearRGBSurfaceVMem(mfxMemId memId)
 {
 #if defined(DX9_D3D) || defined(DX11_D3D)
-    ClearRGBSurfaceD3D(memId);
+	ClearRGBSurfaceD3D(memId);
 #endif
 }
 #endif

--- a/plugins/obs-qsv11/device_directx9.cpp
+++ b/plugins/obs-qsv11/device_directx9.cpp
@@ -12,9 +12,9 @@ Copyright(c) 2011-2015 Intel Corporation. All Rights Reserved.
 
 #if defined(WIN32) || defined(WIN64)
 
-//prefast signature used in combaseapi.h
+// prefast signature used in combaseapi.h
 #ifndef _PREFAST_
-    #pragma warning(disable:4068)
+	#pragma warning(disable:4068)
 #endif
 
 #include "device_directx9.h"
@@ -28,351 +28,329 @@ Copyright(c) 2011-2015 Intel Corporation. All Rights Reserved.
 
 CD3D9Device::CD3D9Device()
 {
-    m_pD3D9 = NULL;
-    m_pD3DD9 = NULL;
-    m_pDeviceManager9 = NULL;
-    MSDK_ZERO_MEMORY(m_D3DPP);
-    m_resetToken = 0;
+	m_pD3D9 = NULL;
+	m_pD3DD9 = NULL;
+	m_pDeviceManager9 = NULL;
+	MSDK_ZERO_MEMORY(m_D3DPP);
+	m_resetToken = 0;
 
-    m_nViews = 0;
-    m_pS3DControl = NULL;
+	m_nViews = 0;
+	m_pS3DControl = NULL;
 
-    MSDK_ZERO_MEMORY(m_backBufferDesc);
-    m_pDXVAVPS = NULL;
-    m_pDXVAVP_Left = NULL;
-    m_pDXVAVP_Right = NULL;
+	MSDK_ZERO_MEMORY(m_backBufferDesc);
+	m_pDXVAVPS = NULL;
+	m_pDXVAVP_Left = NULL;
+	m_pDXVAVP_Right = NULL;
 
-    MSDK_ZERO_MEMORY(m_targetRect);
+	MSDK_ZERO_MEMORY(m_targetRect);
 
-    MSDK_ZERO_MEMORY(m_VideoDesc);
-    MSDK_ZERO_MEMORY(m_BltParams);
-    MSDK_ZERO_MEMORY(m_Sample);
+	MSDK_ZERO_MEMORY(m_VideoDesc);
+	MSDK_ZERO_MEMORY(m_BltParams);
+	MSDK_ZERO_MEMORY(m_Sample);
 
-    // Initialize DXVA structures
+	// Initialize DXVA structures
+	DXVA2_AYUVSample16 color = {
+		0x8000, // Cr
+		0x8000, // Cb
+		0x1000, // Y
+		0xffff  // Alpha
+	};
 
-    DXVA2_AYUVSample16 color = {
-        0x8000,          // Cr
-        0x8000,          // Cb
-        0x1000,          // Y
-        0xffff           // Alpha
-    };
+	DXVA2_ExtendedFormat format =   {           // DestFormat
+		DXVA2_SampleProgressiveFrame,       // SampleFormat
+		DXVA2_VideoChromaSubsampling_MPEG2, // VideoChromaSubsampling
+		DXVA_NominalRange_0_255,            // NominalRange
+		DXVA2_VideoTransferMatrix_BT709,    // VideoTransferMatrix
+		DXVA2_VideoLighting_bright,         // VideoLighting
+		DXVA2_VideoPrimaries_BT709,         // VideoPrimaries
+		DXVA2_VideoTransFunc_709            // VideoTransferFunction
+	};
 
-    DXVA2_ExtendedFormat format =   {           // DestFormat
-        DXVA2_SampleProgressiveFrame,           // SampleFormat
-        DXVA2_VideoChromaSubsampling_MPEG2,     // VideoChromaSubsampling
-        DXVA_NominalRange_0_255,                // NominalRange
-        DXVA2_VideoTransferMatrix_BT709,        // VideoTransferMatrix
-        DXVA2_VideoLighting_bright,             // VideoLighting
-        DXVA2_VideoPrimaries_BT709,             // VideoPrimaries
-        DXVA2_VideoTransFunc_709                // VideoTransferFunction
-    };
+	// init m_VideoDesc structure
+	MSDK_MEMCPY_VAR(m_VideoDesc.SampleFormat, &format,
+			sizeof(DXVA2_ExtendedFormat));
+	m_VideoDesc.SampleWidth                 = 0;
+	m_VideoDesc.SampleHeight                = 0;
+	m_VideoDesc.InputSampleFreq.Numerator   = 60;
+	m_VideoDesc.InputSampleFreq.Denominator = 1;
+	m_VideoDesc.OutputFrameFreq.Numerator   = 60;
+	m_VideoDesc.OutputFrameFreq.Denominator = 1;
 
-    // init m_VideoDesc structure
-    MSDK_MEMCPY_VAR(m_VideoDesc.SampleFormat, &format, sizeof(DXVA2_ExtendedFormat));
-    m_VideoDesc.SampleWidth                         = 0;
-    m_VideoDesc.SampleHeight                        = 0;
-    m_VideoDesc.InputSampleFreq.Numerator           = 60;
-    m_VideoDesc.InputSampleFreq.Denominator         = 1;
-    m_VideoDesc.OutputFrameFreq.Numerator           = 60;
-    m_VideoDesc.OutputFrameFreq.Denominator         = 1;
+	// init m_BltParams structure
+	MSDK_MEMCPY_VAR(m_BltParams.DestFormat, &format,
+			sizeof(DXVA2_ExtendedFormat));
+	MSDK_MEMCPY_VAR(m_BltParams.BackgroundColor, &color,
+			sizeof(DXVA2_AYUVSample16));
 
-    // init m_BltParams structure
-    MSDK_MEMCPY_VAR(m_BltParams.DestFormat, &format, sizeof(DXVA2_ExtendedFormat));
-    MSDK_MEMCPY_VAR(m_BltParams.BackgroundColor, &color, sizeof(DXVA2_AYUVSample16));
+	// init m_Sample structure
+	m_Sample.Start = 0;
+	m_Sample.End = 1;
+	m_Sample.SampleFormat = format;
+	m_Sample.PlanarAlpha.Fraction = 0;
+	m_Sample.PlanarAlpha.Value = 1;
 
-    // init m_Sample structure
-    m_Sample.Start = 0;
-    m_Sample.End = 1;
-    m_Sample.SampleFormat = format;
-    m_Sample.PlanarAlpha.Fraction = 0;
-    m_Sample.PlanarAlpha.Value = 1;
-
-    m_bIsA2rgb10 = FALSE;
+	m_bIsA2rgb10 = FALSE;
 }
 
 bool CD3D9Device::CheckOverlaySupport()
 {
-    D3DCAPS9                d3d9caps;
-    D3DOVERLAYCAPS          d3doverlaycaps = {0};
-    IDirect3D9ExOverlayExtension *d3d9overlay = NULL;
-    bool overlaySupported = false;
+	D3DCAPS9                d3d9caps;
+	D3DOVERLAYCAPS          d3doverlaycaps = {0};
+	IDirect3D9ExOverlayExtension *d3d9overlay = NULL;
+	bool overlaySupported = false;
 
-    memset(&d3d9caps, 0, sizeof(d3d9caps));
-    HRESULT hr = m_pD3D9->GetDeviceCaps(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, &d3d9caps);
-    if (FAILED(hr) || !(d3d9caps.Caps & D3DCAPS_OVERLAY))
-    {
-        overlaySupported = false;
-    }
-    else
-    {
-        hr = m_pD3D9->QueryInterface(IID_PPV_ARGS(&d3d9overlay));
-        if (FAILED(hr) || (d3d9overlay == NULL))
-        {
-            overlaySupported = false;
-        }
-        else
-        {
-            hr = d3d9overlay->CheckDeviceOverlayType(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
-                m_D3DPP.BackBufferWidth,
-                m_D3DPP.BackBufferHeight,
-                m_D3DPP.BackBufferFormat, NULL,
-                D3DDISPLAYROTATION_IDENTITY, &d3doverlaycaps);
-            MSDK_SAFE_RELEASE(d3d9overlay);
+	memset(&d3d9caps, 0, sizeof(d3d9caps));
+	HRESULT hr = m_pD3D9->GetDeviceCaps(D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
+			&d3d9caps);
+	if (FAILED(hr) || !(d3d9caps.Caps & D3DCAPS_OVERLAY)) {
+		overlaySupported = false;
+	} else {
+		hr = m_pD3D9->QueryInterface(IID_PPV_ARGS(&d3d9overlay));
+		if (FAILED(hr) || (d3d9overlay == NULL)) {
+			overlaySupported = false;
+		} else {
+			hr = d3d9overlay->CheckDeviceOverlayType(
+					D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL,
+					m_D3DPP.BackBufferWidth,
+					m_D3DPP.BackBufferHeight,
+					m_D3DPP.BackBufferFormat, NULL,
+					D3DDISPLAYROTATION_IDENTITY,
+					&d3doverlaycaps);
+			MSDK_SAFE_RELEASE(d3d9overlay);
 
-            if (FAILED(hr))
-            {
-                overlaySupported = false;
-            }
-            else
-            {
-                overlaySupported = true;
-            }
-        }
-    }
+			if (FAILED(hr)) {
+				overlaySupported = false;
+			} else {
+				overlaySupported = true;
+			}
+		}
+	}
 
-    return overlaySupported;
+	return overlaySupported;
 }
 
-mfxStatus CD3D9Device::FillD3DPP(mfxHDL hWindow, mfxU16 nViews, D3DPRESENT_PARAMETERS &D3DPP)
+mfxStatus CD3D9Device::FillD3DPP(mfxHDL hWindow, mfxU16 nViews,
+	D3DPRESENT_PARAMETERS &D3DPP)
 {
-    mfxStatus sts = MFX_ERR_NONE;
+	mfxStatus sts = MFX_ERR_NONE;
 
-    D3DPP.Windowed = true;
-    D3DPP.hDeviceWindow = (HWND)hWindow;
+	D3DPP.Windowed = true;
+	D3DPP.hDeviceWindow = (HWND)hWindow;
 
-    D3DPP.Flags                      = D3DPRESENTFLAG_VIDEO;
-    D3DPP.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
-    D3DPP.PresentationInterval       = D3DPRESENT_INTERVAL_ONE; // note that this setting leads to an implicit timeBeginPeriod call
-    D3DPP.BackBufferCount            = 1;
-    D3DPP.BackBufferFormat           = (m_bIsA2rgb10) ? D3DFMT_A2R10G10B10 : D3DFMT_X8R8G8B8;
+	D3DPP.Flags                      = D3DPRESENTFLAG_VIDEO;
+	D3DPP.FullScreen_RefreshRateInHz = D3DPRESENT_RATE_DEFAULT;
+	D3DPP.PresentationInterval       = D3DPRESENT_INTERVAL_ONE; // note that this setting leads to an implicit timeBeginPeriod call
+	D3DPP.BackBufferCount            = 1;
+	D3DPP.BackBufferFormat           = (m_bIsA2rgb10) ? D3DFMT_A2R10G10B10 :
+		D3DFMT_X8R8G8B8;
 
-    if (hWindow)
-    {
-        RECT r;
-        GetClientRect((HWND)hWindow, &r);
-        int x = GetSystemMetrics(SM_CXSCREEN);
-        int y = GetSystemMetrics(SM_CYSCREEN);
-        D3DPP.BackBufferWidth  = min(r.right - r.left, x);
-        D3DPP.BackBufferHeight = min(r.bottom - r.top, y);
-    }
-    else
-    {
-        D3DPP.BackBufferWidth  = GetSystemMetrics(SM_CYSCREEN);
-        D3DPP.BackBufferHeight = GetSystemMetrics(SM_CYSCREEN);
-    }
-    //
-    // Mark the back buffer lockable if software DXVA2 could be used.
-    // This is because software DXVA2 device requires a lockable render target
-    // for the optimal performance.
-    //
-    {
-        D3DPP.Flags |= D3DPRESENTFLAG_LOCKABLE_BACKBUFFER;
-    }
+	if (hWindow) {
+		RECT r;
+		GetClientRect((HWND)hWindow, &r);
+		int x = GetSystemMetrics(SM_CXSCREEN);
+		int y = GetSystemMetrics(SM_CYSCREEN);
+		D3DPP.BackBufferWidth  = min(r.right - r.left, x);
+		D3DPP.BackBufferHeight = min(r.bottom - r.top, y);
+	} else {
+		D3DPP.BackBufferWidth  = GetSystemMetrics(SM_CYSCREEN);
+		D3DPP.BackBufferHeight = GetSystemMetrics(SM_CYSCREEN);
+	}
+	/*
+	 * Mark the back buffer lockable if software DXVA2 could be used.
+	 * This is because software DXVA2 device requires a lockable render target
+	 * for the optimal performance.
+	 */
+	{
+		D3DPP.Flags |= D3DPRESENTFLAG_LOCKABLE_BACKBUFFER;
+	}
 
-    bool isOverlaySupported = CheckOverlaySupport();
-    if (2 == nViews && !isOverlaySupported)
-        return MFX_ERR_UNSUPPORTED;
+	bool isOverlaySupported = CheckOverlaySupport();
+	if (2 == nViews && !isOverlaySupported)
+		return MFX_ERR_UNSUPPORTED;
 
-    bool needOverlay = (2 == nViews) ? true : false;
+	bool needOverlay = (2 == nViews) ? true : false;
 
-    D3DPP.SwapEffect = needOverlay ? D3DSWAPEFFECT_OVERLAY : D3DSWAPEFFECT_DISCARD;
+	D3DPP.SwapEffect = needOverlay ? D3DSWAPEFFECT_OVERLAY :
+		D3DSWAPEFFECT_DISCARD;
 
-    return sts;
+	return sts;
 }
 
 mfxStatus CD3D9Device::Init(
-    mfxHDL hWindow,
-    mfxU16 nViews,
-    mfxU32 nAdapterNum)
+	mfxHDL hWindow,
+	mfxU16 nViews,
+	mfxU32 nAdapterNum)
 {
-    mfxStatus sts = MFX_ERR_NONE;
+	mfxStatus sts = MFX_ERR_NONE;
 
-    if (2 < nViews)
-        return MFX_ERR_UNSUPPORTED;
+	if (2 < nViews)
+		return MFX_ERR_UNSUPPORTED;
 
-    m_nViews = nViews;
+	m_nViews = nViews;
 
-    HRESULT hr = Direct3DCreate9Ex(D3D_SDK_VERSION, &m_pD3D9);
-    if (!m_pD3D9 || FAILED(hr))
-        return MFX_ERR_DEVICE_FAILED;
+	HRESULT hr = Direct3DCreate9Ex(D3D_SDK_VERSION, &m_pD3D9);
+	if (!m_pD3D9 || FAILED(hr))
+		return MFX_ERR_DEVICE_FAILED;
 
-    ZeroMemory(&m_D3DPP, sizeof(m_D3DPP));
-    sts = FillD3DPP(hWindow, nViews, m_D3DPP);
-    MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	ZeroMemory(&m_D3DPP, sizeof(m_D3DPP));
+	sts = FillD3DPP(hWindow, nViews, m_D3DPP);
+	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-    hr = m_pD3D9->CreateDeviceEx(
-        nAdapterNum,
-        D3DDEVTYPE_HAL,
-        (HWND)hWindow,
-        D3DCREATE_SOFTWARE_VERTEXPROCESSING | D3DCREATE_MULTITHREADED | D3DCREATE_FPU_PRESERVE,
-        &m_D3DPP,
-        NULL,
-        &m_pD3DD9);
-    if (FAILED(hr))
-        return MFX_ERR_NULL_PTR;
+	hr = m_pD3D9->CreateDeviceEx(
+			nAdapterNum,
+			D3DDEVTYPE_HAL,
+			(HWND)hWindow,
+			D3DCREATE_SOFTWARE_VERTEXPROCESSING | D3DCREATE_MULTITHREADED | D3DCREATE_FPU_PRESERVE,
+			&m_D3DPP,
+			NULL,
+			&m_pD3DD9);
+	if (FAILED(hr))
+		return MFX_ERR_NULL_PTR;
 
-    if(hWindow)
-    {
-        hr = m_pD3DD9->ResetEx(&m_D3DPP, NULL);
-        if (FAILED(hr))
-            return MFX_ERR_UNDEFINED_BEHAVIOR;
-        hr = m_pD3DD9->Clear(0, NULL, D3DCLEAR_TARGET, D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
-        if (FAILED(hr))
-            return MFX_ERR_UNDEFINED_BEHAVIOR;
-    }
-    UINT resetToken = 0;
+	if(hWindow) {
+		hr = m_pD3DD9->ResetEx(&m_D3DPP, NULL);
+		if (FAILED(hr))
+			return MFX_ERR_UNDEFINED_BEHAVIOR;
+		hr = m_pD3DD9->Clear(0, NULL, D3DCLEAR_TARGET,
+				D3DCOLOR_XRGB(0, 0, 0), 1.0f, 0);
+		if (FAILED(hr))
+			return MFX_ERR_UNDEFINED_BEHAVIOR;
+	}
+	UINT resetToken = 0;
 
-    hr = DXVA2CreateDirect3DDeviceManager9(&resetToken, &m_pDeviceManager9);
-    if (FAILED(hr))
-        return MFX_ERR_NULL_PTR;
+	hr = DXVA2CreateDirect3DDeviceManager9(&resetToken, &m_pDeviceManager9);
+	if (FAILED(hr))
+		return MFX_ERR_NULL_PTR;
 
-    hr = m_pDeviceManager9->ResetDevice(m_pD3DD9, resetToken);
-    if (FAILED(hr))
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
+	hr = m_pDeviceManager9->ResetDevice(m_pD3DD9, resetToken);
+	if (FAILED(hr))
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
 
-    m_resetToken = resetToken;
+	m_resetToken = resetToken;
 
-    return sts;
+	return sts;
 }
 
 mfxStatus CD3D9Device::Reset()
 {
-    HRESULT hr = NO_ERROR;
-    MSDK_CHECK_POINTER(m_pD3DD9, MFX_ERR_NULL_PTR);
+	HRESULT hr = NO_ERROR;
+	MSDK_CHECK_POINTER(m_pD3DD9, MFX_ERR_NULL_PTR);
 
-    if (m_D3DPP.Windowed)
-    {
-        RECT r;
-        GetClientRect((HWND)m_D3DPP.hDeviceWindow, &r);
-        int x = GetSystemMetrics(SM_CXSCREEN);
-        int y = GetSystemMetrics(SM_CYSCREEN);
-        m_D3DPP.BackBufferWidth  = min(r.right - r.left, x);
-        m_D3DPP.BackBufferHeight = min(r.bottom - r.top, y);
-    }
-    else
-    {
-        m_D3DPP.BackBufferWidth  = GetSystemMetrics(SM_CXSCREEN);
-        m_D3DPP.BackBufferHeight = GetSystemMetrics(SM_CYSCREEN);
-    }
+	if (m_D3DPP.Windowed) {
+		RECT r;
+		GetClientRect((HWND)m_D3DPP.hDeviceWindow, &r);
+		int x = GetSystemMetrics(SM_CXSCREEN);
+		int y = GetSystemMetrics(SM_CYSCREEN);
+		m_D3DPP.BackBufferWidth  = min(r.right - r.left, x);
+		m_D3DPP.BackBufferHeight = min(r.bottom - r.top, y);
+	} else {
+		m_D3DPP.BackBufferWidth  = GetSystemMetrics(SM_CXSCREEN);
+		m_D3DPP.BackBufferHeight = GetSystemMetrics(SM_CYSCREEN);
+	}
 
-    // Reset will change the parameters, so use a copy instead.
-    D3DPRESENT_PARAMETERS d3dpp = m_D3DPP;
-    hr = m_pD3DD9->ResetEx(&d3dpp, NULL);
+	// Reset will change the parameters, so use a copy instead.
+	D3DPRESENT_PARAMETERS d3dpp = m_D3DPP;
+	hr = m_pD3DD9->ResetEx(&d3dpp, NULL);
 
-    if (FAILED(hr))
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
+	if (FAILED(hr))
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
 
-    hr = m_pDeviceManager9->ResetDevice(m_pD3DD9, m_resetToken);
-    if (FAILED(hr))
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
+	hr = m_pDeviceManager9->ResetDevice(m_pD3DD9, m_resetToken);
+	if (FAILED(hr))
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
 
-    return MFX_ERR_NONE;
+	return MFX_ERR_NONE;
 }
 
 void CD3D9Device::Close()
 {
-    MSDK_SAFE_RELEASE(m_pDXVAVP_Left);
-    MSDK_SAFE_RELEASE(m_pDXVAVP_Right);
-    MSDK_SAFE_RELEASE(m_pDXVAVPS);
+	MSDK_SAFE_RELEASE(m_pDXVAVP_Left);
+	MSDK_SAFE_RELEASE(m_pDXVAVP_Right);
+	MSDK_SAFE_RELEASE(m_pDXVAVPS);
 
-    MSDK_SAFE_RELEASE(m_pDeviceManager9);
-    MSDK_SAFE_RELEASE(m_pD3DD9);
-    MSDK_SAFE_RELEASE(m_pD3D9);
-    m_pS3DControl = NULL;
+	MSDK_SAFE_RELEASE(m_pDeviceManager9);
+	MSDK_SAFE_RELEASE(m_pD3DD9);
+	MSDK_SAFE_RELEASE(m_pD3D9);
+	m_pS3DControl = NULL;
 }
 
 CD3D9Device::~CD3D9Device()
 {
-    Close();
+	Close();
 }
 
 mfxStatus CD3D9Device::GetHandle(mfxHandleType type, mfxHDL *pHdl)
 {
-    if (MFX_HANDLE_DIRECT3D_DEVICE_MANAGER9 == type && pHdl != NULL)
-    {
-        *pHdl = m_pDeviceManager9;
+	if (MFX_HANDLE_DIRECT3D_DEVICE_MANAGER9 == type && pHdl != NULL) {
+		*pHdl = m_pDeviceManager9;
 
-        return MFX_ERR_NONE;
-    }
-    else if (MFX_HANDLE_GFXS3DCONTROL == type && pHdl != NULL)
-    {
-        *pHdl = m_pS3DControl;
+		return MFX_ERR_NONE;
+	} else if (MFX_HANDLE_GFXS3DCONTROL == type && pHdl != NULL) {
+		*pHdl = m_pS3DControl;
 
-        return MFX_ERR_NONE;
-    }
-    return MFX_ERR_UNSUPPORTED;
+		return MFX_ERR_NONE;
+	}
+	return MFX_ERR_UNSUPPORTED;
 }
 
 mfxStatus CD3D9Device::SetHandle(mfxHandleType type, mfxHDL hdl)
 {
-    if (MFX_HANDLE_GFXS3DCONTROL == type && hdl != NULL)
-    {
-        m_pS3DControl = (IGFXS3DControl*)hdl;
-        return MFX_ERR_NONE;
-    }
-    else if (MFX_HANDLE_DEVICEWINDOW == type && hdl != NULL) //for render window handle
-    {
-        m_D3DPP.hDeviceWindow = (HWND)hdl;
-        return MFX_ERR_NONE;
-    }
-    return MFX_ERR_UNSUPPORTED;
+	if (MFX_HANDLE_GFXS3DCONTROL == type && hdl != NULL) {
+		m_pS3DControl = (IGFXS3DControl*)hdl;
+		return MFX_ERR_NONE;
+	} else if (MFX_HANDLE_DEVICEWINDOW == type && hdl != NULL) {
+		//for render window handle
+		m_D3DPP.hDeviceWindow = (HWND)hdl;
+		return MFX_ERR_NONE;
+	}
+	return MFX_ERR_UNSUPPORTED;
 }
 
-mfxStatus CD3D9Device::RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllocator * pmfxAlloc)
+mfxStatus CD3D9Device::RenderFrame(mfxFrameSurface1 *pSurface,
+	mfxFrameAllocator *pmfxAlloc)
 {
-    HRESULT hr = S_OK;
+	HRESULT hr = S_OK;
 
-    if (!(1 == m_nViews || (2 == m_nViews && NULL != m_pS3DControl)))
-        return MFX_ERR_UNDEFINED_BEHAVIOR;
+	if (!(1 == m_nViews || (2 == m_nViews && NULL != m_pS3DControl)))
+		return MFX_ERR_UNDEFINED_BEHAVIOR;
 
-    MSDK_CHECK_POINTER(pSurface, MFX_ERR_NULL_PTR);
-    MSDK_CHECK_POINTER(m_pDeviceManager9, MFX_ERR_NOT_INITIALIZED);
-    MSDK_CHECK_POINTER(pmfxAlloc, MFX_ERR_NULL_PTR);
+	MSDK_CHECK_POINTER(pSurface, MFX_ERR_NULL_PTR);
+	MSDK_CHECK_POINTER(m_pDeviceManager9, MFX_ERR_NOT_INITIALIZED);
+	MSDK_CHECK_POINTER(pmfxAlloc, MFX_ERR_NULL_PTR);
 
-    // don't try to render second view if output rect changed since first view
-    if (2 == m_nViews && (0 != pSurface->Info.FrameId.ViewId))
-        return MFX_ERR_NONE;
+	// don't try to render second view if output rect changed since first view
+	if (2 == m_nViews && (0 != pSurface->Info.FrameId.ViewId))
+		return MFX_ERR_NONE;
 
-    hr = m_pD3DD9->TestCooperativeLevel();
+	hr = m_pD3DD9->TestCooperativeLevel();
 
-    switch (hr)
-    {
-        case D3D_OK :
-            break;
+	switch (hr) {
+	case D3D_OK:
+		break;
+	case D3DERR_DEVICELOST:
+		return MFX_ERR_DEVICE_LOST;
+	case D3DERR_DEVICENOTRESET:
+		return MFX_ERR_UNKNOWN;
+	default:
+		return MFX_ERR_UNKNOWN;
+	}
 
-        case D3DERR_DEVICELOST :
-        {
-            return MFX_ERR_DEVICE_LOST;
-        }
+	CComPtr<IDirect3DSurface9> pBackBuffer;
+	hr = m_pD3DD9->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO,
+			&pBackBuffer);
 
-        case D3DERR_DEVICENOTRESET :
-            {
-            return MFX_ERR_UNKNOWN;
-        }
+	mfxHDLPair *dxMemId = (mfxHDLPair*)pSurface->Data.MemId;
 
-        default :
-        {
-            return MFX_ERR_UNKNOWN;
-        }
-    }
+	hr = m_pD3DD9->StretchRect((IDirect3DSurface9*)dxMemId->first, NULL,
+			pBackBuffer, NULL, D3DTEXF_LINEAR);
+	if (FAILED(hr))
+		return MFX_ERR_UNKNOWN;
 
-    CComPtr<IDirect3DSurface9> pBackBuffer;
-    hr = m_pD3DD9->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &pBackBuffer);
+	if (SUCCEEDED(hr)&& (1 == m_nViews ||
+		pSurface->Info.FrameId.ViewId == 1))
+		hr = m_pD3DD9->Present(NULL, NULL, NULL, NULL);
 
-    mfxHDLPair* dxMemId = (mfxHDLPair*)pSurface->Data.MemId;
-
-    hr = m_pD3DD9->StretchRect((IDirect3DSurface9*)dxMemId->first, NULL, pBackBuffer, NULL, D3DTEXF_LINEAR);
-    if (FAILED(hr))
-    {
-        return MFX_ERR_UNKNOWN;
-    }
-
-    if (SUCCEEDED(hr)&& (1 == m_nViews || pSurface->Info.FrameId.ViewId == 1))
-    {
-        hr = m_pD3DD9->Present(NULL, NULL, NULL, NULL);
-    }
-
-    return SUCCEEDED(hr) ? MFX_ERR_NONE : MFX_ERR_DEVICE_FAILED;
+	return SUCCEEDED(hr) ? MFX_ERR_NONE : MFX_ERR_DEVICE_FAILED;
 }
 
 /*

--- a/plugins/obs-qsv11/device_directx9.h
+++ b/plugins/obs-qsv11/device_directx9.h
@@ -10,7 +10,7 @@ Copyright(c) 2011-2014 Intel Corporation. All Rights Reserved.
 
 #pragma once
 
-#if defined( _WIN32 ) || defined ( _WIN64 )
+#if defined(_WIN32) || defined (_WIN64)
 
 #include "common_utils.h"
 
@@ -30,31 +30,31 @@ class IGFXS3DControl;
 class CHWDevice
 {
 public:
-    virtual ~CHWDevice(){}
-    /** Initializes device for requested processing.
-    @param[in] hWindow Window handle to bundle device to.
-    @param[in] nViews Number of views to process.
-    @param[in] nAdapterNum Number of adapter to use
-    */
-    virtual mfxStatus Init(
-        mfxHDL hWindow,
-        mfxU16 nViews,
-        mfxU32 nAdapterNum) = 0;
-    /// Reset device.
-    virtual mfxStatus Reset() = 0;
-    /// Get handle can be used for MFX session SetHandle calls
-    virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *pHdl) = 0;
-    /** Set handle.
-    Particular device implementation may require other objects to operate.
-    */
-    virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl) = 0;
-    virtual mfxStatus RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllocator * pmfxAlloc) = 0;
-    virtual void      Close() = 0;
+	virtual ~CHWDevice(){}
+	/** Initializes device for requested processing.
+	@param[in] hWindow Window handle to bundle device to.
+	@param[in] nViews Number of views to process.
+	@param[in] nAdapterNum Number of adapter to use
+	*/
+	virtual mfxStatus Init(
+		mfxHDL hWindow,
+		mfxU16 nViews,
+		mfxU32 nAdapterNum) = 0;
+	/// Reset device.
+	virtual mfxStatus Reset() = 0;
+	/// Get handle can be used for MFX session SetHandle calls
+	virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *pHdl) = 0;
+	/** Set handle.
+	Particular device implementation may require other objects to operate.
+	*/
+	virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl) = 0;
+	virtual mfxStatus RenderFrame(mfxFrameSurface1 *pSurface, mfxFrameAllocator *pmfxAlloc) = 0;
+	virtual void      Close() = 0;
 };
 
 enum {
-    MFX_HANDLE_GFXS3DCONTROL = 0x100, /* A handle to the IGFXS3DControl instance */
-    MFX_HANDLE_DEVICEWINDOW  = 0x101 /* A handle to the render window */
+	MFX_HANDLE_GFXS3DCONTROL = 0x100, /* A handle to the IGFXS3DControl instance */
+	MFX_HANDLE_DEVICEWINDOW  = 0x101 /* A handle to the render window */
 }; //mfxHandleType
 
 /** Direct3D 9 device implementation.
@@ -66,53 +66,52 @@ MFX_HANDLE_GFXS3DCONTROL must be set prior if initializing for 2 views.
 class CD3D9Device : public CHWDevice
 {
 public:
-    CD3D9Device();
-    virtual ~CD3D9Device();
+	CD3D9Device();
+	virtual ~CD3D9Device();
 
-    virtual mfxStatus Init(
-        mfxHDL hWindow,
-        mfxU16 nViews,
-        mfxU32 nAdapterNum);
-    virtual mfxStatus Reset();
-    virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *pHdl);
-    virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl);
-    virtual mfxStatus RenderFrame(mfxFrameSurface1 * pSurface, mfxFrameAllocator * pmfxAlloc);
-    virtual void      UpdateTitle(double /*fps*/) { }
-    virtual void      Close() ;
-            void      DefineFormat(bool isA2rgb10) { m_bIsA2rgb10 = (isA2rgb10) ? TRUE : FALSE; }
+	virtual mfxStatus Init(
+		mfxHDL hWindow,
+		mfxU16 nViews,
+		mfxU32 nAdapterNum);
+	virtual mfxStatus Reset();
+	virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *pHdl);
+	virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl);
+	virtual mfxStatus RenderFrame(mfxFrameSurface1 *pSurface, mfxFrameAllocator *pmfxAlloc);
+	virtual void      UpdateTitle(double /*fps*/) { }
+	virtual void      Close();
+	        void      DefineFormat(bool isA2rgb10) { m_bIsA2rgb10 = (isA2rgb10) ? TRUE : FALSE; }
 protected:
-    mfxStatus CreateVideoProcessors();
-    bool CheckOverlaySupport();
-    virtual mfxStatus FillD3DPP(mfxHDL hWindow, mfxU16 nViews, D3DPRESENT_PARAMETERS &D3DPP);
+	mfxStatus CreateVideoProcessors();
+	bool CheckOverlaySupport();
+	virtual mfxStatus FillD3DPP(mfxHDL hWindow, mfxU16 nViews, D3DPRESENT_PARAMETERS &D3DPP);
 private:
-    IDirect3D9Ex*               m_pD3D9;
-    IDirect3DDevice9Ex*         m_pD3DD9;
-    IDirect3DDeviceManager9*    m_pDeviceManager9;
-    D3DPRESENT_PARAMETERS       m_D3DPP;
-    UINT                        m_resetToken;
+	IDirect3D9Ex               *m_pD3D9;
+	IDirect3DDevice9Ex         *m_pD3DD9;
+	IDirect3DDeviceManager9    *m_pDeviceManager9;
+	D3DPRESENT_PARAMETERS       m_D3DPP;
+	UINT                        m_resetToken;
 
-    mfxU16                      m_nViews;
-    IGFXS3DControl*             m_pS3DControl;
+	mfxU16                      m_nViews;
+	IGFXS3DControl             *m_pS3DControl;
 
+	D3DSURFACE_DESC                 m_backBufferDesc;
 
-    D3DSURFACE_DESC                 m_backBufferDesc;
+	// service required to create video processors
+	IDirectXVideoProcessorService  *m_pDXVAVPS;
+	//left channel processor
+	IDirectXVideoProcessor         *m_pDXVAVP_Left;
+	// right channel processor
+	IDirectXVideoProcessor         *m_pDXVAVP_Right;
 
-    // service required to create video processors
-    IDirectXVideoProcessorService*  m_pDXVAVPS;
-    //left channel processor
-    IDirectXVideoProcessor*         m_pDXVAVP_Left;
-    // right channel processor
-    IDirectXVideoProcessor*         m_pDXVAVP_Right;
+	// target rectangle
+	RECT                            m_targetRect;
 
-    // target rectangle
-    RECT                            m_targetRect;
+	// various structures for DXVA2 calls
+	DXVA2_VideoDesc                 m_VideoDesc;
+	DXVA2_VideoProcessBltParams     m_BltParams;
+	DXVA2_VideoSample               m_Sample;
 
-    // various structures for DXVA2 calls
-    DXVA2_VideoDesc                 m_VideoDesc;
-    DXVA2_VideoProcessBltParams     m_BltParams;
-    DXVA2_VideoSample               m_Sample;
-
-    BOOL                            m_bIsA2rgb10;
+	BOOL                            m_bIsA2rgb10;
 };
 
 #endif // #if defined( _WIN32 ) || defined ( _WIN64 )

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -491,9 +491,9 @@ static void *obs_qsv_create(obs_data_t *settings, obs_encoder_t *encoder)
 		               "\tGopPictSize:    %d\n"
 		               "\tg_pts2dtsShift: %d",
 		               interval, GopPicSize, g_pts2dtsShift);
-	}
-	else
+	} else {
 		g_pts2dtsShift = -1;
+	}
 
 	if (!obsqsv->context) {
 		bfree(obsqsv);
@@ -520,7 +520,7 @@ static bool obs_qsv_extra_data(void *data, uint8_t **extra_data, size_t *size)
 	return true;
 }
 
-static bool obs_qsv_sei(void *data, uint8_t **sei,size_t *size)
+static bool obs_qsv_sei(void *data, uint8_t **sei, size_t *size)
 {
 	struct obs_qsv *obsqsv = data;
 
@@ -542,7 +542,7 @@ static inline bool valid_format(enum video_format format)
 }
 
 static inline void cap_resolution(obs_encoder_t *encoder,
-		struct video_scale_info *info)
+	struct video_scale_info *info)
 {
 	enum qsv_cpu_platform qsv_platform = qsv_get_cpu_platform();
 	uint32_t width = obs_encoder_get_width(encoder);
@@ -578,7 +578,8 @@ static void obs_qsv_video_info(void *data, struct video_scale_info *info)
 	cap_resolution(obsqsv->encoder, info);
 }
 
-static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, mfxBitstream *pBS, uint32_t fps_num, bool *received_packet)
+static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet,
+	mfxBitstream *pBS, uint32_t fps_num, bool *received_packet)
 {
 	uint8_t *start, *end;
 	int type;
@@ -637,8 +638,7 @@ static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, 
 
 	// In case MSDK doesn't support automatic DecodeTimeStamp, do manual
 	// calculation
-	if (g_pts2dtsShift >= 0)
-	{
+	if (g_pts2dtsShift >= 0) {
 		if (g_bFirst) {
 			packet->dts = packet->pts - 3 * obsqsv->params.nFpsDen;
 		} else if (pFrame) {


### PR DESCRIPTION
This commit mostly fixes issues with whitespace, braces, and comments. This commit is probably best viewed in a diff that ignores whitespace changes.

I've wanted to help clean up the obs-qsv11 code for a while, doubly so ever since @Incalex worked on the [QSV on Windows 7 stuff](https://github.com/jp9000/obs-studio/commit/b276b1633e7c37deec4e8a56dec65e4eb36bfc1e).  I don't guarantee that this commit fixes _every_ style issue, but it should fix most of them.  I started feeling fatigued partway through working on this.

Reviews or feedback are appreciated.  Let me know if I've missed something, or if I've made an unwanted change.

I have compiled this on Windows 10 64-bit, but I have not tested it because I don't currently have access to a QSV-enabled Windows machine.  I would greatly appreciate if anyone could test this.