### PR TITLE
CMake: Add fix for FHS compliant distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 include(ObsHelpers)
 include(ObsCpack)
 include(GNUInstallDirs)
+add_definitions(-DFFMPEG_MUX_FIXED=\"/usr/libexec/obs-plugins/obs-ffmpeg/ffmpeg-mux\")
 
 if(MSVC AND NOT EXISTS "${CMAKE_BINARY_DIR}/ALL_BUILD.vcxproj.user")
 	file(GENERATE

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -237,7 +237,11 @@ static void build_command_line(struct ffmpeg_muxer *stream, struct dstr *cmd,
 		num_tracks++;
 	}
 
+#ifdef FFMPEG_MUX_FIXED
+	dstr_init_copy(cmd, FFMPEG_MUX_FIXED);
+#else
 	dstr_init_move_array(cmd, obs_module_file(FFMPEG_MUX));
+#endif
 	dstr_insert_ch(cmd, 0, '\"');
 	dstr_cat(cmd, "\" \"");
 


### PR DESCRIPTION
This attempts to fix the issue presented in:

https://obsproject.com/mantis/view.php?id=273

This allows someone to build with the -DFFMPEG_MUX_FIXED CMake flag to
output the FFMpeg muxer to the correct directory structure for those
distributrions. I am not the original author of this fix, I am just
presenting it as a PR for discussion and review.