### PR TITLE
Decklink fixes

### DIFF
--- a/plugins/decklink/audio-repack.c
+++ b/plugins/decklink/audio-repack.c
@@ -25,7 +25,7 @@ int check_buffer(struct audio_repack *repack,
 	squash data array
 
 	| FL | FR |LFE | FC | BL | BR |emp |emp |
-    |    |       x      |    |
+	  |    |       x      |    |
 	| FL | FR | FC |LFE | BL | BR |
  */
 int repack_8to6ch_swap23(struct audio_repack *repack,
@@ -33,8 +33,6 @@ int repack_8to6ch_swap23(struct audio_repack *repack,
 {
 	if (check_buffer(repack, frame_count) < 0)
 		return -1;
-
-	const uint32_t size = frame_count * repack->base_src_size;
 
 	const __m128i *src = (__m128i *)bsrc;
 	const __m128i *esrc = src + frame_count;
@@ -61,8 +59,6 @@ int repack_8ch_swap23(struct audio_repack *repack,
 {
 	if (check_buffer(repack, frame_count) < 0)
 		return -1;
-
-	const uint32_t size = frame_count * repack->base_src_size;
 
 	const __m128i *src = (__m128i *)bsrc;
 	const __m128i *esrc = src + frame_count;

--- a/plugins/decklink/decklink-device.cpp
+++ b/plugins/decklink/decklink-device.cpp
@@ -128,7 +128,7 @@ const std::string& DeckLinkDevice::GetName(void) const
 	return name;
 }
 
-const int32_t DeckLinkDevice::GetMaxChannel(void) const
+int32_t DeckLinkDevice::GetMaxChannel(void) const
 {
 	return maxChannel;
 }

--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -31,7 +31,7 @@ public:
 	const std::string& GetHash(void) const;
 	const std::vector<DeckLinkDeviceMode *>& GetModes(void) const;
 	const std::string& GetName(void) const;
-	const int32_t GetMaxChannel(void) const;
+	int32_t GetMaxChannel(void) const;
 
 	bool GetInput(IDeckLinkInput **input);
 

--- a/plugins/decklink/linux/CMakeLists.txt
+++ b/plugins/decklink/linux/CMakeLists.txt
@@ -1,5 +1,10 @@
 project(linux-decklink)
 
+if(DISABLE_DECKLINK)
+	message(STATUS "decklink plugin disabled")
+	return()
+endif()
+
 set(linux-decklink-sdk_HEADERS
 	decklink-sdk/DeckLinkAPI.h
 	decklink-sdk/DeckLinkAPIConfiguration.h

--- a/plugins/decklink/mac/CMakeLists.txt
+++ b/plugins/decklink/mac/CMakeLists.txt
@@ -1,5 +1,10 @@
 project(mac-decklink)
 
+if(DISABLE_DECKLINK)
+	message(STATUS "decklink plugin disabled")
+	return()
+endif()
+
 find_library(COREFOUNDATION CoreFoundation)
 
 include_directories(${COREFOUNDATION})

--- a/plugins/decklink/win/CMakeLists.txt
+++ b/plugins/decklink/win/CMakeLists.txt
@@ -1,5 +1,10 @@
 project(win-decklink)
 
+if(DISABLE_DECKLINK)
+	message(STATUS "decklink plugin disabled")
+	return()
+endif()
+
 include(IDLFileHelper)
 
 set(win-decklink-sdk_IDLS


### PR DESCRIPTION
Some minor changes/fixes:
* Add the ability to disable the plugin by passing `-DDISABLE_DECKLINK=1` to cmake
* Fix two compiler warnings