### PR TITLE
obs-outputs: Add Mixer FTL support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "plugins/obs-vst"]
 	path = plugins/obs-vst
 	url = https://github.com/DDRBoxman/obs-vst.git
+[submodule "plugins/obs-outputs/ftl-sdk"]
+	path = plugins/obs-outputs/ftl-sdk
+	url = https://github.com/Mixer/ftl-sdk.git

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -411,7 +411,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 			* 1000000000 / total_time / 1000;
 
 		if (obs_output_get_frames_dropped(output) ||
-		    (int)bitrate < (wiz->startingBitrate * 75 / 100)) {
+			(int)bitrate < (wiz->startingBitrate * 75 / 100)) {
 			server.bitrate = (int)bitrate * 70 / 100;
 		} else {
 			server.bitrate = wiz->startingBitrate;
@@ -436,7 +436,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 		bool close = abs(server.bitrate - bestBitrate) < 400;
 
 		if ((!close && server.bitrate > bestBitrate) ||
-		    (close && server.ms < bestMS)) {
+			(close && server.ms < bestMS)) {
 			bestServer = server.address;
 			bestServerName = server.name;
 			bestBitrate = server.bitrate;
@@ -867,7 +867,7 @@ void AutoConfigTestPage::TestRecordingEncoderThread()
 	}
 
 	if (wiz->type == AutoConfig::Type::Recording &&
-	    wiz->hardwareEncodingAvailable)
+		wiz->hardwareEncodingAvailable)
 		FindIdealHardwareResolution();
 
 	wiz->recordingQuality = AutoConfig::Quality::High;
@@ -983,7 +983,7 @@ void AutoConfigTestPage::FinalizeResults()
 			QString::number(wiz->idealResolutionCY));
 
 	if (wiz->recordingEncoder != AutoConfig::Encoder::Stream ||
-	    wiz->recordingQuality != AutoConfig::Quality::Stream)
+		wiz->recordingQuality != AutoConfig::Quality::Stream)
 		form->addRow(newLabel(TEST_RESULT_RE),
 			new QLabel(encName(wiz->recordingEncoder),
 				ui->finishPage));

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -245,8 +245,9 @@ void AutoConfigTestPage::TestBandwidthThread()
 	else
 		GetServers(servers);
 
-	/* just use the first server if it only has one alternate server */
-	if (servers.size() < 3)
+	/* just use the first server if it only has one alternate server,
+	 * or if using Mixer due to its "auto" server */
+	if (servers.size() < 3 || wiz->serviceName == "Mixer.com")
 		servers.resize(1);
 
 	/* -----------------------------------*/

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -326,8 +326,6 @@ bool AutoConfigStreamPage::validatePage()
 			wiz->service = AutoConfig::Service::Twitch;
 		else if (wiz->serviceName == "hitbox.tv")
 			wiz->service = AutoConfig::Service::Hitbox;
-		else if (wiz->serviceName == "beam.pro")
-			wiz->service = AutoConfig::Service::Beam;
 		else
 			wiz->service = AutoConfig::Service::Other;
 	} else {
@@ -368,8 +366,7 @@ void AutoConfigStreamPage::ServiceChanged()
 
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 	bool regionBased = service == "Twitch" ||
-	                   service == "hitbox.tv" ||
-	                   service == "beam.pro";
+	                   service == "hitbox.tv";
 	bool testBandwidth = ui->doBandwidthTest->isChecked();
 	bool custom = ui->streamType->currentIndex() == 1;
 
@@ -685,17 +682,6 @@ bool AutoConfig::CanTestServer(const char *server)
 		} else if (astrcmp_n(server, "South Korea:", 12) == 0 ||
 		           astrcmp_n(server, "Asia:", 5) == 0 ||
 		           astrcmp_n(server, "China:", 6) == 0) {
-			return regionAsia;
-		} else if (regionOther) {
-			return true;
-		}
-	} else if (service == Service::Beam) {
-		if (astrcmp_n(server, "US:", 3) == 0) {
-			return regionUS;
-		} else if (astrcmp_n(server, "EU:", 3) == 0) {
-			return regionEU;
-		} else if (astrcmp_n(server, "South Korea:", 12) == 0 ||
-		           astrcmp_n(server, "Asia:", 5) == 0) {
 			return regionAsia;
 		} else if (regionOther) {
 			return true;

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -134,8 +134,8 @@ AutoConfigVideoPage::AutoConfigVideoPage(QWidget *parent)
 
 		QString str = QTStr(RES_USE_DISPLAY)
 			.arg(QString::number(i + 1),
-			     QString::number(as.width()),
-			     QString::number(as.height()));
+				 QString::number(as.width()),
+				 QString::number(as.height()));
 
 		ui->canvasRes->addItem(str, encRes);
 	}
@@ -366,7 +366,7 @@ void AutoConfigStreamPage::ServiceChanged()
 
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 	bool regionBased = service == "Twitch" ||
-	                   service == "hitbox.tv";
+					   service == "hitbox.tv";
 	bool testBandwidth = ui->doBandwidthTest->isChecked();
 	bool custom = ui->streamType->currentIndex() == 1;
 
@@ -661,8 +661,8 @@ bool AutoConfig::CanTestServer(const char *server)
 
 	if (service == Service::Twitch) {
 		if (astrcmp_n(server, "US West:", 8) == 0 ||
-		    astrcmp_n(server, "US East:", 8) == 0 ||
-		    astrcmp_n(server, "US Central:", 11) == 0) {
+			astrcmp_n(server, "US East:", 8) == 0 ||
+			astrcmp_n(server, "US Central:", 11) == 0) {
 			return regionUS;
 		} else if (astrcmp_n(server, "EU:", 3) == 0) {
 			return regionEU;
@@ -675,13 +675,13 @@ bool AutoConfig::CanTestServer(const char *server)
 		if (strcmp(server, "Default") == 0) {
 			return true;
 		} else if (astrcmp_n(server, "US-West:", 8) == 0 ||
-		           astrcmp_n(server, "US-East:", 8) == 0) {
+				   astrcmp_n(server, "US-East:", 8) == 0) {
 			return regionUS;
 		} else if (astrcmp_n(server, "EU-", 3) == 0) {
 			return regionEU;
 		} else if (astrcmp_n(server, "South Korea:", 12) == 0 ||
-		           astrcmp_n(server, "Asia:", 5) == 0 ||
-		           astrcmp_n(server, "China:", 6) == 0) {
+				   astrcmp_n(server, "Asia:", 5) == 0 ||
+				   astrcmp_n(server, "China:", 6) == 0) {
 			return regionAsia;
 		} else if (regionOther) {
 			return true;

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -34,7 +34,6 @@ class AutoConfig : public QWizard {
 	enum class Service {
 		Twitch,
 		Hitbox,
-		Beam,
 		Other
 	};
 

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -234,7 +234,7 @@ void SimpleOutput::LoadRecordingPreset_Lossless()
 			"simple_ffmpeg_output", nullptr, nullptr);
 	if (!fileOutput)
 		throw "Failed to create recording FFmpeg output "
-		      "(simple output)";
+			  "(simple output)";
 	obs_output_release(fileOutput);
 
 	obs_data_t *settings = obs_data_create();
@@ -307,7 +307,7 @@ void SimpleOutput::LoadRecordingPreset()
 		if (!CreateAACEncoder(aacRecording, aacRecEncID, 192,
 					"simple_aac_recording", 0))
 			throw "Failed to create aac recording encoder "
-			      "(simple output)";
+				  "(simple output)";
 	}
 }
 
@@ -343,7 +343,7 @@ SimpleOutput::SimpleOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			obs_data_release(hotkey);
 			if (!replayBuffer)
 				throw "Failed to create replay buffer output "
-				      "(simple output)";
+					  "(simple output)";
 			obs_output_release(replayBuffer);
 
 			signal_handler_t *signal =
@@ -361,7 +361,7 @@ SimpleOutput::SimpleOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 				"simple_file_output", nullptr, nullptr);
 		if (!fileOutput)
 			throw "Failed to create recording output "
-			      "(simple output)";
+				  "(simple output)";
 		obs_output_release(fileOutput);
 	}
 
@@ -689,9 +689,9 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 
 		const char *codec =
 			obs_output_get_supported_audio_codecs(streamOutput);
-        if (!codec) {
-            return false;
-        }
+		if (!codec) {
+			return false;
+		}
 
 		if (strcmp(codec, "aac") != 0) {
 			const char *id = FindAudioEncoderFromCodec(codec);
@@ -1054,14 +1054,14 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 				"adv_ffmpeg_output", nullptr, nullptr);
 		if (!fileOutput)
 			throw "Failed to create recording FFmpeg output "
-			      "(advanced output)";
+				  "(advanced output)";
 		obs_output_release(fileOutput);
 	} else {
 		fileOutput = obs_output_create("ffmpeg_muxer",
 				"adv_file_output", nullptr, nullptr);
 		if (!fileOutput)
 			throw "Failed to create recording output "
-			      "(advanced output)";
+				  "(advanced output)";
 		obs_output_release(fileOutput);
 
 		if (!useStreamEncoder) {
@@ -1070,7 +1070,7 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 					nullptr);
 			if (!h264Recording)
 				throw "Failed to create recording h264 "
-				      "encoder (advanced output)";
+					  "encoder (advanced output)";
 			obs_encoder_release(h264Recording);
 		}
 	}
@@ -1079,7 +1079,7 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			"streaming_h264", streamEncSettings, nullptr);
 	if (!h264Streaming)
 		throw "Failed to create streaming h264 encoder "
-		      "(advanced output)";
+			  "(advanced output)";
 	obs_encoder_release(h264Streaming);
 
 	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
