### PR TITLE
UI: Add functions and events for Studio Mode into the Frontend API

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -369,6 +369,37 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		main->SaveService();
 	}
 
+	bool obs_frontend_preview_program_mode_active(void) override
+	{
+		return main->IsPreviewProgramMode();
+	}
+
+	void obs_frontend_set_preview_program_mode(bool enable) override
+	{
+		main->SetPreviewProgramMode(enable);
+	}
+
+	obs_source_t *obs_frontend_get_current_preview_scene(void) override
+	{
+		OBSSource source = nullptr;
+
+		if (main->IsPreviewProgramMode()) {
+			source = main->GetCurrentSceneSource();
+			obs_source_addref(source);
+		}
+
+		return source;
+	}
+
+	void obs_frontend_set_current_preview_scene(obs_source_t *scene) override
+	{
+		if (main->IsPreviewProgramMode()) {
+			QMetaObject::invokeMethod(main, "SetCurrentScene",
+				Q_ARG(OBSSource, OBSSource(scene)),
+				Q_ARG(bool, false));
+		}
+	}
+
 	void on_load(obs_data_t *settings) override
 	{
 		for (auto cb : saveCallbacks)

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -336,3 +336,29 @@ void obs_frontend_save_streaming_service(void)
 	if (callbacks_valid())
 		c->obs_frontend_save_streaming_service();
 }
+
+bool obs_frontend_preview_program_mode_active(void)
+{
+	return !!callbacks_valid()
+		? c->obs_frontend_preview_program_mode_active()
+		: false;
+}
+
+void obs_frontend_set_preview_program_mode(bool enable)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_preview_program_mode(enable);
+}
+
+obs_source_t *obs_frontend_get_current_preview_scene(void)
+{
+	return !!callbacks_valid()
+		? c->obs_frontend_get_current_preview_scene()
+		: nullptr;
+}
+
+void obs_frontend_set_current_preview_scene(obs_source_t *scene)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_current_preview_scene(scene);
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -103,7 +103,11 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING,
 	OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED,
 	OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING,
-	OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED
+	OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED,
+
+	OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED,
+	OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED,
+	OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED
 };
 
 typedef void (*obs_frontend_event_cb)(enum obs_frontend_event event,
@@ -140,6 +144,12 @@ EXPORT void obs_frontend_pop_ui_translation(void);
 EXPORT void obs_frontend_set_streaming_service(obs_service_t *service);
 EXPORT obs_service_t* obs_frontend_get_streaming_service(void);
 EXPORT void obs_frontend_save_streaming_service(void);
+
+EXPORT bool obs_frontend_preview_program_mode_active(void);
+EXPORT void obs_frontend_set_preview_program_mode(bool enable);
+
+EXPORT obs_source_t *obs_frontend_get_current_preview_scene(void);
+EXPORT void obs_frontend_set_current_preview_scene(obs_source_t *scene);
 
 /* ------------------------------------------------------------------------- */
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -75,6 +75,12 @@ struct obs_frontend_callbacks {
 	virtual obs_service_t *obs_frontend_get_streaming_service(void)=0;
 	virtual void obs_frontend_save_streaming_service()=0;
 
+	virtual bool obs_frontend_preview_program_mode_active(void)=0;
+	virtual void obs_frontend_set_preview_program_mode(bool enable)=0;
+
+	virtual obs_source_t *obs_frontend_get_current_preview_scene(void)=0;
+	virtual void obs_frontend_set_current_preview_scene(obs_source_t *scene)=0;
+
 	virtual void on_load(obs_data_t *settings)=0;
 	virtual void on_save(obs_data_t *settings)=0;
 	virtual void on_event(enum obs_frontend_event event)=0;

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -576,6 +576,9 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 				break;
 			}
 		}
+
+		if (api && IsPreviewProgramMode())
+			api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 	}
 
 	UpdateSceneSelection(scene);
@@ -975,6 +978,9 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->previewLayout->addWidget(program);
 		program->show();
 
+		if (api)
+			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
+
 		blog(LOG_INFO, "Switched to Preview/Program mode");
 		blog(LOG_INFO, "-----------------------------"
 				"-------------------");
@@ -1004,6 +1010,9 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		if (!previewEnabled)
 			EnablePreviewDisplay(false);
+
+		if (api)
+			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED);
 
 		blog(LOG_INFO, "Switched to regular Preview mode");
 		blog(LOG_INFO, "-----------------------------"


### PR DESCRIPTION
This Pull Request aims to add several features to the Frontend API:

- Functions: enable, disable and get Studio Mode status + get and set the current preview scene
- Events: on Studio Mode enable and disable + when the currently previewed scene in Studio Mode changes.

Please let me know of any issue with code style or API design.