### PR TITLE
obs-text: Fix file reader occasionally not updating

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -197,6 +197,7 @@ struct TextSource {
 	bool read_from_file = false;
 	string file;
 	time_t file_timestamp = 0;
+	bool update_file = false;
 	float update_time_elapsed = 0.0f;
 
 	wstring text;
@@ -775,10 +776,15 @@ inline void TextSource::Tick(float seconds)
 		time_t t = get_modified_timestamp(file.c_str());
 		update_time_elapsed = 0.0f;
 
-		if (file_timestamp != t) {
+		if (update_file) {
 			LoadFileText();
 			RenderText();
+			update_file = false;
+		}
+
+		if (file_timestamp != t) {
 			file_timestamp = t;
+			update_file = true;
 		}
 	}
 }

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -238,7 +238,7 @@ static void ft2_video_tick(void *data, float seconds)
 		time_t t = get_modified_timestamp(srcdata->text_file);
 		srcdata->last_checked = os_gettime_ns();
 
-		if (srcdata->m_timestamp != t) {
+		if (srcdata->update_file) {
 			if (srcdata->log_mode)
 				read_from_end(srcdata, srcdata->text_file);
 			else
@@ -246,6 +246,12 @@ static void ft2_video_tick(void *data, float seconds)
 					srcdata->text_file);
 			cache_glyphs(srcdata, srcdata->text);
 			set_up_vertex_buffer(srcdata);
+			srcdata->update_file = false;
+		}
+
+		if (srcdata->m_timestamp != t) {
+			srcdata->m_timestamp = t;
+			srcdata->update_file = true;
 		}
 	}
 

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -38,6 +38,7 @@ struct ft2_source {
 	char *text_file;
 	wchar_t *text;
 	time_t m_timestamp;
+	bool update_file;
 	uint64_t last_checked;
 
 	uint32_t cx, cy, max_h, custom_width;

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -377,8 +377,6 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 		srcdata->text = bzalloc(filesize);
 		bytes_read = fread(srcdata->text, filesize - 2, 1, tmp_file);
 
-		srcdata->m_timestamp =
-			get_modified_timestamp(srcdata->text_file);
 		bfree(tmp_read);
 		fclose(tmp_file);
 
@@ -386,7 +384,6 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	}
 
 	fseek(tmp_file, 0, SEEK_SET);
-	srcdata->m_timestamp = get_modified_timestamp(srcdata->text_file);
 
 	tmp_read = bzalloc(filesize + 1);
 	bytes_read = fread(tmp_read, filesize, 1, tmp_file);
@@ -464,8 +461,6 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 				tmp_file);
 
 		remove_cr(srcdata->text);
-		srcdata->m_timestamp =
-			get_modified_timestamp(srcdata->text_file);
 		bfree(tmp_read);
 		fclose(tmp_file);
 
@@ -485,7 +480,6 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 		srcdata->text, (strlen(tmp_read) + 1));
 
 	remove_cr(srcdata->text);
-	srcdata->m_timestamp = get_modified_timestamp(srcdata->text_file);
 	bfree(tmp_read);
 }
 


### PR DESCRIPTION
Delayed reading the text file till the update after the timestamp changes, this should fix a minor issue where if the file updates twice in one second, only the first change it displayed.

Fix was also appied to text-freetype2.