### PR TITLE
UI: Fix settings dialog crashing on linux

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -464,7 +464,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	delete ui->advancedGeneralGroupBox;
 	delete ui->enableNewSocketLoop;
 	delete ui->enableLowLatencyMode;
+#ifdef __APPLE__
 	delete ui->disableAudioDucking;
+#endif
 	ui->rendererLabel = nullptr;
 	ui->renderer = nullptr;
 	ui->adapterLabel = nullptr;
@@ -474,7 +476,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	ui->advancedGeneralGroupBox = nullptr;
 	ui->enableNewSocketLoop = nullptr;
 	ui->enableLowLatencyMode = nullptr;
+#ifdef __APPLE__
 	ui->disableAudioDucking = nullptr;
+#endif
 #endif
 
 #ifndef __APPLE__


### PR DESCRIPTION
Fix a double free in the settings window that occurs on linux only.
The UI Element already gets deleted above as a child of the
advAudioGroupBox which is not present on linux.
Apart from making the code even more unreadable, this will likely
come back to haunt us if the advAudioGroup will ever be shown on linux.