### PR TITLE
libobs: Provide type_data and data to properties

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -65,7 +65,7 @@ static bool init_encoder(struct obs_encoder *encoder, const char *name,
 		return false;
 
 	if (encoder->info.get_defaults)
-		encoder->info.get_defaults(encoder->context.settings);
+		encoder->info.get_defaults(encoder->context.settings, encoder->info.type_data);
 
 	return true;
 }
@@ -285,7 +285,7 @@ static inline obs_data_t *get_defaults(const struct obs_encoder_info *info)
 {
 	obs_data_t *settings = obs_data_create();
 	if (info->get_defaults)
-		info->get_defaults(settings);
+		info->get_defaults(settings, info->type_data);
 	return settings;
 }
 
@@ -302,7 +302,7 @@ obs_properties_t *obs_get_encoder_properties(const char *id)
 		obs_data_t       *defaults = get_defaults(ei);
 		obs_properties_t *properties;
 
-		properties = ei->get_properties(NULL);
+		properties = ei->get_properties(NULL, ei->type_data);
 		obs_properties_apply_settings(properties, defaults);
 		obs_data_release(defaults);
 		return properties;
@@ -317,7 +317,7 @@ obs_properties_t *obs_encoder_properties(const obs_encoder_t *encoder)
 
 	if (encoder->info.get_properties) {
 		obs_properties_t *props;
-		props = encoder->info.get_properties(encoder->context.data);
+		props = encoder->info.get_properties(encoder->context.data, encoder->info.type_data);
 		obs_properties_apply_settings(props, encoder->context.settings);
 		return props;
 	}

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -172,15 +172,17 @@ struct obs_encoder_info {
 	 * Gets the default settings for this encoder
 	 *
 	 * @param[out]  settings  Data to assign default settings to
+	 * @param[in]   type_data The type_data variable of this structure
 	 */
-	void (*get_defaults)(obs_data_t *settings);
+	void (*get_defaults)(obs_data_t *settings, void *type_data);
 
 	/**
 	 * Gets the property information of this encoder
 	 *
 	 * @return         The properties data
+	 * @param  type_data  The type_data variable of this structure
 	 */
-	obs_properties_t *(*get_properties)(void *data);
+	obs_properties_t *(*get_properties)(void *data, void *type_data);
 
 	/**
 	 * Updates the settings for this encoder (usually used for things like

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -130,7 +130,7 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 	output->video    = obs_get_video();
 	output->audio    = obs_get_audio();
 	if (output->info.get_defaults)
-		output->info.get_defaults(output->context.settings);
+		output->info.get_defaults(output->context.settings, output->info.type_data);
 
 	ret = os_event_init(&output->reconnect_stop_event,
 			OS_EVENT_TYPE_MANUAL);
@@ -415,7 +415,7 @@ static inline obs_data_t *get_defaults(const struct obs_output_info *info)
 {
 	obs_data_t *settings = obs_data_create();
 	if (info->get_defaults)
-		info->get_defaults(settings);
+		info->get_defaults(settings, info->type_data);
 	return settings;
 }
 
@@ -432,7 +432,7 @@ obs_properties_t *obs_get_output_properties(const char *id)
 		obs_data_t       *defaults = get_defaults(info);
 		obs_properties_t *properties;
 
-		properties = info->get_properties(NULL);
+		properties = info->get_properties(NULL, info->type_data);
 		obs_properties_apply_settings(properties, defaults);
 		obs_data_release(defaults);
 		return properties;
@@ -447,7 +447,7 @@ obs_properties_t *obs_output_properties(const obs_output_t *output)
 
 	if (output && output->info.get_properties) {
 		obs_properties_t *props;
-		props = output->info.get_properties(output->context.data);
+		props = output->info.get_properties(output->context.data, output->info.type_data);
 		obs_properties_apply_settings(props, output->context.settings);
 		return props;
 	}

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -52,9 +52,9 @@ struct obs_output_info {
 	/* optional */
 	void (*update)(void *data, obs_data_t *settings);
 
-	void (*get_defaults)(obs_data_t *settings);
+	void (*get_defaults)(obs_data_t *settings, void *type_data);
 
-	obs_properties_t *(*get_properties)(void *data);
+	obs_properties_t *(*get_properties)(void *data, void *type_data);
 
 	void (*pause)(void *data);
 

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -123,7 +123,7 @@ static inline obs_data_t *get_defaults(const struct obs_service_info *info)
 {
 	obs_data_t *settings = obs_data_create();
 	if (info->get_defaults)
-		info->get_defaults(settings);
+		info->get_defaults(settings, info->type_data);
 	return settings;
 }
 
@@ -140,7 +140,7 @@ obs_properties_t *obs_get_service_properties(const char *id)
 		obs_data_t       *defaults = get_defaults(info);
 		obs_properties_t *properties;
 
-		properties = info->get_properties(NULL);
+		properties = info->get_properties(NULL, info->type_data);
 		obs_properties_apply_settings(properties, defaults);
 		obs_data_release(defaults);
 		return properties;
@@ -155,7 +155,7 @@ obs_properties_t *obs_service_properties(const obs_service_t *service)
 
 	if (service->info.get_properties) {
 		obs_properties_t *props;
-		props = service->info.get_properties(service->context.data);
+		props = service->info.get_properties(service->context.data, service->info.type_data);
 		obs_properties_apply_settings(props, service->context.settings);
 		return props;
 	}

--- a/libobs/obs-service.h
+++ b/libobs/obs-service.h
@@ -42,9 +42,9 @@ struct obs_service_info {
 
 	void (*update)(void *data, obs_data_t *settings);
 
-	void (*get_defaults)(obs_data_t *settings);
+	void (*get_defaults)(obs_data_t *settings, void *type_data);
 
-	obs_properties_t *(*get_properties)(void *data);
+	obs_properties_t *(*get_properties)(void *data, void *type_data);
 
 	/**
 	 * Called when getting ready to start up an output, before the encoders

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -322,7 +322,7 @@ static obs_source_t *obs_source_create_internal(const char *id,
 		goto fail;
 
 	if (info && info->get_defaults)
-		info->get_defaults(source->context.settings);
+		info->get_defaults(source->context.settings, source->info.type_data);
 
 	if (!obs_source_init(source))
 		goto fail;
@@ -689,7 +689,7 @@ static inline obs_data_t *get_defaults(const struct obs_source_info *info)
 {
 	obs_data_t *settings = obs_data_create();
 	if (info->get_defaults)
-		info->get_defaults(settings);
+		info->get_defaults(settings, info->type_data);
 	return settings;
 }
 
@@ -712,7 +712,7 @@ obs_properties_t *obs_get_source_properties(const char *id)
 		obs_data_t       *defaults = get_defaults(info);
 		obs_properties_t *properties;
 
-		properties = info->get_properties(NULL);
+		properties = info->get_properties(NULL, info->type_data);
 		obs_properties_apply_settings(properties, defaults);
 		obs_data_release(defaults);
 		return properties;
@@ -739,7 +739,7 @@ obs_properties_t *obs_source_properties(const obs_source_t *source)
 
 	if (source->info.get_properties) {
 		obs_properties_t *props;
-		props = source->info.get_properties(source->context.data);
+		props = source->info.get_properties(source->context.data, source->info.type_data);
 		obs_properties_apply_settings(props, source->context.settings);
 		return props;
 	}

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -200,16 +200,19 @@ struct obs_source_info {
 	/**
 	 * Gets the default settings for this source
 	 *
+	 * @param  type_data  The type_data variable of this structure
 	 * @param[out]  settings  Data to assign default settings to
 	 */
-	void (*get_defaults)(obs_data_t *settings);
+	void (*get_defaults)(obs_data_t *settings, void *type_data);
 
 	/**
 	 * Gets the property information of this source
 	 *
+	 * @param data      Source data
+	 * @param  type_data  The type_data variable of this structure
 	 * @return         The properties data
 	 */
-	obs_properties_t *(*get_properties)(void *data);
+	obs_properties_t *(*get_properties)(void *data, void *type_data);
 
 	/**
 	 * Updates the settings for this source

--- a/plugins/coreaudio-encoder/encoder.cpp
+++ b/plugins/coreaudio-encoder/encoder.cpp
@@ -1030,8 +1030,9 @@ static UInt32 find_matching_bitrate(UInt32 bitrate)
 	return match;
 }
 
-static void aac_defaults(obs_data_t *settings)
+static void aac_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "samplerate", 0); //match input
 	obs_data_set_default_int(settings, "bitrate",
 			find_matching_bitrate(128));
@@ -1316,8 +1317,9 @@ static bool samplerate_updated(obs_properties_t *props, obs_property_t *prop,
 	return false;
 }
 
-static obs_properties_t *aac_properties(void *data)
+static obs_properties_t *aac_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	ca_encoder *ca = static_cast<ca_encoder*>(data);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/decklink/plugin-main.cpp
+++ b/plugins/decklink/plugin-main.cpp
@@ -72,8 +72,9 @@ static void decklink_update(void *data, obs_data_t *settings)
 	decklink->Activate(device, id);
 }
 
-static void decklink_get_defaults(obs_data_t *settings)
+static void decklink_get_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_bool(settings, BUFFERING, true);
 	obs_data_set_default_int(settings, PIXEL_FORMAT, bmdFormat8BitYUV);
 	obs_data_set_default_int(settings, CHANNEL_FORMAT, SPEAKERS_STEREO);
@@ -162,8 +163,9 @@ static void fill_out_devices(obs_property_t *list)
 	deviceEnum->Unlock();
 }
 
-static obs_properties_t *decklink_get_properties(void *data)
+static obs_properties_t *decklink_get_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_property_t *list = obs_properties_add_list(props, DEVICE_HASH,

--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -44,8 +44,9 @@ static void color_source_destroy(void *data)
 	bfree(data);
 }
 
-static obs_properties_t *color_source_properties(void *unused)
+static obs_properties_t *color_source_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();
@@ -97,8 +98,9 @@ static uint32_t color_source_getheight(void *data)
 	return context->height;
 }
 
-static void color_source_defaults(obs_data_t *settings)
+static void color_source_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "color", 0xFFFFFFFF);
 	obs_data_set_default_int(settings, "width", 400);
 	obs_data_set_default_int(settings, "height", 400);

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -91,8 +91,9 @@ static void image_source_update(void *data, obs_data_t *settings)
 		image_source_unload(data);
 }
 
-static void image_source_defaults(obs_data_t *settings)
+static void image_source_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_bool(settings, "unload", false);
 }
 
@@ -221,8 +222,9 @@ static const char *image_filter =
 	"JPEG Files (*.jpeg *.jpg);;"
 	"GIF Files (*.gif)";
 
-static obs_properties_t *image_source_properties(void *data)
+static obs_properties_t *image_source_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	struct image_source *s = data;
 	struct dstr path = {0};
 

--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -500,8 +500,9 @@ static uint32_t ss_height(void *data)
 	return ss->transition ? ss->cy : 0;
 }
 
-static void ss_defaults(obs_data_t *settings)
+static void ss_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_string(settings, S_TRANSITION, "fade");
 	obs_data_set_default_int(settings, S_SLIDE_TIME, 8000);
 	obs_data_set_default_int(settings, S_TR_SPEED, 700);
@@ -520,8 +521,9 @@ static const char *aspects[] = {
 
 #define NUM_ASPECTS (sizeof(aspects) / sizeof(const char *))
 
-static obs_properties_t *ss_properties(void *data)
+static obs_properties_t *ss_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 	struct slideshow *ss = data;
 	struct obs_video_info ovi;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-aac.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-aac.c
@@ -247,13 +247,15 @@ static bool aac_encode(void *data, struct encoder_frame *frame,
 	return do_aac_encode(enc, packet, received_packet);
 }
 
-static void aac_defaults(obs_data_t *settings)
+static void aac_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "bitrate", 128);
 }
 
-static obs_properties_t *aac_properties(void *unused)
+static obs_properties_t *aac_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -451,8 +451,9 @@ static void ffmpeg_mux_data(void *data, struct encoder_packet *packet)
 	write_packet(stream, packet);
 }
 
-static obs_properties_t *ffmpeg_mux_properties(void *unused)
+static obs_properties_t *ffmpeg_mux_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();
@@ -802,8 +803,9 @@ static void replay_buffer_data(void *data, struct encoder_packet *packet)
 	}
 }
 
-static void replay_buffer_defaults(obs_data_t *s)
+static void replay_buffer_defaults(obs_data_t *s, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(s, "max_time_sec", 15);
 	obs_data_set_default_int(s, "max_size_mb", 500);
 	obs_data_set_default_string(s, "format", "%CCYY-%MM-%DD %hh-%mm-%ss");

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -378,8 +378,9 @@ static bool nvenc_encode(void *data, struct encoder_frame *frame,
 	return true;
 }
 
-static void nvenc_defaults(obs_data_t *settings)
+static void nvenc_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "cqp", 23);
@@ -416,8 +417,9 @@ static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *nvenc_properties(void *unused)
+static obs_properties_t *nvenc_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -83,8 +83,9 @@ static bool is_local_file_modified(obs_properties_t *props,
 	return true;
 }
 
-static void ffmpeg_source_defaults(obs_data_t *settings)
+static void ffmpeg_source_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_bool(settings, "is_local_file", true);
 	obs_data_set_default_bool(settings, "looping", false);
 	obs_data_set_default_bool(settings, "clear_on_media_end", true);
@@ -102,8 +103,9 @@ static const char *video_filter =
 static const char *audio_filter =
 	" (*.mp3 *.aac *.ogg *.wav);;";
 
-static obs_properties_t *ffmpeg_source_getproperties(void *data)
+static obs_properties_t *ffmpeg_source_getproperties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	struct ffmpeg_source *s = data;
 	struct dstr filter = {0};
 	struct dstr path = {0};

--- a/plugins/obs-filters/async-delay-filter.c
+++ b/plugins/obs-filters/async-delay-filter.c
@@ -110,8 +110,9 @@ static void async_delay_filter_destroy(void *data)
 	bfree(data);
 }
 
-static obs_properties_t *async_delay_filter_properties(void *data)
+static obs_properties_t *async_delay_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_int(props, SETTING_DELAY_MS, TEXT_DELAY_MS,

--- a/plugins/obs-filters/chroma-key-filter.c
+++ b/plugins/obs-filters/chroma-key-filter.c
@@ -229,8 +229,9 @@ static bool key_type_changed(obs_properties_t *props, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *chroma_key_properties(void *data)
+static obs_properties_t *chroma_key_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_property_t *p = obs_properties_add_list(props,
@@ -263,8 +264,9 @@ static obs_properties_t *chroma_key_properties(void *data)
 	return props;
 }
 
-static void chroma_key_defaults(obs_data_t *settings)
+static void chroma_key_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, SETTING_OPACITY, 100);
 	obs_data_set_default_double(settings, SETTING_CONTRAST, 0.0);
 	obs_data_set_default_double(settings, SETTING_BRIGHTNESS, 0.0);

--- a/plugins/obs-filters/color-correction-filter.c
+++ b/plugins/obs-filters/color-correction-filter.c
@@ -346,8 +346,9 @@ static void color_correction_filter_render(void *data, gs_effect_t *effect)
  * maximum and step values. While a custom interface can be built, for a
  * simple filter like this it's better to use the supplied functions.
  */
-static obs_properties_t *color_correction_filter_properties(void *data)
+static obs_properties_t *color_correction_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_float_slider(props, SETTING_GAMMA,
@@ -377,8 +378,9 @@ static obs_properties_t *color_correction_filter_properties(void *data)
  * *NOTE* this function is completely optional, as is providing a default
  * for any particular setting.
  */
-static void color_correction_filter_defaults(obs_data_t *settings)
+static void color_correction_filter_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_double(settings, SETTING_GAMMA, 0.0);
 	obs_data_set_default_double(settings, SETTING_CONTRAST, 0.0);
 	obs_data_set_default_double(settings, SETTING_BRIGHTNESS, 0.0);

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -56,13 +56,15 @@ static void color_grade_filter_update(void *data, obs_data_t *settings)
 	obs_leave_graphics();
 }
 
-static void color_grade_filter_defaults(obs_data_t *settings)
+static void color_grade_filter_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_double(settings, SETTING_CLUT_AMOUNT, 1);
 }
 
-static obs_properties_t *color_grade_filter_properties(void *data)
+static obs_properties_t *color_grade_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	struct lut_filter_data *s = data;
 	struct dstr path = {0};
 	const char *slash;

--- a/plugins/obs-filters/color-key-filter.c
+++ b/plugins/obs-filters/color-key-filter.c
@@ -196,8 +196,9 @@ static bool key_type_changed(obs_properties_t *props, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *color_key_properties(void *data)
+static obs_properties_t *color_key_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_property_t *p = obs_properties_add_list(props,
@@ -230,8 +231,9 @@ static obs_properties_t *color_key_properties(void *data)
 	return props;
 }
 
-static void color_key_defaults(obs_data_t *settings)
+static void color_key_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, SETTING_OPACITY, 100);
 	obs_data_set_default_double(settings, SETTING_CONTRAST, 0.0);
 	obs_data_set_default_double(settings, SETTING_BRIGHTNESS, 0.0);

--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -189,8 +189,9 @@ static struct obs_audio_data *compressor_filter_audio(void *data,
 	return audio;
 }
 
-static void compressor_defaults(obs_data_t *s)
+static void compressor_defaults(obs_data_t *s, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_double(s, S_RATIO, 10.0f);
 	obs_data_set_default_double(s, S_THRESHOLD, -18.0f);
 	obs_data_set_default_int(s, S_ATTACK_TIME, 6);
@@ -198,8 +199,9 @@ static void compressor_defaults(obs_data_t *s)
 	obs_data_set_default_double(s, S_OUTPUT_GAIN, 0.0f);
 }
 
-static obs_properties_t *compressor_properties(void *data)
+static obs_properties_t *compressor_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_float_slider(props, S_RATIO,

--- a/plugins/obs-filters/crop-filter.c
+++ b/plugins/obs-filters/crop-filter.c
@@ -98,8 +98,9 @@ static bool relative_clicked(obs_properties_t *props, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *crop_filter_properties(void *data)
+static obs_properties_t *crop_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_property_t *p = obs_properties_add_bool(props, "relative",
@@ -124,8 +125,9 @@ static obs_properties_t *crop_filter_properties(void *data)
 	return props;
 }
 
-static void crop_filter_defaults(obs_data_t *settings)
+static void crop_filter_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_bool(settings, "relative", true);
 }
 

--- a/plugins/obs-filters/gain-filter.c
+++ b/plugins/obs-filters/gain-filter.c
@@ -66,13 +66,15 @@ static struct obs_audio_data *gain_filter_audio(void *data,
 	return audio;
 }
 
-static void gain_defaults(obs_data_t *s)
+static void gain_defaults(obs_data_t *s, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_double(s, S_GAIN_DB, 0.0f);
 }
 
-static obs_properties_t *gain_properties(void *data)
+static obs_properties_t *gain_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 
 	obs_properties_add_float_slider(ppts, S_GAIN_DB, TEXT_GAIN_DB,

--- a/plugins/obs-filters/gpu-delay.c
+++ b/plugins/obs-filters/gpu-delay.c
@@ -143,8 +143,9 @@ static void gpu_delay_filter_update(void *data, obs_data_t *s)
 	free_textures(f);
 }
 
-static obs_properties_t *gpu_delay_filter_properties(void *data)
+static obs_properties_t *gpu_delay_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_int(props, S_DELAY_MS, T_DELAY_MS, 0, 500, 1);

--- a/plugins/obs-filters/mask-filter.c
+++ b/plugins/obs-filters/mask-filter.c
@@ -71,8 +71,9 @@ static void mask_filter_update(void *data, obs_data_t *settings)
 	obs_leave_graphics();
 }
 
-static void mask_filter_defaults(obs_data_t *settings)
+static void mask_filter_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_string(settings, SETTING_TYPE,
 			"mask_color_filter.effect");
 	obs_data_set_default_int(settings, SETTING_COLOR, 0xFFFFFF);
@@ -82,8 +83,9 @@ static void mask_filter_defaults(obs_data_t *settings)
 #define IMAGE_FILTER_EXTENSIONS \
 	" (*.bmp *.jpg *.jpeg *.tga *.gif *.png)"
 
-static obs_properties_t *mask_filter_properties(void *data)
+static obs_properties_t *mask_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 	struct dstr filter_str = {0};
 	obs_property_t *p;

--- a/plugins/obs-filters/noise-gate-filter.c
+++ b/plugins/obs-filters/noise-gate-filter.c
@@ -152,8 +152,9 @@ static struct obs_audio_data *noise_gate_filter_audio(void *data,
 	return audio;
 }
 
-static void noise_gate_defaults(obs_data_t *s)
+static void noise_gate_defaults(obs_data_t *s, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_double(s, S_OPEN_THRESHOLD, -26.0f);
 	obs_data_set_default_double(s, S_CLOSE_THRESHOLD, -32.0f);
 	obs_data_set_default_int   (s, S_ATTACK_TIME, 25);
@@ -161,8 +162,9 @@ static void noise_gate_defaults(obs_data_t *s)
 	obs_data_set_default_int   (s, S_RELEASE_TIME, 150);
 }
 
-static obs_properties_t *noise_gate_properties(void *data)
+static obs_properties_t *noise_gate_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 
 	obs_properties_add_float_slider(ppts, S_CLOSE_THRESHOLD,

--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -267,13 +267,15 @@ static struct obs_audio_data *noise_suppress_filter_audio(void *data,
 	return &ng->output_audio;
 }
 
-static void noise_suppress_defaults(obs_data_t *s)
+static void noise_suppress_defaults(obs_data_t *s, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(s, S_SUPPRESS_LEVEL, -30);
 }
 
-static obs_properties_t *noise_suppress_properties(void *data)
+static obs_properties_t *noise_suppress_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 
 	obs_properties_add_int_slider(ppts, S_SUPPRESS_LEVEL,

--- a/plugins/obs-filters/scale-filter.c
+++ b/plugins/obs-filters/scale-filter.c
@@ -309,8 +309,9 @@ static bool sampling_modified(obs_properties_t *props, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *scale_filter_properties(void *data)
+static obs_properties_t *scale_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 	struct obs_video_info ovi;
 	obs_property_t *p;
@@ -365,8 +366,9 @@ static obs_properties_t *scale_filter_properties(void *data)
 	return props;
 }
 
-static void scale_filter_defaults(obs_data_t *settings)
+static void scale_filter_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_string(settings, S_SAMPLING, S_SAMPLING_BICUBIC);
 	obs_data_set_default_string(settings, S_RESOLUTION, T_NONE);
 	obs_data_set_default_bool(settings, S_UNDISTORT, 0);

--- a/plugins/obs-filters/scroll-filter.c
+++ b/plugins/obs-filters/scroll-filter.c
@@ -114,8 +114,9 @@ static bool limit_cy_clicked(obs_properties_t *props, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *scroll_filter_properties(void *data)
+static obs_properties_t *scroll_filter_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *p;
 
@@ -142,8 +143,9 @@ static obs_properties_t *scroll_filter_properties(void *data)
 	return props;
 }
 
-static void scroll_filter_defaults(obs_data_t *settings)
+static void scroll_filter_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_bool(settings, "limit_size", false);
 	obs_data_set_default_int(settings, "cx", 100);
 	obs_data_set_default_int(settings, "cy", 100);

--- a/plugins/obs-filters/sharpness-filter.c
+++ b/plugins/obs-filters/sharpness-filter.c
@@ -96,8 +96,9 @@ static void sharpness_render(void *data, gs_effect_t *effect)
 	UNUSED_PARAMETER(effect);
 }
 
-static obs_properties_t *sharpness_properties(void *data)
+static obs_properties_t *sharpness_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_float_slider(props, "sharpness",
@@ -107,8 +108,9 @@ static obs_properties_t *sharpness_properties(void *data)
 	return props;
 }
 
-static void sharpness_defaults(obs_data_t *settings)
+static void sharpness_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_double(settings, "sharpness", 0.08);
 }
 

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -207,8 +207,9 @@ static void flv_output_data(void *data, struct encoder_packet *packet)
 	}
 }
 
