### PR TITLE
rtmp-services: Fix misspelled country name

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 70,
+	"version": 71,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 70
+			"version": 71
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -106,7 +106,7 @@
                     "url": "rtmp://live-lim.twitch.tv/app"
                 },
                 {
-                    "name": "South America: Medellin, Columbia",
+                    "name": "South America: Medellin, Colombia",
                     "url": "rtmp://live-mde.twitch.tv/app"
                 },
                 {


### PR DESCRIPTION
That said "Columbia", and not "Colombia".
https://en.wikipedia.org/wiki/Medell%C3%ADn

Many people in USA are confusing with this name, but well, here is the fix :)