### PR TITLE
librtmp: Fix build error with ENODATA on FreeBSD

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -729,6 +729,8 @@ add_addr_info(struct sockaddr_storage *service, socklen_t *addrlen, AVal *host, 
         // since we're handling multiple addresses internally, fake the correct error response
 #ifdef _WIN32
         *socket_error = WSANO_DATA;
+#elif __FreeBSD__
+        *socket_error = ENOATTR;
 #else
         *socket_error = ENODATA;
 #endif


### PR DESCRIPTION
When building on FreeBSD before this patch, it would produce the error:
`plugins/obs-outputs/librtmp/rtmp.c:733:25: error: use of undeclared identifier 'ENODATA'`

This patch fixes that.  For more information, check this [FreeBSD mailing list conversation](https://lists.freebsd.org/pipermail/freebsd-hackers/2016-May/049494.html) and this [file from Ceph](https://github.com/ceph/ceph/blob/e8f03e205d27dc3f25b4446093b4c11ba7b9a135/src/include/compat.h#L27).

This patch builds successfully on FreeBSD 11.  As always, I would appreciate additional testing and feedback.  On this particular PR, review from @jp9000 or @notr1ch would be great since it touches librtmp.  If there's a better solution, feel free to edit this PR or close it and fix the issue in another commit.