-static obs_properties_t *flv_output_properties(void *unused)
+static obs_properties_t *flv_output_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1099,8 +1099,9 @@ static void rtmp_stream_data(void *data, struct encoder_packet *packet)
 		obs_encoder_packet_release(&new_packet);
 }
 
-static void rtmp_stream_defaults(obs_data_t *defaults)
+static void rtmp_stream_defaults(obs_data_t *defaults, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(defaults, OPT_DROP_THRESHOLD, 700);
 	obs_data_set_default_int(defaults, OPT_PFRAME_DROP_THRESHOLD, 900);
 	obs_data_set_default_int(defaults, OPT_MAX_SHUTDOWN_TIME_SEC, 30);
@@ -1109,8 +1110,9 @@ static void rtmp_stream_defaults(obs_data_t *defaults)
 	obs_data_set_default_bool(defaults, OPT_LOWLATENCY_ENABLED, false);
 }
 
-static obs_properties_t *rtmp_stream_properties(void *unused)
+static obs_properties_t *rtmp_stream_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -137,8 +137,9 @@ static void obs_qsv_destroy(void *data)
 	}
 }
 
-static void obs_qsv_defaults(obs_data_t *settings)
+static void obs_qsv_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_string(settings, "target_usage", "balanced");
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "max_bitrate", 3000);
@@ -233,8 +234,9 @@ static inline void add_rate_controls(obs_property_t *list,
 	}
 }
 
