### PR TITLE
UI: Add Japanese shortcut keys for Windows

### DIFF
--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -53,6 +53,7 @@ public:
 		// enough with the default focus frame
 		setReadOnly(true);
 #endif
+		setAttribute(Qt::WA_InputMethodEnabled, false);
 		setAttribute(Qt::WA_MacShowFocusRect, true);
 		InitSignalHandler();
 		ResetKey();

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -328,6 +328,8 @@ static int get_virtual_key(obs_key_t key)
 	case OBS_KEY_BRACKETRIGHT: return VK_OEM_6;
 	case OBS_KEY_ASCIITILDE: return VK_OEM_3;
 
+	case OBS_KEY_HENKAN: return VK_CONVERT;
+	case OBS_KEY_MUHENKAN: return VK_NONCONVERT;
 	case OBS_KEY_KANJI: return VK_KANJI;
 	case OBS_KEY_TOUROKU: return VK_OEM_FJ_TOUROKU;
 	case OBS_KEY_MASSYO: return VK_OEM_FJ_MASSHOU;


### PR DESCRIPTION
This commit also modifies the libobs modules.

This is a workaround for:
https://obsproject.com/mantis/view.php?id=727

Add Japanese shortcut keys, non-convert (無変換) and convert (変換) and disable IME for OBSHotkeyEdit.