### PR TITLE
libobs-d3d11, libobs-opengl: Don't deallocate foreign memory

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1768,12 +1768,19 @@ OBSBasic::~OBSBasic()
 			OBSBasic::RenderMain, this);
 
 	obs_enter_graphics();
-	gs_vertexbuffer_destroy(box);
-	gs_vertexbuffer_destroy(boxLeft);
-	gs_vertexbuffer_destroy(boxTop);
-	gs_vertexbuffer_destroy(boxRight);
-	gs_vertexbuffer_destroy(boxBottom);
-	gs_vertexbuffer_destroy(circle);
+	gs_vertbuffer_t* vbs[] = {
+		box,
+		boxLeft,
+		boxTop,
+		boxRight,
+		boxBottom,
+		circle
+	};
+	for (auto vb : vbs) {
+		struct gs_vb_data *vbd = gs_vertexbuffer_get_data(vb);
+		gs_vertexbuffer_destroy(vb);
+		gs_vbdata_destroy(vbd);
+	}
 	obs_leave_graphics();
 
 	/* When shutting down, sometimes source references can get in to the

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -201,7 +201,7 @@ struct VBDataPtr {
 	gs_vb_data *data;
 
 	inline VBDataPtr(gs_vb_data *data) : data(data) {}
-	inline ~VBDataPtr() {gs_vbdata_destroy(data);}
+	inline ~VBDataPtr() {}
 };
 
 enum class gs_type {
@@ -278,7 +278,7 @@ struct DataPtr {
 	void *data;
 
 	inline DataPtr(void *data) : data(data) {}
-	inline ~DataPtr() {bfree(data);}
+	inline ~DataPtr() {}
 };
 
 struct gs_index_buffer : gs_obj {

--- a/libobs-opengl/gl-indexbuffer.c
+++ b/libobs-opengl/gl-indexbuffer.c
@@ -26,7 +26,6 @@ static inline bool init_ib(struct gs_index_buffer *ib)
 			ib->size, ib->data, usage);
 
 	if (!ib->dynamic) {
-		bfree(ib->data);
 		ib->data = NULL;
 	}
 
@@ -65,7 +64,6 @@ void gs_indexbuffer_destroy(gs_indexbuffer_t *ib)
 		if (ib->buffer)
 			gl_delete_buffers(1, &ib->buffer);
 
-		bfree(ib->data);
 		bfree(ib);
 	}
 }

--- a/libobs-opengl/gl-vertexbuffer.c
+++ b/libobs-opengl/gl-vertexbuffer.c
@@ -66,7 +66,6 @@ static bool create_buffers(struct gs_vertex_buffer *vb)
 	}
 
 	if (!vb->dynamic) {
-		gs_vbdata_destroy(vb->data);
 		vb->data = NULL;
 	}
 
@@ -114,7 +113,6 @@ void gs_vertexbuffer_destroy(gs_vertbuffer_t *vb)
 
 		da_free(vb->uv_sizes);
 		da_free(vb->uv_buffers);
-		gs_vbdata_destroy(vb->data);
 
 		bfree(vb);
 	}

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -592,7 +592,9 @@ void gs_render_stop(enum gs_draw_mode mode)
 		gs_load_indexbuffer(NULL);
 		gs_draw(mode, 0, 0);
 
+		struct gs_vb_data *vbd = gs_vertexbuffer_get_data(vb);
 		gs_vertexbuffer_destroy(vb);
+		gs_vbdata_destroy(vbd);
 	}
 
 	graphics->vbd = NULL;

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -197,7 +197,9 @@ static void ft2_source_destroy(void *data)
 		srcdata->tex = NULL;
 	}
 	if (srcdata->vbuf != NULL) {
+		struct gs_vb_data *vbd = gs_vertexbuffer_get_data(srcdata->vbuf);
 		gs_vertexbuffer_destroy(srcdata->vbuf);
+		gs_vbdata_destroy(vbd);
 		srcdata->vbuf = NULL;
 	}
 	if (srcdata->draw_effect != NULL) {

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -97,7 +97,9 @@ void set_up_vertex_buffer(struct ft2_source *srcdata)
 	if (srcdata->vbuf != NULL) {
 		gs_vertbuffer_t *tmpvbuf = srcdata->vbuf;
 		srcdata->vbuf = NULL;
+		struct gs_vb_data *vbd = gs_vertexbuffer_get_data(tmpvbuf);
 		gs_vertexbuffer_destroy(tmpvbuf);
+		gs_vbdata_destroy(vbd);
 	}
 
 	if (*srcdata->text == 0) {


### PR DESCRIPTION
Changes the deallocation behaviour of either data to be manual in order to allow the calling application to use predetermined points in memory without encountering unexpected crashes.

Fixes: https://obsproject.com/mantis/view.php?id=907