### PR TITLE
UI: Fix stats window geometry saving

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2938,7 +2938,7 @@ void OBSBasic::CloseDialogs()
 		projector.clear();
 	}
 
-	delete stats;
+	if (!stats.isNull()) stats->close(); //call close to save Stats geometry
 }
 
 void OBSBasic::EnumDialogs()


### PR DESCRIPTION
Possible fix for: https://obsproject.com/mantis/view.php?id=923

If you close whole application (not just Stats window) it skips the
close event and thus saving of the geometry.