### PR TITLE
Add fix to watch for VisibilityNotify events.

### DIFF
--- a/plugins/linux-capture/xcompcap-helper.cpp
+++ b/plugins/linux-capture/xcompcap-helper.cpp
@@ -267,6 +267,9 @@ namespace XCompcap
 			if (ev.type == Expose)
 				changedWindows.insert(ev.xexpose.window);
 
+			if (ev.type == VisibilityNotify)
+				changedWindows.insert(ev.xvisibility.window);
+
 			if (ev.type == DestroyNotify)
 				changedWindows.insert(ev.xdestroywindow.event);
 		}

--- a/plugins/linux-capture/xcompcap-main.cpp
+++ b/plugins/linux-capture/xcompcap-main.cpp
@@ -318,7 +318,10 @@ void XCompcapMain::updateSettings(obs_data_t *settings)
 	}
 
 	if (p->win)
-		XSelectInput(xdisp, p->win, StructureNotifyMask | ExposureMask);
+		XSelectInput(xdisp, p->win,
+			StructureNotifyMask
+			| ExposureMask
+			| VisibilityChangeMask);
 	XSync(xdisp, 0);
 
 	XWindowAttributes attr;


### PR DESCRIPTION
Some window managers like i3 don't issue Expose events when switching
between workspaces, but send VisibilityNotify events. This causes the
stream to freeze even when the workspace is switched back.

Related issue: https://obsproject.com/mantis/view.php?id=863