### PR TITLE
libobs, UI: Add obs memory usage except Windows

### DIFF
--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -30,7 +30,6 @@ using namespace std;
 #include <shellapi.h>
 #include <shlobj.h>
 #include <Dwmapi.h>
-#include <psapi.h>
 #include <mmdeviceapi.h>
 #include <audiopolicy.h>
 
@@ -260,17 +259,6 @@ bool DisableAudioDucking(bool disable)
 
 	result = sessionControl2->SetDuckingPreference(disable);
 	return SUCCEEDED(result);
-}
-
-uint64_t CurrentMemoryUsage()
-{
-	PROCESS_MEMORY_COUNTERS pmc = {};
-	pmc.cb = sizeof(pmc);
-
-	if (!GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
-		return 0;
-
-	return (uint64_t)pmc.WorkingSetSize;
 }
 
 struct RunOnceMutexData {

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -43,7 +43,6 @@ void SetAeroEnabled(bool enable);
 void SetProcessPriority(const char *priority);
 void SetWin32DropStyle(QWidget *window);
 bool DisableAudioDucking(bool disable);
-uint64_t CurrentMemoryUsage();
 
 struct RunOnceMutexData;
 

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -57,15 +57,11 @@ OBSBasicStats::OBSBasicStats(QWidget *parent)
 
 	cpuUsage = new QLabel(this);
 	hddSpace = new QLabel(this);
-#ifdef _WIN32
 	memUsage = new QLabel(this);
-#endif
 
 	newStat("CPUUsage", cpuUsage, 0);
 	newStat("HDDSpaceAvailable", hddSpace, 0);
-#ifdef _WIN32
 	newStat("MemoryUsage", memUsage, 0);
-#endif
 
 	fps = new QLabel(this);
 	renderTime = new QLabel(this);
@@ -300,12 +296,10 @@ void OBSBasicStats::Update()
 
 	/* ------------------ */
 
-#ifdef _WIN32
-	num = (long double)CurrentMemoryUsage() / (1024.0l * 1024.0l);
+	num = (long double)os_get_proc_resident_size() / (1024.0l * 1024.0l);
 
 	str = QString::number(num, 'f', 1) + QStringLiteral(" MB");
 	memUsage->setText(str);
-#endif
 
 	/* ------------------ */
 

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -33,6 +33,16 @@
 #if !defined(__APPLE__)
 #include <sys/times.h>
 #include <sys/wait.h>
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#include <sys/queue.h>
+#include <sys/socket.h>
+#include <sys/user.h>
+#include <unistd.h>
+#include <libprocstat.h>
+#else
+#include <sys/resource.h>
+#endif
 #include <spawn.h>
 #endif
 
@@ -678,6 +688,117 @@ int os_get_logical_cores(void)
 		os_get_cores_internal();
 	return logical_cores;
 }
+
+#ifdef __FreeBSD__
+uint64_t os_get_sys_free_size(void)
+{
+	uint64_t mem_free = 0;
+	size_t length = sizeof(mem_free);
+	if (sysctlbyname("vm.stats.vm.v_free_count", &mem_free, &length, NULL, 0) < 0)
+		return 0;
+	return mem_free;
+}
+
+static inline bool os_get_proc_memory_usage_internal(struct kinfo_proc *kinfo)
+{
+	int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
+	size_t length = sizeof(*kinfo);
+	if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), kinfo, &length, NULL, 0) < 0)
+		return false;
+	return true;
+}
+
+bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage)
+{
+	struct kinfo_proc kinfo;
+	if (!os_get_proc_memory_usage_internal(&kinfo))
+		return false;
+
+	usage->resident_size = (uint64_t)kinfo.ki_rssize * sysconf(_SC_PAGESIZE);
+	usage->virtual_size  = (uint64_t)kinfo.ki_size;
+	return true;
+}
+
+uint64_t os_get_proc_resident_size(void)
+{
+	struct kinfo_proc kinfo;
+	if (!os_get_proc_memory_usage_internal(&kinfo))
+		return 0;
+	return (uint64_t)kinfo.ki_rssize * sysconf(_SC_PAGESIZE);
+}
+
+uint64_t os_get_proc_virtual_size(void)
+{
+	struct kinfo_proc kinfo;
+	if (!os_get_proc_memory_usage_internal(&kinfo))
+		return 0;
+	return (uint64_t)kinfo.ki_size;
+}
+#else
+uint64_t os_get_sys_free_size(void) {return 0;}
+
+typedef struct
+{
+	unsigned long virtual_size;
+	unsigned long resident_size;
+	unsigned long share_pages;
+	unsigned long text;
+	unsigned long library;
+	unsigned long data;
+	unsigned long dirty_pages;
+} statm_t;
+
+static inline bool os_get_proc_memory_usage_internal(statm_t *statm)
+{
+	const char *statm_path = "/proc/self/statm";
+
+	FILE *f = fopen(statm_path, "r");
+	if (!f)
+		return false;
+
+	if (fscanf(f, "%ld %ld %ld %ld %ld %ld %ld",
+	    &statm->virtual_size,
+	    &statm->resident_size,
+	    &statm->share_pages,
+	    &statm->text,
+	    &statm->library,
+	    &statm->data,
+	    &statm->dirty_pages) != 7) {
+		fclose(f);
+		return false;
+	}
+
+	fclose(f);
+	return true;
+}
+
+bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage)
+{
+	statm_t statm = {};
+	if (!os_get_proc_memory_usage_internal(&statm))
+		return false;
+
+	usage->resident_size = statm.resident_size;
+	usage->virtual_size  = statm.virtual_size;
+	return true;
+}
+
+uint64_t os_get_proc_resident_size(void)
+{
+	statm_t statm = {};
+	if (!os_get_proc_memory_usage_internal(&statm))
+		return 0;
+	return (uint64_t)statm.resident_size;
+}
+
+uint64_t os_get_proc_virtual_size(void)
+{
+	statm_t statm = {};
+	if (!os_get_proc_memory_usage_internal(&statm))
+		return 0;
+	return (uint64_t)statm.virtual_size;
+}
+#endif
 #endif
 
 uint64_t os_get_free_disk_space(const char *dir)

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -19,6 +19,7 @@
 #include <shellapi.h>
 #include <shlobj.h>
 #include <intrin.h>