-static obs_properties_t *obs_qsv_props(void *unused)
+static obs_properties_t *obs_qsv_props(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -859,8 +859,9 @@ static bool extents_modified(obs_properties_t *props, obs_property_t *p,
 
 #undef set_vis
 
-static obs_properties_t *get_properties(void *data)
+static obs_properties_t *get_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	TextSource *s = reinterpret_cast<TextSource*>(data);
 	string path;
 
@@ -973,8 +974,9 @@ bool obs_module_load(void)
 	{
 		return reinterpret_cast<TextSource*>(data)->cy;
 	};
-	si.get_defaults = [] (obs_data_t *settings)
+	si.get_defaults = [](obs_data_t *settings, void *type_data)
 	{
+		UNUSED_PARAMETER(type_data);
 		obs_data_t *font_obj = obs_data_create();
 		obs_data_set_default_string(font_obj, "face", "Arial");
 		obs_data_set_default_int(font_obj, "size", 36);

--- a/plugins/obs-transitions/transition-fade-to-color.c
+++ b/plugins/obs-transitions/transition-fade-to-color.c
@@ -146,8 +146,9 @@ static bool fade_to_color_audio_render(void *data, uint64_t *ts_out,
 		audio, mixers, channels, sample_rate, mix_a, mix_b);
 }
 
-static obs_properties_t *fade_to_color_properties(void *data)
+static obs_properties_t *fade_to_color_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 
 	obs_properties_add_color(props, S_COLOR, S_COLOR_TEXT);
@@ -158,8 +159,9 @@ static obs_properties_t *fade_to_color_properties(void *data)
 	return props;
 }
 
-static void fade_to_color_defaults(obs_data_t *settings)
+static void fade_to_color_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, S_COLOR, 0xFF000000);
 	obs_data_set_default_int(settings, S_SWITCH_POINT, 50);
 }

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -123,8 +123,9 @@ static void luma_wipe_destroy(void *data)
 	bfree(lwipe);
 }
 
