### PR TITLE
libobs: fix bug in circlebuf

### DIFF
--- a/libobs/util/circlebuf.h
+++ b/libobs/util/circlebuf.h
@@ -100,7 +100,7 @@ static inline void circlebuf_upsize(struct circlebuf *cb, size_t size)
 	cb->size = size;
 	circlebuf_ensure_capacity(cb);
 
-	if (new_end_pos > cb->capacity) {
+	if (new_end_pos >= cb->capacity) {
 		size_t back_size = cb->capacity - cb->end_pos;
 		size_t loop_size = add_size - back_size;
 
@@ -151,7 +151,7 @@ static inline void circlebuf_push_back(struct circlebuf *cb, const void *data,
 	cb->size += size;
 	circlebuf_ensure_capacity(cb);
 
-	if (new_end_pos > cb->capacity) {
+	if (new_end_pos >= cb->capacity) {
 		size_t back_size = cb->capacity - cb->end_pos;
 		size_t loop_size = size - back_size;
 

--- a/libobs/util/circlebuf.h
+++ b/libobs/util/circlebuf.h
@@ -100,7 +100,7 @@ static inline void circlebuf_upsize(struct circlebuf *cb, size_t size)
 	cb->size = size;
 	circlebuf_ensure_capacity(cb);
 
-	if (new_end_pos >= cb->capacity) {
+	if (new_end_pos > cb->capacity) {
 		size_t back_size = cb->capacity - cb->end_pos;
 		size_t loop_size = add_size - back_size;
 
@@ -151,7 +151,7 @@ static inline void circlebuf_push_back(struct circlebuf *cb, const void *data,
 	cb->size += size;
 	circlebuf_ensure_capacity(cb);
 
-	if (new_end_pos >= cb->capacity) {
+	if (new_end_pos > cb->capacity) {
 		size_t back_size = cb->capacity - cb->end_pos;
 		size_t loop_size = size - back_size;
 
@@ -240,6 +240,8 @@ static inline void circlebuf_pop_front(struct circlebuf *cb, void *data,
 	cb->start_pos += size;
 	if (cb->start_pos >= cb->capacity)
 		cb->start_pos -= cb->capacity;
+    if (cb->size == 0)
+        cb->end_pos = cb->start_pos;
 }
 
 static inline void circlebuf_pop_back(struct circlebuf *cb, void *data,
@@ -252,6 +254,8 @@ static inline void circlebuf_pop_back(struct circlebuf *cb, void *data,
 		cb->end_pos = cb->capacity - (size - cb->end_pos);
 	else
 		cb->end_pos -= size;
+    if (cb->size == 0)
+        cb->end_pos = cb->start_pos;
 }
 
 static inline void *circlebuf_data(struct circlebuf *cb, size_t idx)


### PR DESCRIPTION
Bug description:
    1. circlebuf_init()
    2. circlebuf_push_back(size1)
    3. circlebuf_pop_front(size1) // cb->end_pos will wrongly be equal to "capacity".
    4. circlebuf_push_back(size2) // size2 > size1
    5. circlebuf_pop_front(size2) // the data popped out will be disordered