### PR TITLE
Make *nix system info logging more like Windows/Mac

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -16,6 +16,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#if defined(__FreeBSD__)
+#define _GNU_SOURCE
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -87,55 +90,105 @@ char *find_libobs_data_file(const char *file)
 
 static void log_processor_cores(void)
 {
-	blog(LOG_INFO, "Processor: %lu logical cores",
-	     sysconf(_SC_NPROCESSORS_ONLN));
+	blog(LOG_INFO, "Physical Cores: %d, Logical Cores: %d",
+			os_get_physical_cores(), os_get_logical_cores());
 }
 
 #if defined(__linux__)
 static void log_processor_info(void)
 {
-	FILE *fp;
 	int physical_id = -1;
 	int last_physical_id = -1;
 	char *line = NULL;
 	size_t linecap = 0;
-	struct dstr processor;
+
+	FILE *fp;
+	struct dstr proc_name;
+	struct dstr proc_speed;
 
 	fp = fopen("/proc/cpuinfo", "r");
 	if (!fp)
 		return;
 
-	dstr_init(&processor);
+	dstr_init(&proc_name);
+	dstr_init(&proc_speed);
 
 	while (getline(&line, &linecap, fp) != -1) {
 		if (!strncmp(line, "model name", 10)) {
 			char *start = strchr(line, ':');
 			if (!start || *(++start) == '\0')
 				continue;
-			dstr_copy(&processor, start);
-			dstr_resize(&processor, processor.len - 1);
-			dstr_depad(&processor);
+
+			dstr_copy(&proc_name, start);
+			dstr_resize(&proc_name, proc_name.len - 1);
+			dstr_depad(&proc_name);
 		}
 
 		if (!strncmp(line, "physical id", 11)) {
 			char *start = strchr(line, ':');
 			if (!start || *(++start) == '\0')
 				continue;
+
 			physical_id = atoi(start);
+		}
+
+		if (!strncmp(line, "cpu MHz", 7)) {
+			char *start = strchr(line, ':');
+			if (!start || *(++start) == '\0')
+				continue;
+
+			dstr_copy(&proc_speed, start);
+			dstr_resize(&proc_speed, proc_speed.len - 1);
+			dstr_depad(&proc_speed);
 		}
 
 		if (*line == '\n' && physical_id != last_physical_id) {
 			last_physical_id = physical_id;
-			blog(LOG_INFO, "Processor: %s", processor.array);
+			blog(LOG_INFO, "CPU Name: %s", proc_name.array);
+			blog(LOG_INFO, "CPU Speed: %sMHz", proc_speed.array);
 		}
 	}
 
 	fclose(fp);
-	dstr_free(&processor);
+	dstr_free(&proc_name);
+	dstr_free(&proc_speed);
 	free(line);
 }
 #elif defined(__FreeBSD__)
-static void log_processor_info(void)
+static void log_processor_speed(void)
+{
+	char *line = NULL;
+	size_t linecap = 0;
+	FILE *fp;
+	struct dstr proc_speed;
+
+	fp = fopen("/var/run/dmesg.boot", "r");
+	if (!fp) {
+		blog(LOG_INFO, "CPU: Missing /var/run/dmesg.boot !");
+		return;
+	}
+
+	dstr_init(&proc_speed);
+
+	while (getline(&line, &linecap, fp) != -1) {
+		if (!strncmp(line, "CPU: ", 5)) {
+			char *start = strrchr(line, '(');
+			if (!start || *(++start) == '\0')
+				continue;
+
+			size_t len = strcspn(start, "-");
+			dstr_ncopy(&proc_speed, start, len);
+		}
+	}
+
+	blog(LOG_INFO, "CPU Speed: %sMHz", proc_speed.array);
+
+	fclose(fp);
+	dstr_free(&proc_speed);
+	free(line);
+}
+
+static void log_processor_name(void)
 {
 	int mib[2];
 	size_t len;
@@ -150,9 +203,15 @@ static void log_processor_info(void)
 		return;
 
 	sysctl(mib, 2, proc, &len, NULL, 0);
-	blog(LOG_INFO, "Processor: %s", proc);
+	blog(LOG_INFO, "CPU Name: %s", proc);
 
 	bfree(proc);
+}
+
+static void log_processor_info(void)
+{
+	log_processor_name();
+	log_processor_speed();
 }
 #endif
 
@@ -162,8 +221,10 @@ static void log_memory_info(void)
 	if (sysinfo(&info) < 0)
 		return;
 
-	blog(LOG_INFO, "Physical Memory: %"PRIu64"MB Total",
-			(uint64_t)info.totalram * info.mem_unit / 1024 / 1024);
+	blog(LOG_INFO, "Physical Memory: %"PRIu64"MB Total, %"PRIu64"MB Free",
+			(uint64_t)info.totalram * info.mem_unit / 1024 / 1024,
+			((uint64_t)info.freeram + (uint64_t)info.bufferram) *
+			info.mem_unit / 1024 / 1024);
 }
 
 static void log_kernel_version(void)
