### PR TITLE
UI: Fix incorrect properties set for Hardware (AMD)

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -555,20 +555,17 @@ void SimpleOutput::UpdateStreamingSettings_amd(obs_data_t *settings,
 	// Static Properties
 	obs_data_set_int(settings, "Usage", 0);
 	obs_data_set_int(settings, "Profile", 100); // High
-	obs_data_set_string(settings, "profile", "high"); // High
 	
 	// Rate Control Properties
-	obs_data_set_int(settings, "RateControlMethod", 1);
-	obs_data_set_string(settings, "rate_control", "CBR");
+	obs_data_set_int(settings, "RateControlMethod", 3);
 	obs_data_set_int(settings, "Bitrate.Target", bitrate);
-	obs_data_set_int(settings, "bitrate", bitrate);
 	obs_data_set_int(settings, "FillerData", 1);
 	obs_data_set_int(settings, "VBVBuffer", 1);
 	obs_data_set_int(settings, "VBVBuffer.Size", bitrate);
 	
 	// Picture Control Properties
 	obs_data_set_double(settings, "KeyframeInterval", 2.0);
-	obs_data_set_int(settings, "keyint_sec", 2);
+	obs_data_set_int(settings, "BFrame.Pattern", 0);
 }
 
 void SimpleOutput::UpdateRecordingSettings_amd_cqp(int cqp)
@@ -578,11 +575,9 @@ void SimpleOutput::UpdateRecordingSettings_amd_cqp(int cqp)
 	// Static Properties
 	obs_data_set_int(settings, "Usage", 0);
 	obs_data_set_int(settings, "Profile", 100); // High
-	obs_data_set_string(settings, "profile", "high"); // High
 
 	// Rate Control Properties
 	obs_data_set_int(settings, "RateControlMethod", 0);
-	obs_data_set_string(settings, "rate_control", "CQP");
 	obs_data_set_int(settings, "QP.IFrame", cqp);
 	obs_data_set_int(settings, "QP.PFrame", cqp);
 	obs_data_set_int(settings, "QP.BFrame", cqp);
@@ -591,7 +586,7 @@ void SimpleOutput::UpdateRecordingSettings_amd_cqp(int cqp)
 
 	// Picture Control Properties
 	obs_data_set_double(settings, "KeyframeInterval", 2.0);
-	obs_data_set_int(settings, "keyint_sec", 2);
+	obs_data_set_int(settings, "BFrame.Pattern", 0);
 
 	// Update and release
 	obs_encoder_update(h264Recording, settings);


### PR DESCRIPTION
Due to an oversight in enc-amf with strcmp, the code currently causes certain weirdness to appear. This fixes it so it will use "High" Profile instead of attempting to use "Constrained Baseline" and also changes it to actually set things up for "Constant Bitrate" instead of "Variable Bitrate (Latency Constrained)". Finally I've added a slight change that always makes it set the B-Frame Pattern to 0 in order to work better with VCE2.0 and VCE3.0 cards.

Another PR is coming up for the new AMF and AMD Driver. Can't exactly claim I know when.