-static obs_properties_t *luma_wipe_properties(void *data)
+static obs_properties_t *luma_wipe_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *props = obs_properties_create();
 	struct luma_wipe_info *lwipe = data;
 
@@ -147,8 +148,9 @@ static obs_properties_t *luma_wipe_properties(void *data)
 	return props;
 }
 
-static void luma_wipe_defaults(obs_data_t *settings)
+static void luma_wipe_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_string(settings, S_LUMA_IMG, "linear-h.png");
 	obs_data_set_default_double(settings, S_LUMA_SOFT, 0.03);
 	obs_data_set_default_bool(settings, S_LUMA_INV, false);

--- a/plugins/obs-transitions/transition-slide.c
+++ b/plugins/obs-transitions/transition-slide.c
@@ -131,8 +131,9 @@ bool slide_audio_render(void *data, uint64_t *ts_out,
 		audio, mixers, channels, sample_rate, mix_a, mix_b);
 }
 
-static obs_properties_t *slide_properties(void *data)
+static obs_properties_t *slide_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 	obs_property_t *p;
 

--- a/plugins/obs-transitions/transition-swipe.c
+++ b/plugins/obs-transitions/transition-swipe.c
@@ -124,8 +124,9 @@ static bool swipe_audio_render(void *data, uint64_t *ts_out,
 		audio, mixers, channels, sample_rate, mix_a, mix_b);
 }
 