@@ -1089,7 +1089,7 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 		if (!CreateAACEncoder(aacTrack[i], aacEncoderID[i],
 					GetAudioBitrate(i), name, i))
 			throw "Failed to create audio encoder "
-			      "(advanced output)";
+				  "(advanced output)";
 	}
 
 	startRecording.Connect(obs_output_get_signal_handler(fileOutput),
@@ -1337,7 +1337,7 @@ int AdvancedOutput::GetAudioBitrate(size_t i) const
 bool AdvancedOutput::StartStreaming(obs_service_t *service)
 {
 	if (!useStreamEncoder ||
-	    (!ffmpegOutput && !obs_output_active(fileOutput))) {
+		(!ffmpegOutput && !obs_output_active(fileOutput))) {
 		UpdateStreamSettings();
 	}
 
@@ -1384,9 +1384,9 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 
 		const char *codec =
 			obs_output_get_supported_audio_codecs(streamOutput);
-        if (!codec) {
-            return false;
-        }
+		if (!codec) {
+			return false;
+		}
 
 		if (strcmp(codec, "aac") == 0) {
 			streamAudioEnc = aacTrack[trackIndex - 1];

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -689,6 +689,9 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 
 		const char *codec =
 			obs_output_get_supported_audio_codecs(streamOutput);
+        if (!codec) {
+            return false;
+        }
 
 		if (strcmp(codec, "aac") != 0) {
 			const char *id = FindAudioEncoderFromCodec(codec);

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -556,7 +556,7 @@ void SimpleOutput::UpdateStreamingSettings_amd(obs_data_t *settings,
 	obs_data_set_int(settings, "Usage", 0);
 	obs_data_set_int(settings, "Profile", 100); // High
 	obs_data_set_string(settings, "profile", "high"); // High
-	
+
 	// Rate Control Properties
 	obs_data_set_int(settings, "RateControlMethod", 1);
 	obs_data_set_string(settings, "rate_control", "CBR");
@@ -565,7 +565,7 @@ void SimpleOutput::UpdateStreamingSettings_amd(obs_data_t *settings,
 	obs_data_set_int(settings, "FillerData", 1);
 	obs_data_set_int(settings, "VBVBuffer", 1);
 	obs_data_set_int(settings, "VBVBuffer.Size", bitrate);
-	
+
 	// Picture Control Properties
 	obs_data_set_double(settings, "KeyframeInterval", 2.0);
 	obs_data_set_int(settings, "keyint_sec", 2);
@@ -1381,6 +1381,9 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 
 		const char *codec =
 			obs_output_get_supported_audio_codecs(streamOutput);
+        if (!codec) {
+            return false;
+        }
 
 		if (strcmp(codec, "aac") == 0) {
 			streamAudioEnc = aacTrack[trackIndex - 1];

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -16,6 +16,7 @@ set(obs-ffmpeg_HEADERS
 set(obs-ffmpeg_SOURCES
 	obs-ffmpeg.c
 	obs-ffmpeg-aac.c
+	obs-ffmpeg-opus.c
 	obs-ffmpeg-nvenc.c
 	obs-ffmpeg-output.c
 	obs-ffmpeg-mux.c

--- a/plugins/obs-ffmpeg/obs-ffmpeg-opus.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-opus.c
@@ -1,0 +1,303 @@
+/******************************************************************************
+    Copyright (C) 2014 by Quinn Damerell <qdamere@microsoft.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include <media-io/audio-resampler.h>
+#include <util/base.h>
+#include <util/circlebuf.h>
+#include <util/darray.h>
+#include <obs-module.h>
+
+#include <libavformat/avformat.h>
+
+#include "obs-ffmpeg-formats.h"
+#include "obs-ffmpeg-compat.h"
+
+#define do_log(level, format, ...) \
+	blog(level, "[FFmpeg opus encoder: '%s'] " format, \
+			obs_encoder_get_name(enc->encoder), ##__VA_ARGS__)
+
+#define error(format, ...) do_log(LOG_ERROR,   format, ##__VA_ARGS__)
+#define warn(format, ...)  do_log(LOG_WARNING, format, ##__VA_ARGS__)
+#define info(format, ...)  do_log(LOG_INFO,    format, ##__VA_ARGS__)
+#define debug(format, ...) do_log(LOG_DEBUG,   format, ##__VA_ARGS__)
+
+struct opus_encoder {
+	obs_encoder_t    *encoder;
+
+	AVCodec          *opus;
+	AVCodecContext   *context;
+
+	uint8_t          *samples[MAX_AV_PLANES];
+	AVFrame          *aframe;
+	int64_t          total_samples;
+
+	DARRAY(uint8_t)  packet_buffer;
+
+	size_t           audio_planes;
+	size_t           audio_size;
+
+	int              frame_size; /* pretty much always 1024 for opus */
+	int              frame_size_bytes;
+};
+
+static const char *opus_getname(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+	return obs_module_text("FFmpegOpus");
+}
+
+static void opus_destroy(void *data)
+{
+	struct opus_encoder *enc = data;
+
+	if (enc->samples[0])
+		av_freep(&enc->samples[0]);
+	if (enc->context)
+		avcodec_close(enc->context);
+	if (enc->aframe)
+		av_frame_free(&enc->aframe);
+
+	da_free(enc->packet_buffer);
+	bfree(enc);
+}
+
+static bool initialize_codec(struct opus_encoder *enc)
+{
+	int ret;
+
+	enc->aframe  = av_frame_alloc();
+	if (!enc->aframe) {
+		warn("Failed to allocate audio frame");
+		return false;
+	}
+
+	ret = avcodec_open2(enc->context, enc->opus, NULL);
+	if (ret < 0) {
+		warn("Failed to open opus codec: %s", av_err2str(ret));
+		return false;
+	}
+
+	enc->frame_size = enc->context->frame_size;
+	if (!enc->frame_size)
+		enc->frame_size = 1024;
+
+	enc->frame_size_bytes = enc->frame_size * (int)enc->audio_size;
+
+	ret = av_samples_alloc(enc->samples, NULL, enc->context->channels,
+			enc->frame_size, enc->context->sample_fmt, 0);
+	if (ret < 0) {
+		warn("Failed to create audio buffer: %s", av_err2str(ret));
+		return false;
+	}
+
+	return true;
+}
+
+static void init_sizes(struct opus_encoder *enc, audio_t *audio)
+{
+	const struct audio_output_info *aoi;
+	enum audio_format format;
+
+	aoi    = audio_output_get_info(audio);
+	format = convert_ffmpeg_sample_format(enc->context->sample_fmt);
+
+	enc->audio_planes = get_audio_planes(format, aoi->speakers);
+	enc->audio_size   = get_audio_size(format, aoi->speakers, 1);
+}
+
+#ifndef MIN
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+#endif
+
+static void *opus_create(obs_data_t *settings, obs_encoder_t *encoder)
+{
+	struct opus_encoder *enc;
+	int                bitrate = (int)obs_data_get_int(settings, "bitrate");
+	audio_t            *audio   = obs_encoder_audio(encoder);
+
+	avcodec_register_all();
+
+	enc          = bzalloc(sizeof(struct opus_encoder));
+	enc->encoder = encoder;
+	enc->opus    = avcodec_find_encoder(AV_CODEC_ID_OPUS);
+
+	blog(LOG_INFO, "---------------------------------");
+
+	if (!enc->opus) {
+		warn("Couldn't find encoder");
+		goto fail;
+	}
+
+	if (!bitrate) {
+		warn("Invalid bitrate specified");
+		return NULL;
+	}
+
+	enc->context = avcodec_alloc_context3(enc->opus);
+	if (!enc->context) {
+		warn("Failed to create codec context");
+		goto fail;
+	}
+
+	enc->context->bit_rate    = bitrate * 1000;
+	enc->context->channels    = (int)audio_output_get_channels(audio);
+	enc->context->sample_rate = 48000;
+	enc->context->sample_fmt  = enc->opus->sample_fmts ?
+		enc->opus->sample_fmts[0] : AV_SAMPLE_FMT_FLTP;
+
+	/* if using FFmpeg's opus encoder, at least set a cutoff value
+	 * (recommended by konverter) */
+	if (strcmp(enc->opus->name, "opus") == 0) {
+		int cutoff1 = 4000 + (int)enc->context->bit_rate / 8;
+		int cutoff2 = 12000 + (int)enc->context->bit_rate / 8;
+		int cutoff3 = enc->context->sample_rate / 2;
+		int cutoff;
+
+		cutoff = MIN(cutoff1, cutoff2);
+		cutoff = MIN(cutoff, cutoff3);
+		enc->context->cutoff = cutoff;
+	}
+
+	info("bitrate: %d, channels: %d",
+			enc->context->bit_rate / 1000, enc->context->channels);
+
+	init_sizes(enc, audio);
+
+	/* enable experimental FFmpeg encoder if the only one available */
+	enc->context->strict_std_compliance = -2;
+
+	enc->context->flags = CODEC_FLAG_GLOBAL_HEADER;
+
+	if (initialize_codec(enc))
+		return enc;
+
+fail:
+	opus_destroy(enc);
+	return NULL;
+}
+
+static bool do_opus_encode(struct opus_encoder *enc,
+		struct encoder_packet *packet, bool *received_packet)
+{
+	AVRational time_base = {1, enc->context->sample_rate};
+	AVPacket   avpacket  = {0};
+	int        got_packet;
+	int        ret;
+
+	enc->aframe->nb_samples = enc->frame_size;
+	enc->aframe->pts = av_rescale_q(enc->total_samples,
+			(AVRational){1, enc->context->sample_rate},
+			enc->context->time_base);
+
+	ret = avcodec_fill_audio_frame(enc->aframe, enc->context->channels,
+			enc->context->sample_fmt, enc->samples[0],
+			enc->frame_size_bytes * enc->context->channels, 1);
+	if (ret < 0) {
+		warn("avcodec_fill_audio_frame failed: %s", av_err2str(ret));
+		return false;
+	}
+
+	enc->total_samples += enc->frame_size;
+
+	ret = avcodec_encode_audio2(enc->context, &avpacket, enc->aframe,
+			&got_packet);
+	if (ret < 0) {
+		warn("avcodec_encode_audio2 failed: %s", av_err2str(ret));
+		return false;
+	}
+
+	*received_packet = !!got_packet;
+	if (!got_packet)
+		return true;
+
+	da_resize(enc->packet_buffer, 0);
+	da_push_back_array(enc->packet_buffer, avpacket.data, avpacket.size);
+
+	packet->pts  = rescale_ts(avpacket.pts, enc->context, time_base);
+	packet->dts  = rescale_ts(avpacket.dts, enc->context, time_base);
+	packet->data = enc->packet_buffer.array;
+	packet->size = avpacket.size;
+	packet->type = OBS_ENCODER_AUDIO;
+	packet->timebase_num = 1;
+	packet->timebase_den = (int32_t)enc->context->sample_rate;
+	av_free_packet(&avpacket);
+	return true;
+}
+
+static bool opus_encode(void *data, struct encoder_frame *frame,
+		struct encoder_packet *packet, bool *received_packet)
+{
+	struct opus_encoder *enc = data;
+
+	for (size_t i = 0; i < enc->audio_planes; i++)
+		memcpy(enc->samples[i], frame->data[i], enc->frame_size_bytes);
+
+	return do_opus_encode(enc, packet, received_packet);
+}
+
+static void opus_defaults(obs_data_t *settings)
+{
+	obs_data_set_default_int(settings, "bitrate", 160);
+}
+
+static obs_properties_t *opus_properties(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+
+	obs_properties_t *props = obs_properties_create();
+
+	obs_properties_add_int(props, "bitrate",
+			obs_module_text("Bitrate"), 32, 320, 32);
+	return props;
+}
+
+static bool opus_extra_data(void *data, uint8_t **extra_data, size_t *size)
+{
+	struct opus_encoder *enc = data;
+
+	*extra_data = enc->context->extradata;
+	*size       = enc->context->extradata_size;
+	return true;
+}
+
+static void opus_audio_info(void *data, struct audio_convert_info *info)
+{
+	struct opus_encoder *enc = data;
+	info->format = convert_ffmpeg_sample_format(enc->context->sample_fmt);
+	info->samples_per_sec = 48000;
+}
+
+static size_t opus_frame_size(void *data)
+{
+	struct opus_encoder *enc =data;
+	return enc->frame_size;
+}
+
+struct obs_encoder_info opus_encoder_info = {
+	.id             = "ffmpeg_opus",
+	.type           = OBS_ENCODER_AUDIO,
+	.codec          = "opus",
+	.get_name       = opus_getname,
+	.create         = opus_create,
+	.destroy        = opus_destroy,
+	.encode         = opus_encode,
+	.get_frame_size = opus_frame_size,
+	.get_defaults   = opus_defaults,
+	.get_properties = opus_properties,
+	.get_extra_data = opus_extra_data,
+	.get_audio_info = opus_audio_info
+};

--- a/plugins/obs-ffmpeg/obs-ffmpeg-opus.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-opus.c
@@ -1,18 +1,18 @@
 /******************************************************************************
-    Copyright (C) 2014 by Quinn Damerell <qdamere@microsoft.com>
+	Copyright (C) 2017 by Quinn Damerell <qdamere@microsoft.com>
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 2 of the License, or
-    (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 2 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
 #include <media-io/audio-resampler.h>
@@ -79,7 +79,7 @@ static bool initialize_codec(struct opus_encoder *enc)
 {
 	int ret;
 
-	enc->aframe  = av_frame_alloc();
+	enc->aframe = av_frame_alloc();
 	if (!enc->aframe) {
 		warn("Failed to allocate audio frame");
 		return false;
@@ -126,8 +126,8 @@ static void init_sizes(struct opus_encoder *enc, audio_t *audio)
 static void *opus_create(obs_data_t *settings, obs_encoder_t *encoder)
 {
 	struct opus_encoder *enc;
-	int                bitrate = (int)obs_data_get_int(settings, "bitrate");
-	audio_t            *audio   = obs_encoder_audio(encoder);
+	int bitrate = (int)obs_data_get_int(settings, "bitrate");
+	audio_t *audio   = obs_encoder_audio(encoder);
 
 	avcodec_register_all();
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -13,6 +13,7 @@ extern struct obs_output_info  ffmpeg_output;
 extern struct obs_output_info  ffmpeg_muxer;
 extern struct obs_output_info  replay_buffer;
 extern struct obs_encoder_info aac_encoder_info;
+extern struct obs_encoder_info opus_encoder_info;
 extern struct obs_encoder_info nvenc_encoder_info;
 
 static DARRAY(struct log_context {
@@ -148,6 +149,7 @@ bool obs_module_load(void)
 	obs_register_output(&ffmpeg_muxer);
 	obs_register_output(&replay_buffer);
 	obs_register_encoder(&aac_encoder_info);
+	obs_register_encoder(&opus_encoder_info);
 	if (nvenc_supported()) {
 		blog(LOG_INFO, "NVENC supported");
 		obs_register_encoder(&nvenc_encoder_info);

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -19,6 +19,63 @@ else()
 	add_definitions(-DNO_CRYPTO)
 endif()
 
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ftl-sdk/CMakeLists.txt")
+	find_package(Libcurl REQUIRED)
+
+	include_directories(${LIBCURL_INCLUDE_DIRS})
+
+	set(ftl_SOURCES
+		ftl-stream.c
+		ftl-sdk/libftl/hmac/hmac.c
+		ftl-sdk/libftl/hmac/sha2.c
+		ftl-sdk/libftl/ftl-sdk.c
+		ftl-sdk/libftl/handshake.c
+		ftl-sdk/libftl/ingest.c
+		ftl-sdk/libftl/ftl_helpers.c
+		ftl-sdk/libftl/media.c
+		ftl-sdk/libftl/gettimeofday/gettimeofday.c
+		ftl-sdk/libftl/logging.c)
+	set(ftl_HEADERS
+		ftl-sdk/libftl/hmac/hmac.h
+		ftl-sdk/libftl/hmac/sha2.h
+		ftl-sdk/libftl/ftl.h
+		ftl-sdk/libftl/ftl_private.h)
+	set(ftl_IMPORTS
+		${OBS_JANSSON_IMPORT}
+		${LIBCURL_LIBRARIES})
+
+	if (WIN32)
+		list(APPEND ftl_SOURCES
+			ftl-sdk/libftl/win32/socket.c
+			ftl-sdk/libftl/gettimeofday/gettimeofday.c
+			ftl-sdk/libftl/win32/threads.c)
+		list(APPEND ftl_HEADERS
+			ftl-sdk/libftl/gettimeofday/gettimeofday.h
+			ftl-sdk/libftl/win32/threads.h)
+
+		include_directories(ftl-sdk/libftl/win32)
+	else()
+		list(APPEND ftl_SOURCES
+			ftl-sdk/libftl/posix/socket.c
+			ftl-sdk/libftl/posix/threads.c)
+		list(APPEND ftl_HEADERS
+			ftl-sdk/libftl/posix/threads.h)
+
+		include_directories(ftl-sdk/libftl/posix)
+	endif()
+
+	include_directories(ftl-sdk/libftl)
+
+	set(COMPILE_FTL TRUE)
+else()
+	set(COMPILE_FTL FALSE)
+endif()
+
+configure_file(
+	"${CMAKE_CURRENT_SOURCE_DIR}/obs-outputs-config.h.in"
+	"${CMAKE_BINARY_DIR}/plugins/obs-outputs/config/obs-outputs-config.h")
+
+include_directories("${CMAKE_BINARY_DIR}/plugins/obs-outputs/config")
 
 if(WIN32)
 	set(obs-outputs_PLATFORM_DEPS
@@ -60,6 +117,7 @@ if(NOT WIN32)
 endif()
 
 set(obs-outputs_HEADERS
+	"${CMAKE_BINARY_DIR}/plugins/obs-outputs/config/obs-outputs-config.h"
 	obs-output-ver.h
 	rtmp-helpers.h
 	rtmp-stream.h
@@ -75,6 +133,8 @@ set(obs-outputs_SOURCES
 	net-if.c)
 	
 add_library(obs-outputs MODULE
+	${ftl_SOURCES}
+	${ftl_HEADERS}
 	${obs-outputs_SOURCES}
 	${obs-outputs_HEADERS}
 	${obs-outputs_librtmp_SOURCES}
@@ -83,6 +143,7 @@ target_link_libraries(obs-outputs
 	libobs
 	${SSL_LIBRARIES}
 	${ZLIB_LIBRARIES}
+	${ftl_IMPORTS}
 	${obs-outputs_PLATFORM_DEPS})
 
 install_obs_plugin_with_data(obs-outputs data)

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -1155,6 +1155,7 @@ static int _ftl_error_to_obs_error(int status)
 	case FTL_BAD_OR_INVALID_STREAM_KEY:
 	case FTL_CHANNEL_IN_USE:
 	case FTL_REGION_UNSUPPORTED:
+    case FTL_GAME_BLOCKED:
 		return OBS_OUTPUT_CONNECT_FAILED;
 	case FTL_NO_MEDIA_TIMEOUT:
 		return OBS_OUTPUT_DISCONNECTED;

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -1,0 +1,1173 @@
+/******************************************************************************
+    Copyright (C) 2014 by Quinn Damerell <qdamere@microsoft.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include <obs-module.h>
+#include <obs-avc.h>
+#include <util/platform.h>
+#include <util/circlebuf.h>
+#include <util/dstr.h>
+#include <util/threading.h>
+#include <inttypes.h>
+#include "ftl.h"
+#include "flv-mux.h"
+#include "net-if.h"
+
+#ifdef _WIN32
+#include <Iphlpapi.h>
+#else
+#include <sys/ioctl.h>
+#define INFINITE 0xFFFFFFFF
+#endif
+
+#define do_log(level, format, ...) \
+	blog(level, "[ftl stream: '%s'] " format, \
+			obs_output_get_name(stream->output), ##__VA_ARGS__)
+
+#define warn(format, ...)  do_log(LOG_WARNING, format, ##__VA_ARGS__)
+#define info(format, ...)  do_log(LOG_INFO,    format, ##__VA_ARGS__)
+#define debug(format, ...) do_log(LOG_DEBUG,   format, ##__VA_ARGS__)
+
+#define OPT_DROP_THRESHOLD "drop_threshold_ms"
+#define OPT_MAX_SHUTDOWN_TIME_SEC "max_shutdown_time_sec"
+#define OPT_BIND_IP "bind_ip"
+
+typedef struct _nalu_t {
+	int len;
+	int dts_usec;
+	int send_marker_bit;
+	uint8_t *data;
+} nalu_t;
+
+typedef struct _frame_of_nalus_t {
+	nalu_t nalus[100];
+	int total;
+	int complete_frame;
+} frame_of_nalus_t;
+
+struct ftl_stream {
+	obs_output_t     *output;
+
+	pthread_mutex_t  packets_mutex;
+	struct circlebuf packets;
+	bool             sent_headers;
+	int64_t          frames_sent;
+
+	volatile bool    connecting;
+	pthread_t        connect_thread;
+	pthread_t        status_thread;
+
+	volatile bool    active;
+	volatile bool    disconnected;
+	pthread_t        send_thread;
+
+	int              max_shutdown_time_sec;
+
+	os_sem_t         *send_sem;
+	os_event_t       *stop_event;
+	uint64_t         stop_ts;
+	uint64_t         shutdown_timeout_ts;
+
+	struct dstr      path;
+	uint32_t         channel_id;
+	struct dstr      username, password;
+	struct dstr      encoder_name;
+	struct dstr      bind_ip;
+
+	/* frame drop variables */
+	int64_t          drop_threshold_usec;
+	int64_t          pframe_drop_threshold_usec;
+	int              min_priority;
+	float            congestion;
+
+	int64_t          last_dts_usec;
+
+	uint64_t         total_bytes_sent;
+	int              dropped_frames;
+
+	ftl_handle_t	    ftl_handle;
+	ftl_ingest_params_t params;
+	int                 peak_kbps;
+	uint32_t            scale_width, scale_height, width, height;
+	frame_of_nalus_t    coded_pic_buffer;
+};
+
+static void log_libftl_messages(ftl_log_severity_t log_level,
+		const char *message);
+static bool init_connect(struct ftl_stream *stream);
+static void *connect_thread(void *data);
+static void *status_thread(void *data);
+static int _ftl_error_to_obs_error(int status);
+
+static const char *ftl_stream_getname(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+	return obs_module_text("FTLStream");
+}
+
+static void log_ftl(int level, const char *format, va_list args)
+{
+	blogva(LOG_INFO, format, args);
+}
+
+static inline size_t num_buffered_packets(struct ftl_stream *stream);
+
+static inline void free_packets(struct ftl_stream *stream)
+{
+	size_t num_packets;
+
+	pthread_mutex_lock(&stream->packets_mutex);
+
+	num_packets = num_buffered_packets(stream);
+	if (num_packets)
+		info("Freeing %d remaining packets", (int)num_packets);
+
+	while (stream->packets.size) {
+		struct encoder_packet packet;
+		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
+		obs_encoder_packet_release(&packet);
+	}
+	pthread_mutex_unlock(&stream->packets_mutex);
+}
+
+static inline bool stopping(struct ftl_stream *stream)
+{
+	return os_event_try(stream->stop_event) != EAGAIN;
+}
+
+static inline bool connecting(struct ftl_stream *stream)
+{
+	return os_atomic_load_bool(&stream->connecting);
+}
+
+static inline bool active(struct ftl_stream *stream)
+{
+	return os_atomic_load_bool(&stream->active);
+}
+
+static inline bool disconnected(struct ftl_stream *stream)
+{
+	return os_atomic_load_bool(&stream->disconnected);
+}
+
+static void ftl_stream_destroy(void *data)
+{
+	struct ftl_stream *stream = data;
+	ftl_status_t status_code;
+
+	info("ftl_stream_destroy");
+
+	if (stopping(stream) && !connecting(stream)) {
+		pthread_join(stream->send_thread, NULL);
+
+	} else if (connecting(stream) || active(stream)) {
+		if (stream->connecting) {
+			info("wait for connect_thread to terminate");
+			pthread_join(stream->status_thread, NULL);
+			pthread_join(stream->connect_thread, NULL);
+			info("wait for connect_thread to terminate: done");
+		}
+
+		stream->stop_ts = 0;
+		os_event_signal(stream->stop_event);
+
+		if (active(stream)) {
+			os_sem_post(stream->send_sem);
+			obs_output_end_data_capture(stream->output);
+			pthread_join(stream->send_thread, NULL);
+		}
+	}
+
+	info("ingest destroy");
+
+	status_code = ftl_ingest_destroy(&stream->ftl_handle);
+	if (status_code != FTL_SUCCESS) {
+		info("Failed to destroy from ingest %d", status_code);
+	}
+
+	if (stream) {
+		free_packets(stream);
+		dstr_free(&stream->path);
+		dstr_free(&stream->username);
+		dstr_free(&stream->password);
+		dstr_free(&stream->encoder_name);
+		dstr_free(&stream->bind_ip);
+		os_event_destroy(stream->stop_event);
+		os_sem_destroy(stream->send_sem);
+		pthread_mutex_destroy(&stream->packets_mutex);
+		circlebuf_free(&stream->packets);
+		bfree(stream);
+	}
+}
+
+static void *ftl_stream_create(obs_data_t *settings, obs_output_t *output)
+{
+	struct ftl_stream *stream = bzalloc(sizeof(struct ftl_stream));
+	info("ftl_stream_create");
+
+	stream->output = output;
+	pthread_mutex_init_value(&stream->packets_mutex);
+
+	stream->peak_kbps = -1;
+	ftl_init();
+
+    if (pthread_mutex_init(&stream->packets_mutex, NULL) != 0) {
+        goto fail;
+    }
+    if (os_event_init(&stream->stop_event, OS_EVENT_TYPE_MANUAL) != 0) {
+        goto fail;
+    }
+
+	stream->coded_pic_buffer.total = 0;
+	stream->coded_pic_buffer.complete_frame = 0;
+
+	UNUSED_PARAMETER(settings);
+	return stream;
+
+fail:
+	return NULL;
+}
+
+static void ftl_stream_stop(void *data, uint64_t ts)
+{
+	struct ftl_stream *stream = data;
+	info("ftl_stream_stop");
+
+    if (stopping(stream) && ts != 0) {
+        return;
+    }
+
+	if (connecting(stream)) {
+		pthread_join(stream->status_thread, NULL);
+		pthread_join(stream->connect_thread, NULL);
+	}
+
+	stream->stop_ts = ts / 1000ULL;
+	os_event_signal(stream->stop_event);
+
+    if (ts) {
+        stream->shutdown_timeout_ts = ts +
+            (uint64_t)stream->max_shutdown_time_sec * 1000000000ULL;
+    }
+
+	if (active(stream)) {
+		if (stream->stop_ts == 0)
+			os_sem_post(stream->send_sem);
+	}
+}
+
+static inline bool get_next_packet(struct ftl_stream *stream,
+		struct encoder_packet *packet)
+{
+	bool new_packet = false;
+
+	pthread_mutex_lock(&stream->packets_mutex);
+	if (stream->packets.size) {
+		circlebuf_pop_front(&stream->packets, packet,
+				sizeof(struct encoder_packet));
+		new_packet = true;
+	}
+	pthread_mutex_unlock(&stream->packets_mutex);
+
+	return new_packet;
+}
+
+static int avc_get_video_frame(struct ftl_stream *stream,
+		struct encoder_packet *packet, bool is_header, size_t idx)
+{
+	int consumed = 0;
+	int len = (int)packet->size;
+	nalu_t *nalu;
+
+	unsigned char *video_stream = packet->data;
+
+	while (consumed < packet->size) {
+		size_t total_max = sizeof(stream->coded_pic_buffer.nalus) /
+			sizeof(stream->coded_pic_buffer.nalus[0]);
+
+		if (stream->coded_pic_buffer.total >= total_max) {
+			warn("ERROR: cannot continue, nalu buffers are full");
+			return -1;
+		}
+
+		nalu = &stream->coded_pic_buffer.nalus
+			[stream->coded_pic_buffer.total];
+
+		if (is_header) {
+			if (consumed == 0) {
+				//first 6 bytes are some obs header with part
+				//of the sps
+				video_stream += 6;
+				consumed += 6;
+			} else {
+				//another spacer byte of 0x1
+				video_stream += 1;
+				consumed += 1;
+			}
+
+			len = video_stream[0] << 8 | video_stream[1];
+			video_stream += 2;
+			consumed += 2;
+		} else {
+			len = video_stream[0] << 24 |
+			      video_stream[1] << 16 |
+			      video_stream[2] << 8 |
+			      video_stream[3];
+
+			if (len > (packet->size - consumed)) {
+				warn("ERROR: got len of %d but packet only "
+						"has %d left",
+						len, packet->size - consumed);
+			}
+
+			consumed += 4;
+			video_stream += 4;
+		}
+
+		consumed += len;
+
+		uint8_t nalu_type = video_stream[0] & 0x1F;
+		uint8_t nri = (video_stream[0] >> 5) & 0x3;
+
+		int send_marker_bit = (consumed >= packet->size) && !is_header;
+
+		if ((nalu_type != 12 && nalu_type != 6 && nalu_type != 9) ||
+		    nri) {
+			nalu->data = video_stream;
+			nalu->len = len;
+			nalu->send_marker_bit = 0;
+			stream->coded_pic_buffer.total++;
+		}
+
+		video_stream += len;
+	}
+
+	if (!is_header) {
+		size_t idx = stream->coded_pic_buffer.total - 1;
+		stream->coded_pic_buffer.nalus[idx].send_marker_bit = 1;
+	}
+
+	return 0;
+}
+
+static int send_packet(struct ftl_stream *stream,
+		struct encoder_packet *packet, bool is_header, size_t idx)
+{
+	int bytes_sent = 0;
+	int recv_size = 0;
+	int ret = 0;
+
+	if (packet->type == OBS_ENCODER_VIDEO) {
+		stream->coded_pic_buffer.total = 0;
+		avc_get_video_frame(stream, packet, is_header, idx);
+
+		int i;
+		for (i = 0; i < stream->coded_pic_buffer.total; i++) {
+			nalu_t *nalu = &stream->coded_pic_buffer.nalus[i];
+			bytes_sent += ftl_ingest_send_media_dts(
+					&stream->ftl_handle,
+					FTL_VIDEO_DATA,
+					packet->dts_usec,
+					nalu->data,
+					nalu->len,
+					nalu->send_marker_bit);
+
+			if (nalu->send_marker_bit) {
+				stream->frames_sent++;
+			}
+		}
+
+	} else if (packet->type == OBS_ENCODER_AUDIO) {
+		bytes_sent += ftl_ingest_send_media_dts(
+				&stream->ftl_handle,
+				FTL_AUDIO_DATA,
+				packet->dts_usec,
+				packet->data,
+				(int)packet->size, 0);
+	} else {
+		warn("Got packet type %d", packet->type);
+	}
+
+    if (is_header) {
+        bfree(packet->data);
+    }
+    else {
+        obs_encoder_packet_release(packet);
+    }
+
+	stream->total_bytes_sent += bytes_sent;
+	return ret;
+}
+
+static void set_peak_bitrate(struct ftl_stream *stream)
+{
+	int speedtest_kbps = 15000;
+	int speedtest_duration = 2000;
+	speed_test_t results;
+	ftl_status_t status_code;
+
+	status_code = ftl_ingest_speed_test_ex(
+			&stream->ftl_handle,
+			speedtest_kbps,
+			speedtest_duration,
+			&results);
+
+	if (status_code == FTL_SUCCESS) {
+		float percent_lost = (float)results.lost_pkts * 100.f /
+			(float)results.pkts_sent;
+
+		info("Speed test completed: Peak kbps %d, "
+				"initial rtt %d, "
+				"final rtt %d, %3.2f lost packets",
+				results.peak_kbps,
+				results.starting_rtt,
+				results.ending_rtt,
+				percent_lost);
+
+		stream->peak_kbps = stream->params.peak_kbps =
+			results.peak_kbps;
+
+		ftl_ingest_update_params(&stream->ftl_handle, &stream->params);
+	} else {
+		warn("Speed test failed with: %s",
+				ftl_status_code_to_string(status_code));
+	}
+}
+
+static inline bool send_headers(struct ftl_stream *stream, int64_t dts_usec);
+
+static inline bool can_shutdown_stream(struct ftl_stream *stream,
+		struct encoder_packet *packet)
+{
+	uint64_t cur_time = os_gettime_ns();
+	bool timeout = cur_time >= stream->shutdown_timeout_ts;
+
+	if (timeout)
+		info("Stream shutdown timeout reached (%d second(s))",
+				stream->max_shutdown_time_sec);
+
+	return timeout || packet->sys_dts_usec >= (int64_t)stream->stop_ts;
+}
+
+static void *send_thread(void *data)
+{
+	struct ftl_stream *stream = data;
+	ftl_status_t status_code;
+
+	os_set_thread_name("ftl-stream: send_thread");
+
+	while (os_sem_wait(stream->send_sem) == 0) {
+		struct encoder_packet packet;
+
+		if (stopping(stream) && stream->stop_ts == 0) {
+			break;
+		}
+
+		if (!get_next_packet(stream, &packet))
+			continue;
+
+		if (stopping(stream)) {
+			if (can_shutdown_stream(stream, &packet)) {
+				obs_encoder_packet_release(&packet);
+				break;
+			}
+		}
+
+		/* sends sps/pps on every key frame as this is typically
+		 * required for webrtc */
+		if (packet.keyframe) {
+			if (!send_headers(stream, packet.dts_usec)) {
+				os_atomic_set_bool(&stream->disconnected, true);
+				break;
+			}
+		}
+
+		if (send_packet(stream, &packet, false, packet.track_idx) < 0) {
+			os_atomic_set_bool(&stream->disconnected, true);
+			break;
+		}
+	}
+
+	if (disconnected(stream)) {
+		info("Disconnected from %s", stream->path.array);
+	} else {
+		info("User stopped the stream");
+	}
+
+	if (!stopping(stream)) {
+		pthread_detach(stream->send_thread);
+		obs_output_signal_stop(stream->output, OBS_OUTPUT_DISCONNECTED);
+	} else {
+		obs_output_end_data_capture(stream->output);
+	}
+
+	info("ingest disconnect");
+
+	status_code = ftl_ingest_disconnect(&stream->ftl_handle);
+	if (status_code != FTL_SUCCESS) {
+		printf("Failed to disconnect from ingest %d", status_code);
+	}
+
+	free_packets(stream);
+	os_event_reset(stream->stop_event);
+	os_atomic_set_bool(&stream->active, false);
+	stream->sent_headers = false;
+	return NULL;
+}
+
+static bool send_video_header(struct ftl_stream *stream, int64_t dts_usec)
+{
+	obs_output_t  *context  = stream->output;
+	obs_encoder_t *vencoder = obs_output_get_video_encoder(context);
+	uint8_t       *header;
+	size_t        size;
+
+	struct encoder_packet packet   = {
+		.type         = OBS_ENCODER_VIDEO,
+		.timebase_den = 1,
+		.keyframe     = true,
+		.dts_usec = dts_usec
+	};
+
+	obs_encoder_get_extra_data(vencoder, &header, &size);
+	packet.size = obs_parse_avc_header(&packet.data, header, size);
+	return send_packet(stream, &packet, true, 0) >= 0;
+}
+
+static inline bool send_headers(struct ftl_stream *stream, int64_t dts_usec)
+{
+	stream->sent_headers = true;
+
+	if (!send_video_header(stream, dts_usec))
+		return false;
+
+	return true;
+}
+
+static inline bool reset_semaphore(struct ftl_stream *stream)
+{
+	os_sem_destroy(stream->send_sem);
+	return os_sem_init(&stream->send_sem, 0) == 0;
+}
+
+#ifdef _WIN32
+#define socklen_t int
+#endif
+
+static int init_send(struct ftl_stream *stream)
+{
+	int ret;
+
+	reset_semaphore(stream);
+
+	ret = pthread_create(&stream->send_thread, NULL, send_thread, stream);
+	if (ret != 0) {
+		warn("Failed to create send thread");
+		return OBS_OUTPUT_ERROR;
+	}
+
+	os_atomic_set_bool(&stream->active, true);
+
+	obs_output_begin_data_capture(stream->output, 0);
+
+	return OBS_OUTPUT_SUCCESS;
+}
+
+static int lookup_ingest_ip(const char *ingest_location, char *ingest_ip)
+{
+	struct hostent *remoteHost;
+	struct in_addr addr;
+	int retval = -1;
+	ingest_ip[0] = '\0';
+
+	remoteHost = gethostbyname(ingest_location);
+
+	if (remoteHost && remoteHost->h_addrtype == AF_INET) {
+		int i = 0;
+
+		while (remoteHost->h_addr_list[i] != 0) {
+			addr.s_addr = *(u_long *)remoteHost->h_addr_list[i++];
+			blog(LOG_INFO, "IP Address #%d of ingest is: %s",
+					i, inet_ntoa(addr));
+
+			/*only use the first ip found*/
+			if (strlen(ingest_ip) == 0) {
+				strcpy(ingest_ip, inet_ntoa(addr));
+				retval = 0;
+			}
+		}
+	}
+
+	return retval;
+}
+
+static int try_connect(struct ftl_stream *stream)
+{
+	ftl_status_t status_code;
+
+	if (dstr_is_empty(&stream->path)) {
+		warn("URL is empty");
+		return OBS_OUTPUT_BAD_PATH;
+	}
+
+	info("Connecting to FTL Ingest URL %s...", stream->path.array);
+
+	stream->width = (int)obs_output_get_width(stream->output);
+	stream->height = (int)obs_output_get_height(stream->output);
+
+	status_code = ftl_ingest_connect(&stream->ftl_handle);
+	if (status_code != FTL_SUCCESS) {
+		warn("Ingest connect failed with: %s (%d)",
+				ftl_status_code_to_string(status_code),
+				status_code);
+		return _ftl_error_to_obs_error(status_code);
+	}
+
+	info("Connection to %s successful", stream->path.array);
+
+	if (stream->peak_kbps < 0) {
+		set_peak_bitrate(stream);
+	}
+
+	pthread_create(&stream->status_thread, NULL, status_thread, stream);
+
+	return init_send(stream);
+}
+
+static bool ftl_stream_start(void *data)
+{
+	struct ftl_stream *stream = data;
+
+	info("ftl_stream_start");
+
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
+		return false;
+	if (!obs_output_initialize_encoders(stream->output, 0))
+		return false;
+
+	stream->frames_sent = 0;
+	os_atomic_set_bool(&stream->connecting, true);
+
+	return pthread_create(&stream->connect_thread, NULL, connect_thread,
+			stream) == 0;
+}
+
+static inline bool add_packet(struct ftl_stream *stream,
+		struct encoder_packet *packet)
+{
+	circlebuf_push_back(&stream->packets, packet,
+			sizeof(struct encoder_packet));
+	return true;
+}
+
+static inline size_t num_buffered_packets(struct ftl_stream *stream)
+{
+	return stream->packets.size / sizeof(struct encoder_packet);
+}
+
+static void drop_frames(struct ftl_stream *stream, const char *name,
+		int highest_priority, bool pframes)
+{
+	UNUSED_PARAMETER(pframes);
+
+	struct circlebuf new_buf            = {0};
+	int              num_frames_dropped = 0;
+
+#ifdef _DEBUG
+	int start_packets = (int)num_buffered_packets(stream);
+#else
+	UNUSED_PARAMETER(name);
+#endif
+
+	circlebuf_reserve(&new_buf, sizeof(struct encoder_packet) * 8);
+
+	while (stream->packets.size) {
+		struct encoder_packet packet;
+		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
+
+		/* do not drop audio data or video keyframes */
+		if (packet.type          == OBS_ENCODER_AUDIO ||
+		    packet.drop_priority >= highest_priority) {
+			circlebuf_push_back(&new_buf, &packet, sizeof(packet));
+
+		} else {
+			num_frames_dropped++;
+			obs_encoder_packet_release(&packet);
+		}
+	}
+
+	circlebuf_free(&stream->packets);
+	stream->packets = new_buf;
+
+	if (stream->min_priority < highest_priority)
+		stream->min_priority = highest_priority;
+	if (!num_frames_dropped)
+		return;
+
+	stream->dropped_frames += num_frames_dropped;
+#ifdef _DEBUG
+	debug("Dropped %s, prev packet count: %d, new packet count: %d",
+			name,
+			start_packets,
+			(int)num_buffered_packets(stream));
+#endif
+}
+
+static bool find_first_video_packet(struct ftl_stream *stream,
+		struct encoder_packet *first)
+{
+	size_t count = stream->packets.size / sizeof(*first);
+
+	for (size_t i = 0; i < count; i++) {
+		struct encoder_packet *cur = circlebuf_data(&stream->packets,
+				i * sizeof(*first));
+		if (cur->type == OBS_ENCODER_VIDEO && !cur->keyframe) {
+			*first = *cur;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void check_to_drop_frames(struct ftl_stream *stream, bool pframes)
+{
+	struct encoder_packet first;
+	int64_t buffer_duration_usec;
+	size_t num_packets = num_buffered_packets(stream);
+	const char *name = pframes ? "p-frames" : "b-frames";
+	int priority = pframes ?
+		OBS_NAL_PRIORITY_HIGHEST : OBS_NAL_PRIORITY_HIGH;
+	int64_t drop_threshold = pframes ?
+		stream->pframe_drop_threshold_usec :
+		stream->drop_threshold_usec;
+
+	if (num_packets < 5) {
+		if (!pframes)
+			stream->congestion = 0.0f;
+		return;
+	}
+
+	if (!find_first_video_packet(stream, &first))
+		return;
+
+	/* if the amount of time stored in the buffered packets waiting to be
+	 * sent is higher than threshold, drop frames */
+	buffer_duration_usec = stream->last_dts_usec - first.dts_usec;
+
+	if (!pframes) {
+		stream->congestion = (float)buffer_duration_usec /
+			(float)drop_threshold;
+	}
+
+	if (buffer_duration_usec > drop_threshold) {
+		debug("buffer_duration_usec: %" PRId64, buffer_duration_usec);
+		drop_frames(stream, name, priority, pframes);
+	}
+}
+
+static bool add_video_packet(struct ftl_stream *stream,
+		struct encoder_packet *packet)
+{
+	check_to_drop_frames(stream, false);
+	check_to_drop_frames(stream, true);
+
+	/* if currently dropping frames, drop packets until it reaches the
+	 * desired priority */
+	if (packet->priority < stream->min_priority) {
+		stream->dropped_frames++;
+		return false;
+	} else {
+		stream->min_priority = 0;
+	}
+
+	stream->last_dts_usec = packet->dts_usec;
+	return add_packet(stream, packet);
+}
+
+
+static void ftl_stream_data(void *data, struct encoder_packet *packet)
+{
+	struct ftl_stream    *stream = data;
+
+	struct encoder_packet new_packet;
+	bool                  added_packet = false;
+
+	if (disconnected(stream) || !active(stream))
+		return;
+
+	if (packet->type == OBS_ENCODER_VIDEO)
+		obs_parse_avc_packet(&new_packet, packet);
+	else
+		obs_encoder_packet_ref(&new_packet, packet);
+
+	pthread_mutex_lock(&stream->packets_mutex);
+
+	if (!disconnected(stream)) {
+		added_packet = (packet->type == OBS_ENCODER_VIDEO) ?
+			add_video_packet(stream, &new_packet) :
+			add_packet(stream, &new_packet);
+	}
+
+	pthread_mutex_unlock(&stream->packets_mutex);
+
+	if (added_packet)
+		os_sem_post(stream->send_sem);
+	else
+		obs_encoder_packet_release(&new_packet);
+}
+
+static void ftl_stream_defaults(obs_data_t *defaults)
+{
+	UNUSED_PARAMETER(defaults);
+}
+
+
+static obs_properties_t *ftl_stream_properties(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+
+	obs_properties_t *props = obs_properties_create();
+/*
+	struct netif_saddr_data addrs = {0};
+	obs_property_t *p;
+*/
+	obs_properties_add_int(props, "peak_bitrate_kbps",
+			obs_module_text("FTLStream.PeakBitrate"),
+			1000, 10000, 500);
+
+/*
+	p = obs_properties_add_list(props, OPT_BIND_IP,
+			obs_module_text("RTMPStream.BindIP"),
+			OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
+
+	obs_property_list_add_string(p, obs_module_text("Default"), "default");
+
+	netif_get_addrs(&addrs);
+	for (size_t i = 0; i < addrs.addrs.num; i++) {
+		struct netif_saddr_item item = addrs.addrs.array[i];
+		obs_property_list_add_string(p, item.name, item.addr);
+	}
+	netif_saddr_data_free(&addrs);
+*/
+	return props;
+}
+
+
+static uint64_t ftl_stream_total_bytes_sent(void *data)
+{
+	struct ftl_stream *stream = data;
+
+	return stream->total_bytes_sent;
+}
+
+static int ftl_stream_dropped_frames(void *data)
+{
+	struct ftl_stream *stream = data;
+	return stream->dropped_frames;
+}
+
+static float ftl_stream_congestion(void *data)
+{
+	struct ftl_stream *stream = data;
+	return stream->min_priority > 0 ? 1.0f : stream->congestion;
+}
+
+
+/*********************************************************************/
+
+enum ret_type {
+	RET_CONTINUE,
+	RET_BREAK,
+	RET_EXIT,
+};
+
+static enum ret_type ftl_event(struct ftl_stream *stream,
+		ftl_status_msg_t status)
+{
+	if (status.msg.event.type != FTL_STATUS_EVENT_TYPE_DISCONNECTED)
+		return RET_CONTINUE;
+
+	info("Disconnected from ingest with reason: %s",
+			ftl_status_code_to_string(status.msg.event.error_code));
+
+	if (status.msg.event.reason == FTL_STATUS_EVENT_REASON_API_REQUEST) {
+		return RET_BREAK;
+	}
+
+	//tell OBS and it will trigger a reconnection
+	blog(LOG_WARNING, "Reconnecting to Ingest");
+	obs_output_signal_stop(stream->output, OBS_OUTPUT_DISCONNECTED);
+	return RET_EXIT;
+}
+
+static void *status_thread(void *data)
+{
+	struct ftl_stream *stream = data;
+
+	ftl_status_msg_t status;
+	ftl_status_t status_code;
+
+	while (!disconnected(stream)) {
+		status_code = ftl_ingest_get_status(&stream->ftl_handle,
+				&status, 1000);
+
+		if (status_code == FTL_STATUS_TIMEOUT ||
+		    status_code == FTL_QUEUE_EMPTY) {
+			continue;
+		} else if (status_code == FTL_NOT_INITIALIZED) {
+			break;
+		}
+
+		if (status.type == FTL_STATUS_EVENT) {
+			enum ret_type ret_type = ftl_event(stream, status);
+			if (ret_type == RET_EXIT)
+				return NULL;
+			else if (ret_type == RET_BREAK)
+				break;
+
+		} else if(status.type == FTL_STATUS_LOG) {
+			blog(LOG_INFO, "[%d] %s", status.msg.log.log_level,
+					status.msg.log.string);
+
+		} else if (status.type == FTL_STATUS_VIDEO_PACKETS) {
+			ftl_packet_stats_msg_t *p = &status.msg.pkt_stats;
+
+			blog(LOG_INFO, "Avg packet send per second %3.1f, "
+					"total nack requests %d",
+					(float)p->sent * 1000.f / p->period,
+					p->nack_reqs);
+
+		} else if (status.type == FTL_STATUS_VIDEO_PACKETS_INSTANT) {
+			ftl_packet_stats_instant_msg_t *p =
+				&status.msg.ipkt_stats;
+
+			blog(LOG_INFO, "avg transmit delay %dms "
+					"(min: %d, max: %d), "
+					"avg rtt %dms (min: %d, max: %d)",
+					p->avg_xmit_delay,
+					p->min_xmit_delay, p->max_xmit_delay,
+					p->avg_rtt, p->min_rtt, p->max_rtt);
+
+		} else if (status.type == FTL_STATUS_VIDEO) {
+			ftl_video_frame_stats_msg_t *v =
+				&status.msg.video_stats;
+
+			blog(LOG_INFO, "Queue an average of %3.2f fps "
+				"(%3.1f kbps), "
+				"sent an average of %3.2f fps "
+				"(%3.1f kbps), "
+				"queue fullness %d, "
+				"max frame size %d",
+				(float)v->frames_queued * 1000.f / v->period,
+				(float)v->bytes_queued / v->period * 8,
+				(float)v->frames_sent * 1000.f / v->period,
+				(float)v->bytes_sent / v->period * 8,
+				v->queue_fullness, v->max_frame_size);
+		} else {
+			blog(LOG_INFO, "Status:  Got Status message of type %d",
+					status.type);
+		}
+	}
+
+	blog(LOG_INFO, "status_thread:  Exited");
+	pthread_detach(stream->status_thread);
+	return NULL;
+}
+
+static void *connect_thread(void *data)
+{
+	struct ftl_stream *stream = data;
+	int ret;
+
+	os_set_thread_name("ftl-stream: connect_thread");
+
+	blog(LOG_WARNING, "ftl-stream: connect thread");
+
+	if (!init_connect(stream)) {
+		obs_output_signal_stop(stream->output, OBS_OUTPUT_BAD_PATH);
+		return NULL;
+	}
+
+	ret = try_connect(stream);
+
+	if (ret != OBS_OUTPUT_SUCCESS) {
+		obs_output_signal_stop(stream->output, ret);
+		info("Connection to %s failed: %d", stream->path.array, ret);
+	}
+
+	if (!stopping(stream))
+		pthread_detach(stream->connect_thread);
+
+	os_atomic_set_bool(&stream->connecting, false);
+	return NULL;
+}
+
+static void log_libftl_messages(ftl_log_severity_t log_level,
+		const char * message)
+{
+	UNUSED_PARAMETER(log_level);
+	blog(LOG_WARNING, "[libftl] %s", message);
+}
+
+static bool init_connect(struct ftl_stream *stream)
+{
+	obs_service_t *service;
+	obs_data_t *settings;
+	const char *bind_ip, *key;
+	ftl_status_t status_code;
+
+	info("init_connect");
+
+	if (stopping(stream))
+		pthread_join(stream->send_thread, NULL);
+
+	free_packets(stream);
+
+	service = obs_output_get_service(stream->output);
+	if (!service)
+		return false;
+
+	os_atomic_set_bool(&stream->disconnected, false);
+	stream->total_bytes_sent  = 0;
+	stream->dropped_frames    = 0;
+	stream->min_priority      = 0;
+
+	settings = obs_output_get_settings(stream->output);
+	obs_encoder_t *video_encoder =
+		obs_output_get_video_encoder(stream->output);
+	obs_data_t *video_settings =
+		obs_encoder_get_settings(video_encoder);
+
+	dstr_copy(&stream->path, obs_service_get_url(service));
+	key = obs_service_get_key(service);
+
+	struct obs_video_info ovi;
+	int fps_num = 30, fps_den = 1;
+	if (obs_get_video_info(&ovi)) {
+		fps_num = ovi.fps_num;
+		fps_den = ovi.fps_den;
+	}
+
+	int target_bitrate = (int)obs_data_get_int(video_settings, "bitrate");
+	int peak_bitrate = (int)((float)target_bitrate * 1.1f);
+
+	//minimum overshoot tolerance of 10%
+	if (peak_bitrate < target_bitrate) {
+		peak_bitrate = target_bitrate;
+	}
+
+	stream->params.stream_key = (char*)key;
+	stream->params.video_codec = FTL_VIDEO_H264;
+	stream->params.audio_codec = FTL_AUDIO_OPUS;
+	stream->params.ingest_hostname = stream->path.array;
+	stream->params.vendor_name = "OBS Studio";
+	stream->params.vendor_version = OBS_VERSION;
+	stream->params.peak_kbps =
+		stream->peak_kbps < 0 ? 0 : stream->peak_kbps;
+
+	//not required when using ftl_ingest_send_media_dts
+	stream->params.fps_num = 0;
+	stream->params.fps_den = 0;
+
+	status_code = ftl_ingest_create(&stream->ftl_handle, &stream->params);
+	if (status_code != FTL_SUCCESS) {
+		blog(LOG_ERROR, "Failed to create ingest handle (%s)",
+				ftl_status_code_to_string(status_code));
+		return false;
+	}
+
+	dstr_copy(&stream->username, obs_service_get_username(service));
+	dstr_copy(&stream->password, obs_service_get_password(service));
+	dstr_depad(&stream->path);
+
+	stream->drop_threshold_usec =
+		(int64_t)obs_data_get_int(settings, OPT_DROP_THRESHOLD) * 1000;
+	stream->max_shutdown_time_sec =
+		(int)obs_data_get_int(settings, OPT_MAX_SHUTDOWN_TIME_SEC);
+
+	bind_ip = obs_data_get_string(settings, OPT_BIND_IP);
+	dstr_copy(&stream->bind_ip, bind_ip);
+
+	obs_data_release(settings);
+	obs_data_release(video_settings);
+	return true;
+}
+
+// Returns 0 on success
+static int _ftl_error_to_obs_error(int status)
+{
+	/* Map FTL errors to OBS errors */
+
+	switch (status) {
+	case FTL_SUCCESS:
+		return OBS_OUTPUT_SUCCESS;
+	case FTL_SOCKET_NOT_CONNECTED:
+	case FTL_MALLOC_FAILURE:
+	case FTL_INTERNAL_ERROR:
+	case FTL_CONFIG_ERROR:
+	case FTL_NOT_ACTIVE_STREAM:
+	case FTL_NOT_CONNECTED:
+	case FTL_ALREADY_CONNECTED:
+	case FTL_STATUS_TIMEOUT:
+	case FTL_QUEUE_FULL:
+	case FTL_STATUS_WAITING_FOR_KEY_FRAME:
+	case FTL_QUEUE_EMPTY:
+	case FTL_NOT_INITIALIZED:
+		return OBS_OUTPUT_ERROR;
+	case FTL_BAD_REQUEST:
+	case FTL_DNS_FAILURE:
+	case FTL_CONNECT_ERROR:
+	case FTL_UNSUPPORTED_MEDIA_TYPE:
+	case FTL_OLD_VERSION:
+	case FTL_UNAUTHORIZED:
+	case FTL_AUDIO_SSRC_COLLISION:
+	case FTL_VIDEO_SSRC_COLLISION:
+	case FTL_STREAM_REJECTED:
+	case FTL_BAD_OR_INVALID_STREAM_KEY:
+	case FTL_CHANNEL_IN_USE:
+	case FTL_REGION_UNSUPPORTED:
+		return OBS_OUTPUT_CONNECT_FAILED;
+	case FTL_NO_MEDIA_TIMEOUT:
+		return OBS_OUTPUT_DISCONNECTED;
+	case FTL_USER_DISCONNECT:
+		return OBS_OUTPUT_SUCCESS;
+	case FTL_UNKNOWN_ERROR_CODE:
+	default:
+		/* Unknown FTL error */
+		return OBS_OUTPUT_ERROR;
+	}
+}
+
+struct obs_output_info ftl_output_info = {
+	.id                   = "ftl_output",
+	.flags                = OBS_OUTPUT_AV |
+	                        OBS_OUTPUT_ENCODED |
+	                        OBS_OUTPUT_SERVICE,
+	.encoded_video_codecs = "h264",
+	.encoded_audio_codecs = "opus",
+	.get_name             = ftl_stream_getname,
+	.create               = ftl_stream_create,
+	.destroy              = ftl_stream_destroy,
+	.start                = ftl_stream_start,
+	.stop                 = ftl_stream_stop,
+	.encoded_packet       = ftl_stream_data,
+	.get_defaults         = ftl_stream_defaults,
+	.get_properties       = ftl_stream_properties,
+	.get_total_bytes      = ftl_stream_total_bytes_sent,
+	.get_congestion       = ftl_stream_congestion,
+	.get_dropped_frames   = ftl_stream_dropped_frames
+};

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -429,9 +429,14 @@ static void set_peak_bitrate(struct ftl_stream *stream)
 		float percent_lost = (float)results.lost_pkts * 100.f /
 			(float)results.pkts_sent;
 
-		info("Speed test completed: Peak kbps %d, "
+        obs_encoder_t *video_encoder = obs_output_get_video_encoder(stream->output);
+        obs_data_t *video_settings = obs_encoder_get_settings(video_encoder);
+        int user_desired_bitrate = (int)obs_data_get_int(video_settings, "bitrate");
+
+		info("Speed test completed: User desired bitrate %d, Peak kbps %d, "
 				"initial rtt %d, "
 				"final rtt %d, %3.2f lost packets",
+                user_desired_bitrate,
 				results.peak_kbps,
 				results.starting_rtt,
 				results.ending_rtt,
@@ -638,9 +643,8 @@ static int try_connect(struct ftl_stream *stream)
 
 	info("Connection to %s successful", stream->path.array);
 
-	if (stream->peak_kbps < 0) {
-		set_peak_bitrate(stream);
-	}
+	// Always get the peak bitrate when we are starting.
+	set_peak_bitrate(stream);	
 
 	pthread_create(&stream->status_thread, NULL, status_thread, stream);
 

--- a/plugins/obs-outputs/obs-outputs-config.h.in
+++ b/plugins/obs-outputs/obs-outputs-config.h.in
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef ON
+#define ON 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#define COMPILE_FTL @COMPILE_FTL@

--- a/plugins/obs-outputs/obs-outputs.c
+++ b/plugins/obs-outputs/obs-outputs.c
@@ -1,5 +1,7 @@
 #include <obs-module.h>
 
+#include "obs-outputs-config.h"
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>
@@ -11,6 +13,9 @@ OBS_MODULE_USE_DEFAULT_LOCALE("obs-outputs", "en-US")
 extern struct obs_output_info rtmp_output_info;
 extern struct obs_output_info null_output_info;
 extern struct obs_output_info flv_output_info;
+#if COMPILE_FTL
+extern struct obs_output_info ftl_output_info;
+#endif
 
 bool obs_module_load(void)
 {
@@ -22,6 +27,9 @@ bool obs_module_load(void)
 	obs_register_output(&rtmp_output_info);
 	obs_register_output(&null_output_info);
 	obs_register_output(&flv_output_info);
+#if COMPILE_FTL
+	obs_register_output(&ftl_output_info);
+#endif
 	return true;
 }
 

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1,5 +1,5 @@
 {
-    "format_version": 1,
+    "format_version": 2,
     "services": [
         {
             "name": "Twitch",
@@ -285,87 +285,93 @@
             "common": true,
             "servers": [
                 {
+                    "name": "Auto (Recommended)",
+                    "url": "auto"
+                },
+                {
                     "name": "US: Dallas, TX",
-                    "url": "rtmp://ingest-dal.mixer.com:1935/beam"
+                    "url": "ingest-dal.mixer.com"
                 },
                 {
                     "name": "US: San Jose, CA",
-                    "url": "rtmp://ingest-sjc.mixer.com:1935/beam"
+                    "url": "ingest-sjc.mixer.com"
                 },
                 {
                     "name": "US: Seattle, WA",
-                    "url": "rtmp://ingest-sea.mixer.com:1935/beam"
+                    "url": "ingest-sea.mixer.com"
                 },
                 {
                     "name": "US: Washington DC",
-                    "url": "rtmp://ingest-wdc.mixer.com:1935/beam"
+                    "url": "ingest-wdc.mixer.com"
                 },
                 {
                     "name": "Canada: Toronto",
-                    "url": "rtmp://ingest-tor.mixer.com:1935/beam"
+                    "url": "ingest-tor.mixer.com"
                 },
                 {
                     "name": "EU: London",
-                    "url": "rtmp://ingest-lon.mixer.com:1935/beam"
+                    "url": "ingest-lon.mixer.com"
                 },
                 {
                     "name": "EU: Amsterdam",
-                    "url": "rtmp://ingest-ams.mixer.com:1935/beam"
+                    "url": "ingest-ams.mixer.com"
                 },
                 {
                     "name": "EU: Milan",
-                    "url": "rtmp://ingest-mil.mixer.com:1935/beam"
+                    "url": "ingest-mil.mixer.com"
                 },
                 {
                     "name": "EU: Paris",
-                    "url": "rtmp://ingest-par.mixer.com:1935/beam"
+                    "url": "ingest-par.mixer.com"
                 },
                 {
                     "name": "EU: Frankfurt",
-                    "url": "rtmp://ingest-fra.mixer.com:1935/beam"
+                    "url": "ingest-fra.mixer.com"
                 },
                 {
                     "name": "EU: Oslo",
-                    "url": "rtmp://ingest-osl.mixer.com:1935/beam"
+                    "url": "ingest-osl.mixer.com"
                 },
                 {
                     "name": "Brazil: Sao Paulo",
-                    "url": "rtmp://ingest-sao.mixer.com:1935/beam"
+                    "url": "ingest-sao.mixer.com"
                 },
                 {
                     "name": "Australia: Melbourne",
-                    "url": "rtmp://ingest-mel.mixer.com:1935/beam"
+                    "url": "ingest-mel.mixer.com"
                 },
                 {
                     "name": "Australia: Sydney",
-                    "url": "rtmp://ingest-syd.mixer.com:1935/beam"
+                    "url": "ingest-syd.mixer.com"
                 },
                 {
                     "name": "Mexico: Mexico City",
-                    "url": "rtmp://ingest-mex.mixer.com:1935/beam"
+                    "url": "ingest-mex.mixer.com"
                 },
                 {
                     "name": "Asia: Hong Kong",
-                    "url": "rtmp://ingest-hkg.mixer.com:1935/beam"
+                    "url": "ingest-hkg.mixer.com"
                 },
                 {
                     "name": "Asia: Tokyo",
-                    "url": "rtmp://ingest-tok.mixer.com:1935/beam"
+                    "url": "ingest-tok.mixer.com"
                 },
                 {
                     "name": "South Korea: Seoul",
-                    "url": "rtmp://ingest-seo.mixer.com:1935/beam"
+                    "url": "ingest-seo.mixer.com"
                 },
                 {
                     "name": "India: Chennai",
-                    "url": "rtmp://ingest-che.mixer.com:1935/beam"
+                    "url": "ingest-che.mixer.com"
                 }
             ],
             "recommended": {
-                "keyint": 1,
+                "keyint": 3,
+                "output": "ftl_output",
                 "max audio bitrate": 160,
                 "max video bitrate": 10000,
-                "profile": "main"
+                "profile": "main",
+                "bframes": 0
             }
         },
         {

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -281,7 +281,7 @@
             }
         },
         {
-            "name": "Mixer.com FTL",
+            "name": "Mixer.com - FTL",
             "common": true,
             "servers": [
                 {
@@ -375,7 +375,7 @@
             }
         },
         {
-            "name": "Mixer.com RTMP",
+            "name": "Mixer.com - RTMP",
             "common": true,
             "servers": [
                 {

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -281,7 +281,7 @@
             }
         },
         {
-            "name": "Mixer.com",
+            "name": "Mixer.com FTL",
             "common": true,
             "servers": [
                 {
@@ -372,6 +372,94 @@
                 "max video bitrate": 10000,
                 "profile": "main",
                 "bframes": 0
+            }
+        },
+        {
+            "name": "Mixer.com RTMP",
+            "common": true,
+            "servers": [
+                {
+                    "name": "US: Dallas, TX",
+                    "url": "rtmp://ingest-dal.mixer.com:1935/beam"
+                },
+                {
+                    "name": "US: San Jose, CA",
+                    "url": "rtmp://ingest-sjc.mixer.com:1935/beam"
+                },
+                {
+                    "name": "US: Seattle, WA",
+                    "url": "rtmp://ingest-sea.mixer.com:1935/beam"
+                },
+                {
+                    "name": "US: Washington DC",
+                    "url": "rtmp://ingest-wdc.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Canada: Toronto",
+                    "url": "rtmp://ingest-tor.mixer.com:1935/beam"
+                },
+                {
+                    "name": "EU: London",
+                    "url": "rtmp://ingest-lon.mixer.com:1935/beam"
+                },
+                {
+                    "name": "EU: Amsterdam",
+                    "url": "rtmp://ingest-ams.mixer.com:1935/beam"
+                },
+                {
+                    "name": "EU: Milan",
+                    "url": "rtmp://ingest-mil.mixer.com:1935/beam"
+                },
+                {
+                    "name": "EU: Paris",
+                    "url": "rtmp://ingest-par.mixer.com:1935/beam"
+                },
+                {
+                    "name": "EU: Frankfurt",
+                    "url": "rtmp://ingest-fra.mixer.com:1935/beam"
+                },
+                {
+                    "name": "EU: Oslo",
+                    "url": "rtmp://ingest-osl.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Brazil: Sao Paulo",
+                    "url": "rtmp://ingest-sao.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Australia: Melbourne",
+                    "url": "rtmp://ingest-mel.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Australia: Sydney",
+                    "url": "rtmp://ingest-syd.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Mexico: Mexico City",
+                    "url": "rtmp://ingest-mex.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Asia: Hong Kong",
+                    "url": "rtmp://ingest-hkg.mixer.com:1935/beam"
+                },
+                {
+                    "name": "Asia: Tokyo",
+                    "url": "rtmp://ingest-tok.mixer.com:1935/beam"
+                },
+                {
+                    "name": "South Korea: Seoul",
+                    "url": "rtmp://ingest-seo.mixer.com:1935/beam"
+                },
+                {
+                    "name": "India: Chennai",
+                    "url": "rtmp://ingest-che.mixer.com:1935/beam"
+                }
+            ],
+            "recommended": {
+                "keyint": 3,
+                "max audio bitrate": 160,
+                "max video bitrate": 10000,
+                "profile": "main"
             }
         },
         {

--- a/plugins/rtmp-services/rtmp-format-ver.h
+++ b/plugins/rtmp-services/rtmp-format-ver.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define RTMP_SERVICES_FORMAT_VERSION 1
+#define RTMP_SERVICES_FORMAT_VERSION 2


### PR DESCRIPTION
This work adds support for Mixer’s custom FTL protocol to OBS. This includes adding support for encoding OPUS audio, adding the FTL submodule, and adding a ftl-output.