### PR TITLE
enc-amf: Version 2.1.3

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -565,21 +565,21 @@ void SimpleOutput::UpdateStreamingSettings_amd(obs_data_t *settings,
 		int bitrate)
 {
 	// Static Properties
-	obs_data_set_int(settings, "AMF.H264.Usage", 0);
-	obs_data_set_int(settings, "AMF.H264.Profile", 100); // High
+	obs_data_set_int(settings, "Usage", 0);
+	obs_data_set_int(settings, "Profile", 100); // High
 	obs_data_set_string(settings, "profile", "high"); // High
 	
 	// Rate Control Properties
-	obs_data_set_int(settings, "AMF.H264.RateControlMethod", 1);
+	obs_data_set_int(settings, "RateControlMethod", 1);
 	obs_data_set_string(settings, "rate_control", "CBR");
-	obs_data_set_int(settings, "AMF.H264.Bitrate.Target", bitrate);
+	obs_data_set_int(settings, "Bitrate.Target", bitrate);
 	obs_data_set_int(settings, "bitrate", bitrate);
-	obs_data_set_int(settings, "AMF.H264.FillerData", 1);
-	obs_data_set_int(settings, "AMF.H264.VBVBuffer", 1);
-	obs_data_set_int(settings, "AMF.H264.VBVBuffer.Size", bitrate);
+	obs_data_set_int(settings, "FillerData", 1);
+	obs_data_set_int(settings, "VBVBuffer", 1);
+	obs_data_set_int(settings, "VBVBuffer.Size", bitrate);
 	
 	// Picture Control Properties
-	obs_data_set_double(settings, "AMF.H264.KeyframeInterval", 2.0);
+	obs_data_set_double(settings, "KeyframeInterval", 2.0);
 	obs_data_set_int(settings, "keyint_sec", 2);
 }
 
@@ -588,21 +588,21 @@ void SimpleOutput::UpdateRecordingSettings_amd_cqp(int cqp)
 	obs_data_t *settings = obs_data_create();
 
 	// Static Properties
-	obs_data_set_int(settings, "AMF.H264.Usage", 0);
-	obs_data_set_int(settings, "AMF.H264.Profile", 100); // High
+	obs_data_set_int(settings, "Usage", 0);
+	obs_data_set_int(settings, "Profile", 100); // High
 	obs_data_set_string(settings, "profile", "high"); // High
 
 	// Rate Control Properties
-	obs_data_set_int(settings, "AMF.H264.RateControlMethod", 0);
+	obs_data_set_int(settings, "RateControlMethod", 0);
 	obs_data_set_string(settings, "rate_control", "CQP");
-	obs_data_set_int(settings, "AMF.H264.QP.IFrame", cqp);
-	obs_data_set_int(settings, "AMF.H264.QP.PFrame", cqp);
-	obs_data_set_int(settings, "AMF.H264.QP.BFrame", cqp);
-	obs_data_set_int(settings, "AMF.H264.VBVBuffer", 1);
-	obs_data_set_int(settings, "AMF.H264.VBVBuffer.Size", 50000);
+	obs_data_set_int(settings, "QP.IFrame", cqp);
+	obs_data_set_int(settings, "QP.PFrame", cqp);
+	obs_data_set_int(settings, "QP.BFrame", cqp);
+	obs_data_set_int(settings, "VBVBuffer", 1);
+	obs_data_set_int(settings, "VBVBuffer.Size", 100000);
 
 	// Picture Control Properties
-	obs_data_set_double(settings, "AMF.H264.KeyframeInterval", 2.0);
+	obs_data_set_double(settings, "KeyframeInterval", 2.0);
 	obs_data_set_int(settings, "keyint_sec", 2);
 
 	// Update and release


### PR DESCRIPTION
For OBS changelogs (includes 2.1.0/2.0.0 changes):

```
* The AMD Encoder has been completely rewritten from scratch for improved stability, performance and new features. All advanced configurations will break due to this change.
* Added HEVC, Two-Pass and Full-Range color support to the AMD Encoder.
* Improved timestamps generated by the AMD Encoder.
```

## Changelog since 1.4.3.11

### 1.9.9.0
- Added: HEVC Encoder for Polaris, Vega, etc.
- Added: Pre-Pass Mode to AVC & HEVC Encoder.
- Added: Variance Based Adaptive Quantization (VBAQ) to AVC & HEVC Encoder.
- Changed: Improved speed by rewriting internal encoder code.
- Changed: Massively reduced encoding latency by removing threaded submission and querying.
- Changed: IDR Period now has a default of 0 ("Don't Overwrite").
- Changed: Improved multi-GPU support with Direct3D9 and Direct3D11 backends.
- Changed: Removed Intra-Refresh settings from AVC Encoder (temporarily).
- Changed: Improved OpenCL Conversion & Submission by reducing state switches.
- Fixed: Rare crash caused by translated text.
- Fixed: Rare Crash in unexpected Direct3D11 and Direct3D9 environments.
- Fixed: Crash on opening/closing OBS.
- Fixed: Memory leak due to never freed memory.