-static obs_properties_t *swipe_properties(void *data)
+static obs_properties_t *swipe_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 	obs_property_t *p;
 

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -89,8 +89,9 @@ static void obs_x264_destroy(void *data)
 	}
 }
 
-static void obs_x264_defaults(obs_data_t *settings)
+static void obs_x264_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int   (settings, "bitrate",     2500);
 	obs_data_set_default_bool  (settings, "use_bufsize", false);
 	obs_data_set_default_int   (settings, "buffer_size", 2500);
@@ -158,8 +159,9 @@ static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *obs_x264_props(void *unused)
+static obs_properties_t *obs_x264_props(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -306,8 +306,9 @@ static bool show_all_services_toggled(obs_properties_t *ppts,
 	return true;
 }
 
-static obs_properties_t *rtmp_common_properties(void *unused)
+static obs_properties_t *rtmp_common_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *ppts = obs_properties_create();

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -57,8 +57,9 @@ static bool use_auth_modified(obs_properties_t *ppts, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *rtmp_custom_properties(void *unused)
+static obs_properties_t *rtmp_custom_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *ppts = obs_properties_create();

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -111,8 +111,9 @@ static uint32_t ft2_source_get_height(void *data)
 	return srcdata->cy;
 }
 
-static obs_properties_t *ft2_source_properties(void *unused)
+static obs_properties_t *ft2_source_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -81,8 +81,9 @@ static void duplicator_capture_destroy(void *data)
 	bfree(capture);
 }
 
