### PR TITLE
UI, obs-qsv11: Fix build in VisualStudio 2017

### DIFF
--- a/UI/win-update/win-update.cpp
+++ b/UI/win-update/win-update.cpp
@@ -490,20 +490,20 @@ void AutoUpdateThread::info(const QString &title, const QString &text)
 			Q_ARG(QString, text));
 }
 
-int AutoUpdateThread::queryUpdateSlot(bool manualUpdate, const QString &text)
+int AutoUpdateThread::queryUpdateSlot(bool localManualUpdate, const QString &text)
 {
-	OBSUpdate updateDlg(App()->GetMainWindow(), manualUpdate, text);
+	OBSUpdate updateDlg(App()->GetMainWindow(), localManualUpdate, text);
 	return updateDlg.exec();
 }
 
-int AutoUpdateThread::queryUpdate(bool manualUpdate, const char *text_utf8)
+int AutoUpdateThread::queryUpdate(bool localManualUpdate, const char *text_utf8)
 {
 	int ret = OBSUpdate::No;
 	QString text = text_utf8;
 	QMetaObject::invokeMethod(this, "queryUpdateSlot",
 			Qt::BlockingQueuedConnection,
 			Q_RETURN_ARG(int, ret),
-			Q_ARG(bool, manualUpdate),
+			Q_ARG(bool, localManualUpdate),
 			Q_ARG(QString, text));
 	return ret;
 }
