### PR TITLE
UI: Add backwards compatible theme fallback

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -736,15 +736,19 @@ bool OBSApp::SetTheme(std::string name, std::string path)
 
 bool OBSApp::InitTheme()
 {
-	const char *themeName = config_get_string(globalConfig, "General",
+	const char *fallbackName = config_get_string(globalConfig, "General",
 			"Theme");
 
-	if (!themeName)
-		themeName = "Default";
+	if (!fallbackName)
+		fallbackName = "Default";
 
-	stringstream t;
-	t << themeName;
-	return SetTheme(t.str());
+	const char *themeName = config_get_string(globalConfig, "General",
+			"CustomTheme");
+
+	if (themeName && SetTheme(themeName)) {
+		return true;
+	}
+	return SetTheme(fallbackName);
 }
 
 OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2438,8 +2438,12 @@ void OBSBasicSettings::SaveGeneralSettings()
 	string theme = themeData.toStdString();
 
 	if (WidgetChanged(ui->theme)) {
-		config_set_string(GetGlobalConfig(), "General", "Theme",
+		config_set_string(GetGlobalConfig(), "General", "CustomTheme",
 				  theme.c_str());
+		if (theme == "Default" || theme == "Dark") {
+			config_set_string(GetGlobalConfig(), "General", "Theme",
+					theme.c_str());
+		}
 		App()->SetTheme(theme);
 	}
 


### PR DESCRIPTION
This commit changes the "Theme" string in the config to only ever be
"Default" or "Dark", and adds a new string "Custom Theme" to accept all
other theme choices.

The reason for this, is because there are custom themes being worked
on that if a user selects, will then cause older versions or other
installations to fail to launch without editing the config.
This makes sure a fallback is always available.

This change also doesn't conflict with older versions of OBS who look
only for the "Theme" string, since they'll just end up using the
fallback instead.