### 1.9.9.1
- Removed: Aspect Ratio due to missing OBS property type.
- Changed: Internal tracking of the "last" versions of settings.
- Fixed: Crash due to non-initialized variable.

### 1.9.9.2
- Changed: AVC Preset 'High Quality' to use a fixed QP of 18/18/18.
- Changed: AVC Preset 'Indistinguishable' to use a fixed QP of 15/15/15.
- Fixed: HEVC now sets the correct Codec for ffmpeg.
- Fixed: Don't attempt to set Full Range Color for HEVC (HEVC only has Full Range).
- Fixed: Green Blocks when using VBAQ and Constant QP (likely due to conflicting goals).

### 1.9.9.3
- Fixed: Duplicate setting of Rate Control Method causing odd behaviour.
- Fixed: Automatic VBV Buffer causing Constant QP to not work.
- Changed: 'Filler Data' and 'Enforce HRD' now default to Disabled for HEVC.
- Changed: 'GOP Size' defaults to Frame Rate for HEVC.
- Changed: 'Automatic' VBV Buffer with Constant QP is now linear instead of semi-linear like Variable and Constant Bitrate use.

### 1.9.9.4
- Fixed: Timestamps in encoded content should now be correct.
- Fixed: Rare crash due to use of non-thread-safe mbstowcs.
- Fixed: Typo in english locale.

### 1.9.9.5
- Changed: 'Filler Data' now defaults to Enabled for HEVC.
- Fixed: Encoder should no longer cause an error due to Filler Data. (Driver 17.2.1 and above)

### 1.9.9.6
- Changed: 'VBAQ' now defaults to Enabled for AVC and HEVC.
- Fixed: Crash when logging due to invalid access.
- Fixed: Automatic VBV Buffer causing Constant QP to not work.

### 2.0.0.0
* Redesigned the internal structure to be much faster for much less CPU usage.
* Fixed several object lifetime issues that were only visible while debugging.
* Massively improved capability testing which now allows us to see the exact limits of the encoder.
* Fixed a crash-to-desktop on closing OBS.
* Added H264/AVC and H265/HEVC encoders.
* Slightly redesigned the UI to further improve quality of life.
* Removed 'OpenGL' and 'Host' entries from the Video API field as they aren't actual APIs. (#216)
* Removed the useless 'Usage' field, which was causing a lot of PEBKAC issues. (#210)
* Added the ability to use Keyframe Interval in 'Master' View Mode.
* Updated preset 'High Quality' to use a QP value of 18/18/18.
* Updated preset 'Indistinguishable' to use a QP value of 15/15/15.
* Fixed a crash with 'Automatic' VBV Buffer while using 'Constant QP'.
* Fixed 'Filler Data' and 'Enforce HRD' not working properly at all times. (#215)
* Changed the behaviour of 'Automatic' VBV Buffer to be linear with 'Constant QP'.
* Massively improved output timestamps.
* Fired Steve.
* Fixed a rare crash that could happen with certain translations.
* Changed the default for 'VBAQ' to 'Enabled' for H264 and H265.
* Added an Asynchronous Queue mode which enables safe multi-threading for slightly higher CPU usage and encoding latency. (#211)
* Split the 'OpenCL' field into 'OpenCL Transfer' (Use OpenCL to send the frame to the GPU?) and 'OpenCL Conversion' (Use OpenCL instead of DirectCompute for frame conversion?). (#212, #214)
* Fixed certain presets permanently locking the Keyframe Interval and IDR Period to low numbers. (#213)
* Improved Performance Tracking which is visible when starting OBS with --verbose --log_unfiltered.

### 2.1.0
* Fixed B-Frames not working properly. (#234)
* Added experimental I/P/B/Skip Period and Interval. (#220)
* Fixed a possible crash with OBS calling functions on a destroyed instance.

### 2.1.1
* Updated Translations from CrowdIn.
* Fixed plugin starting encoding before encoder is actually ready.
* Fixed some properties not being applied.

### 2.1.2
* Fixed full range color causing crushed blacks and whites.
* Further improved the internal main encoding loop code.

### 2.1.3
* Fixed debug log lines showing up even though 'Debug' wasn't checked.
* Fixed 'Encoding overloaded!' by making Asynchronous Queue the default behaviour and removing that option.
* Added 'Multi-Threading' and 'Queue Size' option which can be used to fine-tune the Asynchronous Queue behaviour.