### PR TITLE
Log window capture target

### DIFF
--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -461,6 +461,18 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 	glXBindTexImageEXT(xdisp, p->glxpixmap, GLX_FRONT_LEFT_EXT, NULL);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+	if (!p->windowName.empty()) {
+		blog(LOG_INFO, "[window-capture: '%s'] update settings:\n"
+				"\ttitle: %s\n"
+				"\tclass: %s",
+				obs_source_get_name(p->source),
+				XCompcap::getWindowName(p->win).c_str(),
+				XCompcap::getWindowClass(p->win).c_str());
+		blog(LOG_DEBUG, "\n"
+				"\tid:    %s",
+				std::to_string((long long)p->win).c_str());
+	}
 }
 
 void XCompcapMain::tick(float seconds)

--- a/plugins/mac-capture/mac-window-capture.m
+++ b/plugins/mac-capture/mac-window-capture.m
@@ -177,6 +177,15 @@ static inline void window_capture_update_internal(struct window_capture *wc,
 		kCGWindowImageDefault : kCGWindowImageBoundsIgnoreFraming;
 
 	update_window(&wc->window, settings);
+
+	if (wc->window.window_name.length) {
+		blog(LOG_INFO, "[window-capture: '%s'] update settings:\n"
+				"\twindow: %s\n"
+				"\towner:  %s",
+				obs_source_get_name(wc->source),
+				[wc->window.window_name UTF8String],
+				[wc->window.owner_name UTF8String]);
+	}
 }
 
 static void window_capture_update(void *data, obs_data_t *settings)

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -43,6 +43,15 @@ static void update_settings(struct window_capture *wc, obs_data_t *s)
 
 	build_window_strings(window, &wc->class, &wc->title, &wc->executable);
 
+	if (wc->title != NULL) {
+		blog(LOG_INFO, "[window-capture: '%s'] update settings:\n"
+				"\ttitle:      %s\n"
+				"\texecutable: %s",
+				obs_source_get_name(wc->source), wc->title,
+				wc->executable);
+		blog(LOG_DEBUG, "\tclass:      %s", wc->class);
+	}
+
 	wc->priority      = (enum window_priority)priority;
 	wc->cursor        = obs_data_get_bool(s, "cursor");
 	wc->use_wildcards = obs_data_get_bool(s, "use_wildcards");


### PR DESCRIPTION
Letting this rot on my local repo, so here's a PR.  This PR logs data about window capture targets when window capture sources are created or updated.  This is something that @Fenrirthviti had requested in order to make it easier for those who provide support to OBS users to verify user settings.  This PR is presented as three commits to three components/plugins, but they can be squashed if needed.

I have compiled and tested these changes on Windows 10 Pro 64-bit and Ubuntu 16.04 32-bit.  A gist of the patch along with log examples from my testing can be found [here](https://gist.github.com/RytoEX/ca71b5356a0242e4658002af99dacdde).  I cannot compile and test for Mac, so tests on Mac for this PR would be appreciated.

Feedback on the presentation of the window capture information in log files would be appreciated.  I'm aware that the Linux logging is a bit odd.  That is a side effect of the existing window capture logging code on Linux.