### PR TITLE
libobs: Fix item copying during scene duplication

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1118,6 +1118,12 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 
 			obs_sceneitem_set_crop(new_item, &item->crop);
 
+			if (!new_item->item_render && item_texture_enabled(new_item)) {
+				obs_enter_graphics();
+				new_item->item_render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+				obs_leave_graphics();
+			}
+
 			obs_source_release(source);
 		}
 	}


### PR DESCRIPTION
When item in the old scene had only Scale Filter, texture renderer was not created for an item in the new scene. However if the item also had Crop set, the texture renderer was created.

Now after copying the data, texture renderer is created for the item in the new scene when needed.

Related Issue: https://obsproject.com/mantis/view.php?id=909