@@ -222,10 +283,10 @@ static void log_distribution_info(void)
 
 void log_system_info(void)
 {
-	log_processor_cores();
 #if defined(__linux__) || defined(__FreeBSD__)
 	log_processor_info();
 #endif
+	log_processor_cores();
 	log_memory_info();
 	log_kernel_version();
 #if defined(__linux__)

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -628,8 +628,6 @@ static int physical_cores = 0;
 static int logical_cores = 0;
 static bool core_count_initialized = false;
 
-/* return sysconf(_SC_NPROCESSORS_ONLN); */
-
 static void os_get_cores_internal(void)
 {
 	if (core_count_initialized)
@@ -639,29 +637,120 @@ static void os_get_cores_internal(void)
 
 	logical_cores = sysconf(_SC_NPROCESSORS_ONLN);
 
-#ifndef __linux__
-	physical_cores = logical_cores;
-#else
-	char *text = os_quick_read_utf8_file("/proc/cpuinfo");
-	char *core_id = text;
+#if defined(__linux__)
+	int physical_id = -1;
+	int last_physical_id = -1;
+	int core_count = 0;
+	char *line = NULL;
+	size_t linecap = 0;
+
+	FILE *fp;
+	struct dstr proc_phys_id;
+	struct dstr proc_phys_ids;
+
+	fp = fopen("/proc/cpuinfo", "r");
+	if (!fp)
+		return;
+
+	dstr_init(&proc_phys_id);
+	dstr_init(&proc_phys_ids);
+
+	while (getline(&line, &linecap, fp) != -1) {
+		if (!strncmp(line, "physical id", 11)) {
+			char *start = strchr(line, ':');
+			if (!start || *(++start) == '\0')
+				continue;
+
+			physical_id = atoi(start);
+			dstr_free(&proc_phys_id);
+			dstr_init(&proc_phys_id);
+			dstr_catf(&proc_phys_id, "%d", physical_id);
+		}
+
+		if (!strncmp(line, "cpu cores", 9)) {
+			char *start = strchr(line, ':');
+			if (!start || *(++start) == '\0')
+				continue;
+
+			if (dstr_is_empty(&proc_phys_ids) ||
+				(!dstr_is_empty(&proc_phys_ids) &&
+				!dstr_find(&proc_phys_ids, proc_phys_id.array))) {
+				dstr_cat_dstr(&proc_phys_ids, &proc_phys_id);
+				dstr_cat(&proc_phys_ids, " ");
+				core_count += atoi(start);
+			}
+		}
+
+		if (*line == '\n' && physical_id != last_physical_id) {
+			last_physical_id = physical_id;
+		}
+	}
+
+	if (core_count == 0)
+		physical_cores = logical_cores;
+	else
+		physical_cores = core_count;
+
+	fclose(fp);
+	dstr_free(&proc_phys_ids);
+	dstr_free(&proc_phys_id);
+	free(line);
+#elif defined(__FreeBSD__)
+	char *text = os_quick_read_utf8_file("/var/run/dmesg.boot");
+	char *core_count = text;
+	int packages = 0;
+	int cores = 0;
+
+	struct dstr proc_packages;
+	struct dstr proc_cores;
+	dstr_init(&proc_packages);
+	dstr_init(&proc_cores);
 
 	if (!text || !*text) {
 		physical_cores = logical_cores;
 		return;
 	}
 
-	for (;;) {
-		core_id = strstr(core_id, "\ncore id");
-		if (!core_id)
-			break;
-		physical_cores++;
-		core_id++;
-	}
+	core_count = strstr(core_count, "\nFreeBSD/SMP: ");
+	if (!core_count)
+		goto FreeBSD_cores_cleanup;
 
-	if (physical_cores == 0)
+	core_count++;
+	core_count = strstr(core_count, "\nFreeBSD/SMP: ");
+	if (!core_count)
+		goto FreeBSD_cores_cleanup;
+
+	core_count = strstr(core_count, ": ");
+	core_count += 2;
+	size_t len = strcspn(core_count, " ");
+	dstr_ncopy(&proc_packages, core_count, len);
+
+	core_count = strstr(core_count, "package(s) x ");
+	if (!core_count)
+		goto FreeBSD_cores_cleanup;
+
+	core_count += 13;
+	len = strcspn(core_count, " ");
+	dstr_ncopy(&proc_cores, core_count, len);
+
+	FreeBSD_cores_cleanup:
+	if (!dstr_is_empty(&proc_packages))
+		packages = atoi(proc_packages.array);
+	if (!dstr_is_empty(&proc_cores))
+		cores = atoi(proc_cores.array);
+
+	if (packages == 0)
 		physical_cores = logical_cores;
+	else if (cores == 0)
+		physical_cores = packages;
+	else
+		physical_cores = packages * cores;
 
+	dstr_free(&proc_cores);
+	dstr_free(&proc_packages);
 	bfree(text);
+#else
+	physical_cores = logical_cores;
 #endif
 }
 


### PR DESCRIPTION
This PR's goal is to make the system info logging (CPU name, CPU speed, CPU core counts, and memory) more like Windows and Mac.

Rename "Processor" to "CPU Name" and place it before the number of cores. Log free RAM for *nix. Log CPU Speed on Linux and FreeBSD. Unify processor logging on Linux and FreeBSD. Get logical and physical CPU cores on Linux and FreeBSD, even for multi-core CPUs. Use the new os_get_logical_cores and os_get_physical_cores function from commits 6fc74d6 and e4a64f0 to get CPU core counts on *nix systems.

This has been compiled and tested on Ubuntu 16.04 and FreeBSD 11.  I haven't noticed any memory leaks or errors with this patch.  Additional review, feedback, and/or testing would be appreciated.