### PR TITLE
UI: Fix problem with exporting scene collections/profiles

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -524,15 +524,29 @@ void OBSBasic::on_actionExportProfile_triggered()
 
 		if (!folder.exists()) {
 			folder.mkpath(outputDir);
-			QFile::copy(inputPath + currentProfile + "/basic.ini",
-					outputDir + "/basic.ini");
-			QFile::copy(inputPath + currentProfile + "/service.json",
-					outputDir + "/service.json");
-			QFile::copy(inputPath + currentProfile + "/streamEncoder.json",
-					outputDir + "/streamEncoder.json");
-			QFile::copy(inputPath + currentProfile + "/recordEncoder.json",
-					outputDir + "/recordEncoder.json");
 		}
+		else {
+			if (QFile::exists(outputDir + "/basic.ini"))
+				QFile::remove(outputDir + "/basic.ini");
+
+			if (QFile::exists(outputDir + "/service.json"))
+				QFile::remove(outputDir + "/service.json");
+
+			if (QFile::exists(outputDir + "/streamEncoder.json"))
+				QFile::remove(outputDir + "/streamEncoder.json");
+
+			if (QFile::exists(outputDir + "/recordEncoder.json"))
+				QFile::remove(outputDir + "/recordEncoder.json");
+		}
+
+		QFile::copy(inputPath + currentProfile + "/basic.ini",
+				outputDir + "/basic.ini");
+		QFile::copy(inputPath + currentProfile + "/service.json",
+				outputDir + "/service.json");
+		QFile::copy(inputPath + currentProfile + "/streamEncoder.json",
+				outputDir + "/streamEncoder.json");
+		QFile::copy(inputPath + currentProfile + "/recordEncoder.json",
+				outputDir + "/recordEncoder.json");
 	}
 }
 

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -426,7 +426,12 @@ void OBSBasic::on_actionExportSceneCollection_triggered()
 	string file = QT_TO_UTF8(exportFile);
 
 	if (!exportFile.isEmpty() && !exportFile.isNull())
+	{
+		if (QFile::exists(exportFile))
+			QFile::remove(exportFile);
+
 		QFile::copy(path + currentFile + ".json", exportFile);
+	}
 }
 
 void OBSBasic::ChangeSceneCollection()


### PR DESCRIPTION
When exporting scene collections/profiles existing files are not overwritten.