+#include <psapi.h>
 
 #include "base.h"
 #include "platform.h"
@@ -945,6 +946,55 @@ int os_get_logical_cores(void)
 	if (!core_count_initialized)
 		os_get_cores_internal();
 	return logical_cores;
+}
+
+static inline bool os_get_sys_memory_usage_internal(MEMORYSTATUSEX *msex)
+{
+	if (!GlobalMemoryStatusEx(msex))
+		return false;
+	return true;
+}
+
+uint64_t os_get_sys_free_size(void)
+{
+	MEMORYSTATUSEX msex = {sizeof(MEMORYSTATUSEX)};
+	if (!os_get_sys_memory_usage_internal(&msex))
+		return 0;
+	return msex.ullAvailPhys;
+}
+
+static inline bool os_get_proc_memory_usage_internal(PROCESS_MEMORY_COUNTERS *pmc)
+{
+	if (!GetProcessMemoryInfo(GetCurrentProcess(), pmc, sizeof(*pmc)))
+		return false;
+	return true;
+}
+
+bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage)
+{
+	PROCESS_MEMORY_COUNTERS pmc = {sizeof(PROCESS_MEMORY_COUNTERS)};
+	if (!os_get_proc_memory_usage_internal(&pmc))
+		return false;
+
+	usage->resident_size = pmc.WorkingSetSize;
+	usage->virtual_size  = pmc.PagefileUsage;
+	return true;
+}
+
+uint64_t os_get_proc_resident_size(void)
+{
+	PROCESS_MEMORY_COUNTERS pmc = {sizeof(PROCESS_MEMORY_COUNTERS)};
+	if (!os_get_proc_memory_usage_internal(&pmc))
+		return 0;
+	return pmc.WorkingSetSize;
+}
+
+uint64_t os_get_proc_virtual_size(void)
+{
+	PROCESS_MEMORY_COUNTERS pmc = {sizeof(PROCESS_MEMORY_COUNTERS)};
+	if (!os_get_proc_memory_usage_internal(&pmc))
+		return 0;
+	return pmc.PagefileUsage;
 }
 
 uint64_t os_get_free_disk_space(const char *dir)

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -181,6 +181,18 @@ EXPORT void os_breakpoint(void);
 EXPORT int os_get_physical_cores(void);
 EXPORT int os_get_logical_cores(void);
 
+EXPORT uint64_t os_get_sys_free_size(void);
+
+struct os_proc_memory_usage {
+	uint64_t resident_size;
+	uint64_t virtual_size;
+};
+typedef struct os_proc_memory_usage os_proc_memory_usage_t;
+
+EXPORT bool os_get_proc_memory_usage(os_proc_memory_usage_t *usage);
+EXPORT uint64_t os_get_proc_resident_size(void);
+EXPORT uint64_t os_get_proc_virtual_size(void);
+
 #ifdef _MSC_VER
 #define strtoll _strtoi64
 #if _MSC_VER < 1900


### PR DESCRIPTION
Add feature to show obs memory usage in stat window for macOS, Linux, and FreeBSD.
I don't validate this feature enough for Linux and FreeBSD.