### PR TITLE
libobs/plugins/UI: Suppress warnings about unused variables

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2278,6 +2278,7 @@ void OBSBasic::CheckForUpdates(bool manualUpdate)
 	updateCheckThread = new AutoUpdateThread(manualUpdate);
 	updateCheckThread->start();
 #endif
+UNUSED_PARAMETER(manualUpdate);
 }
 
 void OBSBasic::updateCheckFinished()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2053,8 +2053,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 			"RecRBPrefix");
 	const char *rbSuffix = config_get_string(main->Config(), "SimpleOutput",
 			"RecRBSuffix");
-	int idx;
-
 	loading = true;
 
 	LoadRendererList();
@@ -2109,7 +2107,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	bool enableLowLatencyMode = config_get_bool(main->Config(), "Output",
 			"LowLatencyEnable");
 
-	idx = ui->processPriority->findData(processPriority);
+	int idx = ui->processPriority->findData(processPriority);
 	if (idx == -1)
 		idx = ui->processPriority->findData("Normal");
 	ui->processPriority->setCurrentIndex(idx);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1507,7 +1507,6 @@ static bool update_async_texrender(struct obs_source *source,
 	uint32_t cy = source->async_height;
 
 	float convert_width  = (float)source->async_convert_width;
-	float convert_height = (float)source->async_convert_height;
 
 	gs_effect_t *conv = obs->video.conversion_effect;
 	gs_technique_t *tech = gs_effect_get_technique(conv,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -249,6 +249,7 @@ static void ffmpeg_source_open(struct ffmpeg_source *s)
 
 static void ffmpeg_source_tick(void *data, float seconds)
 {
+	UNUSED_PARAMETER(seconds);
 	struct ffmpeg_source *s = data;
 	if (s->destroy_media) {
 		if (s->media_valid) {

--- a/plugins/obs-filters/gpu-delay.c
+++ b/plugins/obs-filters/gpu-delay.c
@@ -172,8 +172,8 @@ static void gpu_delay_filter_destroy(void *data)
 
 static void gpu_delay_filter_tick(void *data, float t)
 {
+	UNUSED_PARAMETER(t);
 	struct gpu_delay_filter_data *f = data;
-	uint64_t cur_time = obs_get_video_frame_time();
 
 	f->processed_frame = false;
 

--- a/plugins/obs-outputs/null-output.c
+++ b/plugins/obs-outputs/null-output.c
@@ -82,7 +82,7 @@ static void null_output_stop(void *data, uint64_t ts)
 
 static void null_output_data(void *data, struct encoder_packet *packet)
 {
-	struct null_output *context = data;
+	UNUSED_PARAMETER(data);
 	UNUSED_PARAMETER(packet);
 }
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -293,6 +293,7 @@ static void droptest_cap_data_rate(struct rtmp_stream *stream, size_t size)
 
 static int socket_queue_data(RTMPSockBuf *sb, const char *data, int len, void *arg)
 {
+	UNUSED_PARAMETER(sb);
 	struct rtmp_stream *stream = arg;
 
 retry_send:
@@ -951,8 +952,8 @@ static inline size_t num_buffered_packets(struct rtmp_stream *stream)
 static void drop_frames(struct rtmp_stream *stream, const char *name,
 		int highest_priority, bool pframes)
 {
+	UNUSED_PARAMETER(pframes);
 	struct circlebuf new_buf            = {0};
-	uint64_t         last_drop_dts_usec = 0;
 	int              num_frames_dropped = 0;
 
 #ifdef _DEBUG
@@ -966,8 +967,6 @@ static void drop_frames(struct rtmp_stream *stream, const char *name,
 	while (stream->packets.size) {
 		struct encoder_packet packet;
 		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
-
-		last_drop_dts_usec = packet.dts_usec;
 
 		/* do not drop audio data or video keyframes */
 		if (packet.type          == OBS_ENCODER_AUDIO ||


### PR DESCRIPTION
This clears all warnings about unused parameters and variables.