### PR TITLE
rtmp-services: Update ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 56,
+	"version": 57,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 56
+			"version": 57
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -347,27 +347,6 @@
             ]
         },
         {
-            "name": "Livecoding.tv",
-            "common": true,
-            "servers": [
-                {
-                    "name": "United States",
-                    "url": "rtmp://usmedia3.livecoding.tv/livecodingtv"
-                },
-                {
-                    "name": "EU",
-                    "url": "rtmp://eumedia1.livecoding.tv/livecodingtv"
-                },
-                {
-                    "name": "Asia Pacific",
-                    "url": "rtmp://apmedia1.livecoding.tv/livecodingtv"
-                }
-            ],
-            "recommended": {
-                "max video bitrate": 2300
-            }
-        },
-        {
             "name": "WatchPeopleCode.com",
             "servers": [
                 {
@@ -515,15 +494,6 @@
             }
         },
         {
-            "name": "connectcast.tv",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://stream.connectcast.tv/live"
-                }
-            ]
-        },
-        {
             "name": "CyberGame.TV",
             "servers": [
                 {
@@ -533,19 +503,6 @@
                 {
                     "name": "RU Premium",
                     "url": "rtmp://premium.cybergame.tv:1953/premium"
-                }
-            ]
-        },
-        {
-            "name": "CashPlay.tv",
-            "servers": [
-                {
-                    "name": "Primary, UK",
-                    "url": "rtmp://live.cashplay.tv/live"
-                },
-                {
-                    "name": "Low Priority, DE",
-                    "url": "rtmp://de.live.cashplay.tv/live"
                 }
             ]
         },
@@ -611,10 +568,6 @@
                 {
                     "name": "US-West (San Jose, CA)",
                     "url": "rtmp://us-west.restream.io/live"
-                },
-                {
-                    "name": "US-West (Los Angeles, CA)",
-                    "url": "rtmp://us-la.restream.io/live"
                 },
                 {
                     "name": "US-Central (Dallas, TX)",
@@ -698,11 +651,11 @@
             ]
         },
         {
-            "name": "Stre.am",
+            "name": "Stream.live",
             "servers": [
                 {
                     "name": "Default",
-                    "url": "rtmp://media.stre.am:1935/live"
+                    "url": "rtmp://media.stream.live:1935/live"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
- Remove livecoding.tv (now using per-user ingest assignment)
- Remove Connectcast.tv (Shutting down)
- Remove Cashplay.tv (Shut down)
- Remove Restream.io LA ingest (removed)
- Rename Stre.am to Stream.live and update URL