### PR TITLE
CI: exclude .gitignore from AppVeyor artifacts

### DIFF
--- a/CI/before-deploy-win.cmd
+++ b/CI/before-deploy-win.cmd
@@ -1,3 +1,3 @@
-xcopy /e C:\projects\obs-studio\build32\rundir\RelWithDebInfo C:\projects\obs-studio\build\
-robocopy C:\projects\obs-studio\build64\rundir\RelWithDebInfo C:\projects\obs-studio\build\ /E /XC /XN /XO
+robocopy C:\projects\obs-studio\build32\rundir\RelWithDebInfo C:\projects\obs-studio\build\ /E /XF .gitignore
+robocopy C:\projects\obs-studio\build64\rundir\RelWithDebInfo C:\projects\obs-studio\build\ /E /XC /XN /XO /XF .gitignore
 7z a build.zip C:\projects\obs-studio\build\*


### PR DESCRIPTION
.gitignore is useless to users who download artifacts.