### PR TITLE
linux-pulseaudio: Use actual sink device names instead of monitor names

### DIFF
--- a/plugins/linux-pulseaudio/pulse-input.c
+++ b/plugins/linux-pulseaudio/pulse-input.c
@@ -343,15 +343,15 @@ skip:
 /**
  * output info callback
  */
-static void pulse_output_info(pa_context *c, const pa_source_info *i, int eol,
+static void pulse_output_info(pa_context *c, const pa_sink_info *i, int eol,
 	void *userdata)
 {
 	UNUSED_PARAMETER(c);
-	if (eol != 0 || i->monitor_of_sink == PA_INVALID_INDEX)
+	if (eol != 0 || i->monitor_source == PA_INVALID_INDEX)
 		goto skip;
 
 	obs_property_list_add_string((obs_property_t*) userdata,
-		i->description, i->name);
+		i->description, i->monitor_source_name);
 
 skip:
 	pulse_signal(0);
@@ -368,8 +368,10 @@ static obs_properties_t *pulse_properties(bool input)
 		OBS_COMBO_FORMAT_STRING);
 
 	pulse_init();
-	pa_source_info_cb_t cb = (input) ? pulse_input_info : pulse_output_info;
-	pulse_get_source_info_list(cb, (void *) devices);
+	if (input)
+		pulse_get_source_info_list(pulse_input_info, (void *) devices);
+	else
+		pulse_get_sink_info_list(pulse_output_info, (void *) devices);
 	pulse_unref();
 
 	return props;

--- a/plugins/linux-pulseaudio/pulse-wrapper.c
+++ b/plugins/linux-pulseaudio/pulse-wrapper.c
@@ -185,6 +185,28 @@ int_fast32_t pulse_get_source_info_list(pa_source_info_cb_t cb, void* userdata)
 	return 0;
 }
 
+int_fast32_t pulse_get_sink_info_list(pa_sink_info_cb_t cb, void *userdata)
+{
+	if (pulse_context_ready() < 0)
+		return -1;
+
+	pulse_lock();
+
+	pa_operation *op = pa_context_get_sink_info_list(
+		pulse_context, cb, userdata);
+	if (!op) {
+		pulse_unlock();
+		return -1;
+	}
+	while (pa_operation_get_state(op) == PA_OPERATION_RUNNING)
+		pulse_wait();
+	pa_operation_unref(op);
+
+	pulse_unlock();
+
+	return 0;
+}
+
 int_fast32_t pulse_get_source_info(pa_source_info_cb_t cb, const char *name,
 	void *userdata)
 {

--- a/plugins/linux-pulseaudio/pulse-wrapper.h
+++ b/plugins/linux-pulseaudio/pulse-wrapper.h
@@ -94,6 +94,20 @@ void pulse_accept();
 int_fast32_t pulse_get_source_info_list(pa_source_info_cb_t cb, void *userdata);
 
 /**
+ * Request sink information
+ *
+ * The function will block until the operation was executed and the mainloop
+ * called the provided callback function.
+ *
+ * @return negative on error
+ *
+ * @note The function will block until the server context is ready.
+ *
+ * @warning call without active locks
+ */
+int_fast32_t pulse_get_sink_info_list(pa_sink_info_cb_t cb, void *userdata);
+
+/**
  * Request source information from a specific source
  *
  * The function will block until the operation was executed and the mainloop


### PR DESCRIPTION
OBS should use the actual name of the output device in the device selection for pulse audio output sources and not the name of the monitor device. With this the output device selection for PR #940 should make more sense, since using an input device for audio monitoring makes no sense.

I kept the name of the device id that is stored in the properties the same as before including the ".montior" also I think it would make much more sense to just store the name of the actual output device and lookup the monitoring device when it is needed. But that would require that all users have to reconfigure their audio devices.