### PR TITLE
obs-text: Fix file reader occasionally not updating

### DIFF
--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -235,10 +235,11 @@ static void ft2_video_tick(void *data, float seconds)
 	if (!srcdata->from_file || !srcdata->text_file) return;
 
 	if (os_gettime_ns() - srcdata->last_checked >= 1000000000) {
-		time_t t = get_modified_timestamp(srcdata->text_file);
+		struct stat new_stats = get_file_stats(srcdata->text_file);
 		srcdata->last_checked = os_gettime_ns();
 
-		if (srcdata->m_timestamp != t) {
+		if (srcdata->file_stats.st_mtime != new_stats.st_mtime ||
+			srcdata->file_stats.st_size  != new_stats.st_size) {
 			if (srcdata->log_mode)
 				read_from_end(srcdata, srcdata->text_file);
 			else

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -19,7 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <util/platform.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
-#include <sys/stat.h>
 #include "text-freetype2.h"
 #include "obs-convenience.h"
 #include "find-font.h"

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -17,6 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <obs-module.h>
 #include <ft2build.h>
+#include <sys/stat.h>
 
 #define num_cache_slots 65535
 #define src_glyph srcdata->cacheglyphs[glyph_index]

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -37,7 +37,7 @@ struct ft2_source {
 	bool from_file;
 	char *text_file;
 	wchar_t *text;
-	time_t m_timestamp;
+	struct stat file_stats;
 	uint64_t last_checked;
 
 	uint32_t cx, cy, max_h, custom_width;
@@ -83,7 +83,7 @@ static const char *ft2_source_get_name(void *unused);
 
 uint32_t get_ft2_text_width(wchar_t *text, struct ft2_source *srcdata);
 
-time_t get_modified_timestamp(char *filename);
+struct stat get_file_stats(char *filename);
 void load_text_from_file(struct ft2_source *srcdata, const char *filename);
 void read_from_end(struct ft2_source *srcdata, const char *filename);
 


### PR DESCRIPTION
Made file reader check to see if the file size has changed along side the last modify time, this should fix an issue where if the file updates twice in one second, only the first change it displayed.

Fix was also appied to text-freetype2.