-static void duplicator_capture_defaults(obs_data_t *settings)
+static void duplicator_capture_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "monitor", 0);
 	obs_data_set_default_bool(settings, "capture_cursor", true);
 }
@@ -282,10 +283,11 @@ static bool get_monitor_props(obs_property_t *monitor_list, int monitor_idx)
 	return true;
 }
 
-static obs_properties_t *duplicator_capture_properties(void *unused)
+static obs_properties_t *duplicator_capture_properties(void *unused, void *type_data)
 {
 	int monitor_idx = 0;
 
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1761,8 +1761,9 @@ static const char *game_capture_name(void *unused)
 	return TEXT_GAME_CAPTURE;
 }
 
-static void game_capture_defaults(obs_data_t *settings)
+static void game_capture_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_string(settings, SETTING_MODE, SETTING_MODE_ANY);
 	obs_data_set_default_int(settings, SETTING_WINDOW_PRIORITY,
 			(int)WINDOW_PRIORITY_EXE);
@@ -1889,8 +1890,9 @@ static bool window_not_blacklisted(const char *title, const char *class,
 	return !is_blacklisted_exe(exe);
 }
 
-static obs_properties_t *game_capture_properties(void *data)
+static obs_properties_t *game_capture_properties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	HMONITOR monitor;
 	uint32_t cx = 1920;
 	uint32_t cy = 1080;

