### PR TITLE
UI: fix creating log files in windows

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1221,8 +1221,17 @@ static void create_log_file(fstream &logFile)
 	dst << "obs-studio/logs/" << currentLogFile.c_str();
 
 	BPtr<char> path(GetConfigPathPtr(dst.str().c_str()));
+
+#ifdef _WIN32
+	wchar_t *wpath = NULL;
+	os_utf8_to_wcs_ptr(path, 0, &wpath);
+	logFile.open(wpath,
+			ios_base::in | ios_base::out | ios_base::trunc);
+	bfree(wpath);
+#else
 	logFile.open(path,
 			ios_base::in | ios_base::out | ios_base::trunc);
+#endif
 
 	if (logFile.is_open()) {
 		delete_oldest_file("obs-studio/logs");


### PR DESCRIPTION
This commit fixes creating log files in windows with Unicode profile names.

I encountered this bug when running obs-studio 18.0.2 in **Windows** 8.1 x64 with my user **profile path** containing **Unicode** characters.

Steps to reproduce:

1) Create a windows user with a Unicode name: "пользователь"
2) Run OBS-studio, go to Help -> Log Files -> View current log (Nothing happens)

The expected result is opening current log file.

After this commit the expected result is reached.

The code of this commit is adapted from this definition: https://github.com/jp9000/obs-studio/blob/92a258690e6010f6f261c3fc17be08231f6b9bd3/libobs/util/platform.c#L52-L68