### PR TITLE
obs-ffmpeg: Add option to media source to play latest replay buffer

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -25,6 +25,8 @@
 
 struct obs_core *obs = NULL;
 
+char *replay_buffer_filename;
+
 extern void add_default_module_paths(void);
 extern char *find_libobs_data_file(const char *file);
 
@@ -1879,6 +1881,16 @@ bool obs_obj_invalid(void *obj)
 		return true;
 
 	return !context->data;
+}
+
+void obs_set_replay_buffer_filename(char *filename)
+{
+	replay_buffer_filename = filename;
+}
+
+char *obs_get_replay_buffer_filename()
+{
+	return replay_buffer_filename;
 }
 
 bool obs_set_audio_monitoring_device(const char *name, const char *id)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1778,11 +1778,15 @@ EXPORT void *obs_service_get_type_data(obs_service_t *service);
 
 EXPORT const char *obs_service_get_id(const obs_service_t *service);
 
-
 /* ------------------------------------------------------------------------- */
 /* Source frame allocation functions */
 EXPORT void obs_source_frame_init(struct obs_source_frame *frame,
 		enum video_format format, uint32_t width, uint32_t height);
+
+/* ------------------------------------------------------------------------- */
+/* Replay buffer filename */
+EXPORT void obs_set_replay_buffer_filename(char *filename);
+EXPORT char *obs_get_replay_buffer_filename();
 
 static inline void obs_source_frame_free(struct obs_source_frame *frame)
 {

--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -20,6 +20,7 @@ NVENC.Level="Level"
 
 FFmpegSource="Media Source"
 LocalFile="Local File"
+LatestReplayBuffer="Play latest replay buffer"
 Looping="Loop"
 Input="Input"
 InputFormat="Input Format"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -663,6 +663,7 @@ static void *replay_buffer_mux_thread(void *data)
 	}
 
 	info("Wrote replay buffer to '%s'", stream->path.array);
+	obs_set_replay_buffer_filename(stream->path.array);
 
 error:
 	os_process_pipe_destroy(stream->pipe);


### PR DESCRIPTION
This also modifies libobs. If the user selects this option, the media source will play the latest replay buffer.