### PR TITLE
rtmp-services: Update Picarto maximum audio bitrate

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 66,
+	"version": 67,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 66
+			"version": 67
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -827,8 +827,7 @@
             "recommended": {
                 "keyint": 2,
                 "profile": "main",
-                "max video bitrate": 3500,
-                "max audio bitrate": 128
+                "max video bitrate": 3500
             }
         },
         {


### PR DESCRIPTION
This PR removes the enforced maximum audio bitrate limit for Picarto.  It seems that they now recommend leaving the audio bitrate at OBS' default (160), but they permit higher bitrates with no maximum limit specified.
See http://help.picarto.tv/knowledge_base/topics/how-to-configure-open-broadcaster-software:

> You don't have to change the audio bitrate for art live streams. If you are streaming music an increased audio bitrate might bring better quality to your live stream audio. It all depends on your own internet connection.

As always, feedback is appreciated.