### PR TITLE
UI: Fix Delete key not working on scenes/sources

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -86,6 +86,7 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
+            <addaction name="actionRemoveSource"/>
            </widget>
           </item>
          </layout>
@@ -400,6 +401,7 @@
           <property name="defaultDropAction">
            <enum>Qt::TargetMoveAction</enum>
           </property>
+          <addaction name="actionRemoveScene"/>
          </widget>
         </item>
         <item>
@@ -531,6 +533,7 @@
           <property name="selectionMode">
            <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
+          <addaction name="actionRemoveSource"/>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
This commit fixes two regressions introduced by the modular UI (commit
25bb8a444fb3a7ca6c19a429f2d89e83a6ddb823):

- the Delete key no longer working in the scene list
- the Delete key no longer working in the source list

This commit also enables the Delete key on sources that were selected by clicking on them in the preview, which addresses [Mantis Bug 576](https://obsproject.com/mantis/view.php?id=576).

Originally, I had added code for enabling the Delete key on sources selected in the preview by adapting it from the code for adding the "nudge" hotkeys.  After going over the generated UI code, I figured I could attach the "actionRemoveSource" action to the preview widget instead of handwriting additional code for it.  I'm all ears for any feedback on better ways to do this.

All of this was compiled and tested on Windows 10 Pro 64-bit.