### PR TITLE
rtmp-services: Rename Beam to Mixer

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 59,
+	"version": 60,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 59
+			"version": 60
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -249,84 +249,84 @@
             }
         },
         {
-            "name": "beam.pro",
+            "name": "Mixer",
             "common": true,
             "servers": [
                 {
                     "name": "US: Dallas, TX",
-                    "url": "rtmp://ingest-dal.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-dal.mixer.com:1935/beam"
                 },
                 {
                     "name": "US: San Jose, CA",
-                    "url": "rtmp://ingest-sjc.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-sjc.mixer.com:1935/beam"
                 },
                 {
                     "name": "US: Seattle, WA",
-                    "url": "rtmp://ingest-sea.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-sea.mixer.com:1935/beam"
                 },
                 {
                     "name": "US: Washington DC",
-                    "url": "rtmp://ingest-wdc.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-wdc.mixer.com:1935/beam"
                 },
                 {
                     "name": "Canada: Toronto",
-                    "url": "rtmp://ingest-tor.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-tor.mixer.com:1935/beam"
                 },
                 {
                     "name": "EU: London",
-                    "url": "rtmp://ingest-lon.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-lon.mixer.com:1935/beam"
                 },
                 {
                     "name": "EU: Amsterdam",
-                    "url": "rtmp://ingest-ams.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-ams.mixer.com:1935/beam"
                 },
                 {
                     "name": "EU: Milan",
-                    "url": "rtmp://ingest-mil.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-mil.mixer.com:1935/beam"
                 },
                 {
                     "name": "EU: Paris",
-                    "url": "rtmp://ingest-par.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-par.mixer.com:1935/beam"
                 },
                 {
                     "name": "EU: Frankfurt",
-                    "url": "rtmp://ingest-fra.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-fra.mixer.com:1935/beam"
                 },
                 {
                     "name": "EU: Oslo",
-                    "url": "rtmp://ingest-osl.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-osl.mixer.com:1935/beam"
                 },
                 {
                     "name": "Brazil: Sao Paulo",
-                    "url": "rtmp://ingest-sao.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-sao.mixer.com:1935/beam"
                 },
                 {
                     "name": "Australia: Melbourne",
-                    "url": "rtmp://ingest-mel.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-mel.mixer.com:1935/beam"
                 },
                 {
                     "name": "Australia: Sydney",
-                    "url": "rtmp://ingest-syd.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-syd.mixer.com:1935/beam"
                 },
                 {
                     "name": "Mexico: Mexico City",
-                    "url": "rtmp://ingest-mex.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-mex.mixer.com:1935/beam"
                 },
                 {
                     "name": "Asia: Hong Kong",
-                    "url": "rtmp://ingest-hkg.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-hkg.mixer.com:1935/beam"
                 },
                 {
                     "name": "Asia: Tokyo",
-                    "url": "rtmp://ingest-tok.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-tok.mixer.com:1935/beam"
                 },
                 {
                     "name": "South Korea: Seoul",
-                    "url": "rtmp://ingest-seo.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-seo.mixer.com:1935/beam"
                 },
                 {
                     "name": "India: Chennai",
-                    "url": "rtmp://ingest-che.beam.pro:1935/beam"
+                    "url": "rtmp://ingest-che.mixer.com:1935/beam"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
Microsoft renamed Beam.pro to Mixer for some reason, so here's the update for that.