--- a/plugins/win-capture/monitor-capture.c
+++ b/plugins/win-capture/monitor-capture.c
@@ -105,8 +105,9 @@ static void monitor_capture_destroy(void *data)
 	bfree(capture);
 }
 
-static void monitor_capture_defaults(obs_data_t *settings)
+static void monitor_capture_defaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "monitor", 0);
 	obs_data_set_default_bool(settings, "capture_cursor", true);
 	obs_data_set_default_bool(settings, "compatibility", false);
@@ -211,8 +212,9 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect,
 	return TRUE;
 }
 
-static obs_properties_t *monitor_capture_properties(void *unused)
+static obs_properties_t *monitor_capture_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *props = obs_properties_create();

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -104,14 +104,16 @@ static uint32_t wc_height(void *data)
 	return wc->capture.height;
 }
 
-static void wc_defaults(obs_data_t *defaults)
+static void wc_defaults(obs_data_t *defaults, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_bool(defaults, "cursor", true);
 	obs_data_set_default_bool(defaults, "compatibility", false);
 }
 
-static obs_properties_t *wc_properties(void *unused)
+static obs_properties_t *wc_properties(void *unused, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	UNUSED_PARAMETER(unused);
 
 	obs_properties_t *ppts = obs_properties_create();

--- a/plugins/win-dshow/win-dshow-encoder.cpp
+++ b/plugins/win-dshow/win-dshow-encoder.cpp
@@ -315,13 +315,15 @@ static void GetDShowVideoInfo(void *data, struct video_scale_info *info)
 	}
 }
 
