### PR TITLE
UI: Automatically remux if user selects mp4

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -75,6 +75,9 @@ string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
 
+bool autoRemux = false;
+string remuxFilename;
+
 // AMD PowerXpress High Performance Flags
 #ifdef _MSC_VER
 extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
@@ -1145,6 +1148,13 @@ static void get_last_log(void)
 
 string GenerateTimeDateFilename(const char *extension, bool noSpace)
 {
+	if (strcmp(extension, "mp4") == 0) {
+		extension = "mkv";
+		autoRemux = true;
+	} else {
+		autoRemux = false;
+	}
+
 	time_t    now = time(0);
 	char      file[256] = {};
 	struct tm *cur_time;
@@ -1160,14 +1170,26 @@ string GenerateTimeDateFilename(const char *extension, bool noSpace)
 			cur_time->tm_sec,
 			extension);
 
+	remuxFilename = string(file);
+
 	return string(file);
 }
 
 string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 		const char *format)
 {
+	if (strcmp(extension, "mp4") == 0) {
+		extension = "mkv";
+		autoRemux = true;
+	} else {
+		autoRemux = false;
+	}
+
 	BPtr<char> filename = os_generate_formatted_filename(extension,
 			!noSpace, format);
+
+	remuxFilename = string(filename);
+
 	return string(filename);
 }
 

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -176,6 +176,9 @@ static inline int GetProfilePath(char *path, size_t size, const char *file)
 	return window->GetProfilePath(path, size, file);
 }
 
+extern std::string remuxFilename;
+extern bool autoRemux;
+
 extern bool opt_start_streaming;
 extern bool opt_start_recording;
 extern bool opt_start_replaybuffer;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4246,6 +4246,20 @@ void OBSBasic::RecordingStop(int code)
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STOPPED);
 
+	if (autoRemux) {
+		const char *mode = config_get_string(basicConfig, "Output", "Mode");
+		const char *path = strcmp(mode, "Advanced") ?
+		config_get_string(basicConfig, "SimpleOutput", "FilePath") :
+		config_get_string(basicConfig, "AdvOut", "RecFilePath");
+		std::string s(path);
+		s += "/";
+		s += remuxFilename;
+		const QString &str = QString::fromStdString(s);
+		OBSRemux *remux = new OBSRemux(path, this);
+		remux->inputChanged(str);
+		remux->Remux();
+	}
+
 	OnDeactivate();
 }
 

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -51,13 +51,11 @@ public:
 
 	using job_t = std::shared_ptr<struct media_remux_job>;
 
-private slots:
-	void inputChanged(const QString &str);
-
 public slots:
 	void updateProgress(float percent);
 	void remuxFinished(bool success);
 	void Remux();
+	void inputChanged(const QString &str);
 
 signals:
 	void remux();


### PR DESCRIPTION
If the user selects mp4, the file will be recorded as mkv. After the recording is stopped, the file is automatically remuxed to mp4. The mkv file is then deleted. Though rare, this should prevent corrupted mp4 files, in case of crash.