### PR TITLE
libobs: Add default hotkey id to duplicated item

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1119,6 +1119,9 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 			new_item->bounds_align = item->bounds_align;
 			new_item->bounds = item->bounds;
 
+			new_item->toggle_visibility =
+				OBS_INVALID_HOTKEY_PAIR_ID;
+			
 			obs_sceneitem_set_crop(new_item, &item->crop);
 
 			if (!new_item->item_render &&

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1120,7 +1120,7 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 			new_item->bounds = item->bounds;
 
 			new_item->toggle_visibility =
-				OBS_INVALID_HOTKEY_PAIR_ID;
+					OBS_INVALID_HOTKEY_PAIR_ID;
 			
 			obs_sceneitem_set_crop(new_item, &item->crop);
 


### PR DESCRIPTION
Fixes https://obsproject.com/mantis/view.php?id=508

The toggle_visibility set only by init_hotkeys() call, but used each
time in obs_sceneitem_destroy() call. Because zero hotkey_pair_id is 
valid - we need to set item property other than zero here.