### PR TITLE
Suppress -Wimplicit-fallthrough in GCC 7

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -164,6 +164,7 @@ QObject *CreateShortcutFilter()
 			case Qt::Key_Return:
 				if (dialog && pressed)
 					return false;
+				/* Falls through. */
 			default:
 				hotkey.key = obs_key_from_virtual_key(
 					event->nativeVirtualKey());

--- a/libobs/graphics/effect-parser.c
+++ b/libobs/graphics/effect-parser.c
@@ -228,12 +228,14 @@ static void ep_parse_struct(struct effect_parser *ep)
 
 		case PARSE_UNEXPECTED_CONTINUE:
 			cf_adderror_syntax_error(&ep->cfp);
+			/* Falls through. */
 		case PARSE_CONTINUE:
 			ep_var_free(&var);
 			continue;
 
 		case PARSE_UNEXPECTED_BREAK:
 			cf_adderror_syntax_error(&ep->cfp);
+			/* Falls through. */
 		case PARSE_BREAK:
 			ep_var_free(&var);
 			do_break = true;

--- a/libobs/graphics/shader-parser.c
+++ b/libobs/graphics/shader-parser.c
@@ -277,12 +277,14 @@ static void sp_parse_struct(struct shader_parser *sp)
 
 		case PARSE_UNEXPECTED_CONTINUE:
 			cf_adderror_syntax_error(&sp->cfp);
+			/* Falls through. */
 		case PARSE_CONTINUE:
 			shader_var_free(&var);
 			continue;
 
 		case PARSE_UNEXPECTED_BREAK:
 			cf_adderror_syntax_error(&sp->cfp);
+			/* Falls through. */
 		case PARSE_BREAK:
 			shader_var_free(&var);
 			do_break = true;

--- a/libobs/util/cf-lexer.c
+++ b/libobs/util/cf-lexer.c
@@ -123,6 +123,7 @@ static bool cf_is_token_break(struct base_token *start_token,
 			start_token->type = BASETOKEN_DIGIT;
 			break;
 		}
+		/* Falls through. */
 
 	case BASETOKEN_NONE:
 		return true;

--- a/plugins/obs-outputs/librtmp/cencode.c
+++ b/plugins/obs-outputs/librtmp/cencode.c
@@ -48,6 +48,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result = (fragment & 0x0fc) >> 2;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x003) << 4;
+			/* Falls through. */
 	case step_B:
 			if (plainchar == plaintextend)
 			{
@@ -59,6 +60,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result |= (fragment & 0x0f0) >> 4;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x00f) << 2;
+			/* Falls through. */
 	case step_C:
 			if (plainchar == plaintextend)
 			{


### PR DESCRIPTION
Since GCC 7 added new warnings, fall through in switch statements are flagged during compiling time.

Assuming all existing cases are intended, this PR adds a hint to the compiler so no warnings are displayed.

More info about this warning can be found here: https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/