### PR TITLE
vlc-video: Allow media options

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -457,8 +457,7 @@ static inline void vlc_apply_media_options(libvlc_media_t *media,
 					break;
 				}
 			}
-			option_str = malloc((option_len + 1) *
-				sizeof(char));
+			option_str = malloc((option_len + 1) * sizeof(char));
 			memcpy(option_str, options + option_at, option_len);
 			option_str[option_len] = '\0';
 			for (j = k = 1; option_str[j] != '\0'; ++j) {
@@ -479,8 +478,7 @@ static inline void vlc_apply_media_options(libvlc_media_t *media,
 			}
 			option_str[k] = '\0';
 			libvlc_media_add_option_(media, option_str);
-			if (!custom_network_caching &&
-				option_len > 17) {
+			if (!custom_network_caching && option_len > 17) {
 				custom_network_caching = strncmp(
 					option_str,
 					":network-caching=", 17) == 0;


### PR DESCRIPTION
Hi, this is my first time bringing to OBS Studio!

I have added support for media options. They are important or even mandatory for some usages. Options have to begin with ':' and a space must precede the heading colon. This work is to be reviewed.

I am not really experienced in working in C with computers and I'm still disturbed while browsing source code. Although this modification is pretty important to me so I spent some time to figure out myself the lack of support for VLC media options.

Please proofread and give me tips to improve this work and my future works.

It was hard to follow the coding rules, especially the max 80 columns.

Momo :heart: