### PR TITLE
libobs: Always render non-premultiplied alpha

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -486,7 +486,10 @@ static inline void render_item(struct obs_scene_item *item)
 					-(float)item->crop.top,
 					0.0f);
 
+			gs_blend_state_push();
+			gs_blend_function(GS_BLEND_ONE, GS_BLEND_ZERO);
 			obs_source_video_render(item->source);
+			gs_blend_state_pop();
 			gs_texrender_end(item->item_render);
 		}
 	}


### PR DESCRIPTION
Scene Items would incorrectly render using premultiplied alpha when they were scaled with different scale filtering, when they were cropped or when the item itself was a scene. This changes the behaviour to always render non-premultiplied alpha, which makes the behaviour identical in all cases.

Related Issue: https://obsproject.com/mantis/view.php?id=954