-static void GetDShowEncoderDefauts(obs_data_t *settings)
+static void GetDShowEncoderDefauts(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, "bitrate", 1000);
 }
 
-static obs_properties_t *GetDShowEncoderProperties(void *data)
+static obs_properties_t *GetDShowEncoderProperties(void *data, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_properties_t *ppts = obs_properties_create();
 
 	obs_properties_add_int(ppts, "bitrate", obs_module_text("Bitrate"),

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1057,8 +1057,9 @@ static void UpdateDShowInput(void *data, obs_data_t *settings)
 	UNUSED_PARAMETER(settings);
 }
 
-static void GetDShowDefaults(obs_data_t *settings)
+static void GetDShowDefaults(obs_data_t *settings, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	obs_data_set_default_int(settings, FRAME_INTERVAL, FPS_MATCHING);
 	obs_data_set_default_int(settings, RES_TYPE, ResType_Preferred);
 	obs_data_set_default_int(settings, VIDEO_FORMAT, (int)VideoFormat::Any);
@@ -1724,8 +1725,9 @@ static bool ActivateClicked(obs_properties_t *, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *GetDShowProperties(void *obj)
+static obs_properties_t *GetDShowProperties(void *obj, void *type_data)
 {
+	UNUSED_PARAMETER(type_data);
 	DShowInput *input = reinterpret_cast<DShowInput*>(obj);
 	obs_properties_t *ppts = obs_properties_create();
 	PropertiesData *data = new PropertiesData;

--- a/plugins/win-mf/mf-aac.cpp
+++ b/plugins/win-mf/mf-aac.cpp
@@ -13,7 +13,7 @@ static const char *MFAAC_GetName(void*)
 	return obs_module_text("MFAACEnc");
 }
 
-static obs_properties_t *MFAAC_GetProperties(void *)
+static obs_properties_t *MFAAC_GetProperties(void *, void *)
 {
 	obs_properties_t *props = obs_properties_create();
 
@@ -23,7 +23,7 @@ static obs_properties_t *MFAAC_GetProperties(void *)
 	return props;
 }
 
-static void MFAAC_GetDefaults(obs_data_t *settings)
+static void MFAAC_GetDefaults(obs_data_t *settings, void *)
 {
 	obs_data_set_default_int(settings, "bitrate", 128);
 }

--- a/plugins/win-mf/mf-h264.cpp
+++ b/plugins/win-mf/mf-h264.cpp
@@ -194,7 +194,7 @@ static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,
 	return true;
 }
 
-static obs_properties_t *MFH264_GetProperties(void *)
+static obs_properties_t *MFH264_GetProperties(void *, void *)
 {
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *p;
@@ -245,7 +245,7 @@ static obs_properties_t *MFH264_GetProperties(void *)
 	return props;
 }
 
-static void MFH264_GetDefaults(obs_data_t *settings)
+static void MFH264_GetDefaults(obs_data_t *settings, void *)
 {
 #define PROP_DEF(x, y, z) obs_data_set_default_ ## x(settings, y, z)
 	PROP_DEF(int,    MFP_BITRATE,         2500);

--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -486,13 +486,13 @@ static const char *GetWASAPIOutputName(void*)
 	return obs_module_text("AudioOutput");
 }
 
-static void GetWASAPIDefaultsInput(obs_data_t *settings)
+static void GetWASAPIDefaultsInput(obs_data_t *settings, void *)
 {
 	obs_data_set_default_string(settings, OPT_DEVICE_ID, "default");
 	obs_data_set_default_bool(settings, OPT_USE_DEVICE_TIMING, false);
 }
 
-static void GetWASAPIDefaultsOutput(obs_data_t *settings)
+static void GetWASAPIDefaultsOutput(obs_data_t *settings, void *)
 {
 	obs_data_set_default_string(settings, OPT_DEVICE_ID, "default");
 	obs_data_set_default_bool(settings, OPT_USE_DEVICE_TIMING, true);
@@ -557,12 +557,12 @@ static obs_properties_t *GetWASAPIProperties(bool input)
 	return props;
 }
 
-static obs_properties_t *GetWASAPIPropertiesInput(void *)
+static obs_properties_t *GetWASAPIPropertiesInput(void *, void *)
 {
 	return GetWASAPIProperties(true);
 }
 
-static obs_properties_t *GetWASAPIPropertiesOutput(void *)
+static obs_properties_t *GetWASAPIPropertiesOutput(void *, void *)
 {
 	return GetWASAPIProperties(false);
 }


### PR DESCRIPTION
Affects: get_properties, get_defaults

This will allow re-using the same functions based on type_data instead of having to duplicate the same code for almost identical encoders, sources, outputs or services.