### PR TITLE
UI: Fix conditions for redraw the stats labels

### DIFF
--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -240,7 +240,7 @@ void OBSBasicStats::Update()
 	obs_output_release(strOutput);
 	obs_output_release(recOutput);
 
-	if (!strOutput || !recOutput)
+	if (!strOutput && !recOutput)
 		return;
 
 	/* ------------------------------------------- */


### PR DESCRIPTION
After the commit:
https://github.com/jp9000/obs-studio/commit/3491487c71cb5e53365bd03ff7cb691e23268382

obs_frontend_get_streaming_output() returns NULL if "Start Streaming"
button not pressed yet. And due to short logic, update the labels is
skipped, and thus Stats window stays empty if you only Recording.