@@ -536,7 +536,7 @@ try {
 	string         text;
 	string         error;
 	string         signature;
-	CryptProvider  provider;
+	CryptProvider  localProvider;
 	BYTE           manifestHash[BLAKE2_HASH_LENGTH];
 	bool           updatesAvailable = false;
 	bool           success;
@@ -579,7 +579,7 @@ try {
 	/* ----------------------------------- *
 	 * create signature provider           */
 
-	if (!CryptAcquireContext(&provider,
+	if (!CryptAcquireContext(&localProvider,
 	                         nullptr,
 	                         MS_ENH_RSA_AES_PROV,
 	                         PROV_RSA_AES,
@@ -587,7 +587,7 @@ try {
 		throw strprintf("CryptAcquireContext failed: %lu",
 				GetLastError());
 
-	::provider = provider;
+	provider = localProvider;
 
 	/* ----------------------------------- *
 	 * avoid downloading manifest again    */
@@ -638,7 +638,7 @@ try {
 		if (responseCode == 404)
 			return;
 
-		throw strprintf("Failed to fetch manifest file: %s", error);   
+		throw strprintf("Failed to fetch manifest file: %s", error.c_str());
 	}
 
 	/* ----------------------------------- *

--- a/UI/win-update/win-update.cpp
+++ b/UI/win-update/win-update.cpp
@@ -658,11 +658,11 @@ try {
 	if (responseCode == 200) {
 		if (!QuickWriteFile(manifestPath, text.data(), text.size()))
 			throw strprintf("Could not write file '%s'",
-					manifestPath);
+					*manifestPath);
 	} else {
 		if (!QuickReadFile(manifestPath, text))
 			throw strprintf("Could not read file '%s'",
-					manifestPath);
+					*manifestPath);
 	}
 
 	/* ----------------------------------- *
@@ -764,7 +764,7 @@ try {
 		QString msg = QTStr("Updater.FailedToLaunch");
 		info(msg, msg);
 		throw strprintf("Can't launch updater '%s': %d",
-				updateFilePath, GetLastError());
+				*updateFilePath, GetLastError());
 	}
 
 	/* force OBS to perform another update check immediately after updating

--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -62,6 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <obs-module.h>
 #include <string>
 #include <mutex>
+#include <intrin.h> 
 
 #define do_log(level, format, ...) \
 	blog(level, "[qsv encoder: '%s'] " format, \


### PR DESCRIPTION
OBS did not build out of the box in VS2017 but it does with these
changes. This was all done on/in x64.

Please check if the changes are sane as I do not know the OBS code well.

Without the changes the following errors are produced when building:
```
2>D:\Documents\programming\OBS\obs-studio\plugins\obs-qsv11\QSV_Encoder.cpp(173): error C3861: '__cpuid': identifier not found
2>D:\Documents\programming\OBS\obs-studio\plugins\obs-qsv11\QSV_Encoder.cpp(183): error C3861: '__cpuid': identifier not found

1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(661): error C4839: non-standard use of class 'BPtr<char>' as an argument to a variadic function
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(661): note: the constructor and destructor will not be called; a bitwise copy of the class will be passed as the argument
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(375): note: see declaration of 'BPtr<char>'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(661): error C2280: 'BPtr<char>::BPtr(const BPtr<char> &)': attempting to reference a deleted function
1>D:\Documents\programming\OBS\obs-studio\libobs\util/util.hpp(33): note: see declaration of 'BPtr<char>::BPtr'
1>D:\Documents\programming\OBS\obs-studio\libobs\util/util.hpp(33): note: 'BPtr<char>::BPtr(const BPtr<char> &)': function was explicitly deleted
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(665): error C4839: non-standard use of class 'BPtr<char>' as an argument to a variadic function
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(665): note: the constructor and destructor will not be called; a bitwise copy of the class will be passed as the argument
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(375): note: see declaration of 'BPtr<char>'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(665): error C2280: 'BPtr<char>::BPtr(const BPtr<char> &)': attempting to reference a deleted function
1>D:\Documents\programming\OBS\obs-studio\libobs\util/util.hpp(33): note: see declaration of 'BPtr<char>::BPtr'
1>D:\Documents\programming\OBS\obs-studio\libobs\util/util.hpp(33): note: 'BPtr<char>::BPtr(const BPtr<char> &)': function was explicitly deleted
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(767): error C4839: non-standard use of class 'BPtr<char>' as an argument to a variadic function
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(767): note: the constructor and destructor will not be called; a bitwise copy of the class will be passed as the argument
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(375): note: see declaration of 'BPtr<char>'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(767): error C2280: 'BPtr<char>::BPtr(const BPtr<char> &)': attempting to reference a deleted function
1>D:\Documents\programming\OBS\obs-studio\libobs\util/util.hpp(33): note: see declaration of 'BPtr<char>::BPtr'
1>D:\Documents\programming\OBS\obs-studio\libobs\util/util.hpp(33): note: 'BPtr<char>::BPtr(const BPtr<char> &)': function was explicitly deleted
```
Or in pretty:
![capture](https://cloud.githubusercontent.com/assets/1462179/25681883/43f10bb4-3056-11e7-8b76-60d853a48c75.PNG)

The `QSV_Encoder.cpp` errors seem to stem from the `__cpuid` function moving into the `intrin.h` header. I do not know if my change will break the VS2015 build, someone please test this. If yes, then it probably needs to be included conditionally only via the preprocessor.

The `win-update.cpp` errors stem from passing `BPtr<char>` to `strprintf`.  I believe before the parameter was automatically converted to `* char` before but not anymore in this VS version so I made the conversion explicit.

After fixing the errors, some warnings remain. I do not know if they are serious and need to be fixed. If they should be, I could try doing that too, please tell me.
```
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(493): warning C4458: declaration of 'manualUpdate' hides class member
1>d:\documents\programming\obs\obs-studio\ui\win-update\win-update.hpp(9): note: see declaration of 'AutoUpdateThread::manualUpdate'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(499): warning C4458: declaration of 'manualUpdate' hides class member
1>d:\documents\programming\obs\obs-studio\ui\win-update\win-update.hpp(9): note: see declaration of 'AutoUpdateThread::manualUpdate'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(539): warning C4459: declaration of 'provider' hides global declaration
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(33): note: see declaration of 'provider'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(641): warning C4840: non-portable use of class 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>' as an argument to a variadic function
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(641): note: 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>::basic_string' is non-trivial
1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\xstring(1923): note: see declaration of 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>::basic_string'
1>D:\Documents\programming\OBS\obs-studio\UI\win-update\win-update.cpp(641): note: the constructor and destructor will not be called; a bitwise copy of the class will be passed as the argument
1>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.10.25017\include\xstring(3997): note: see declaration of 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>'
```
![captu2re](https://cloud.githubusercontent.com/assets/1462179/25682252/c5f230d8-3057-11e7-9742-c6f5148d9a78.PNG)

