### PR TITLE
libobs: Fix os_safe_replace not working linux

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -434,7 +434,7 @@ int os_rename(const char *old_path, const char *new_path)
 
 int os_safe_replace(const char *target, const char *from, const char *backup)
 {
-	if (backup && rename(target, backup) != 0)
+	if (backup && os_file_exists(target) && rename(target, backup) != 0)
 		return -1;
 	return rename(from, target);
 }


### PR DESCRIPTION
Make sure the target file exists before attempting to create a backup.
This will allow for the function to work correctly if the target does
not yet exist.