### PR TITLE
UI: Allow volume peak to be customized via .qss

### DIFF
--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -671,9 +671,11 @@ QProgressBar::chunk {
 
 VolumeMeter {
 	qproperty-bkColor: rgb(35, 38, 41); /* Dark Gray */
-	qproperty-magColor: rgb(186, 45, 101); /* Dark Pink (Secondary Dark) */
-	qproperty-peakColor: rgb(240, 98, 146); /* Pink (Secondary) */
-	qproperty-peakHoldColor: rgb(255, 148, 194); /* Light Pink (Secondary Light) */
+	qproperty-magColor: rgb(153, 204, 0);
+	qproperty-peakColor: rgb(96, 128, 0);
+	qproperty-peakHoldColor: rgb(210, 255, 77);
+	qproperty-clipColor1: rgb(230, 40, 50);
+	qproperty-clipColor2: rgb(140, 0, 40);
 }
 
 /*******************/
@@ -718,8 +720,6 @@ QPushButton:disabled {
 	border: 1px solid rgb(0, 139, 163); /* Dark Cyan (Primary Dark) */
 	color: rgb(162, 161, 162); /* Lighter Gray */
 }
-
-
 
 /******************************/
 /* --- Dialog Box Buttons --- */

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -255,6 +255,26 @@ void VolumeMeter::setPeakHoldColor(QColor c)
 	peakHoldColor = c;
 }
 
+QColor VolumeMeter::getClipColor1() const
+{
+	return clipColor1;
+}
+
+void VolumeMeter::setClipColor1(QColor c)
+{
+	clipColor1 = c;
+}
+
+QColor VolumeMeter::getClipColor2() const
+{
+	return clipColor2;
+}
+
+void VolumeMeter::setClipColor2(QColor c)
+{
+	clipColor2 = c;
+}
+
 
 VolumeMeter::VolumeMeter(QWidget *parent)
 			: QWidget(parent)

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -17,6 +17,8 @@ class VolumeMeter : public QWidget
 	Q_PROPERTY(QColor magColor READ getMagColor WRITE setMagColor DESIGNABLE true)
 	Q_PROPERTY(QColor peakColor READ getPeakColor WRITE setPeakColor DESIGNABLE true)
 	Q_PROPERTY(QColor peakHoldColor READ getPeakHoldColor WRITE setPeakHoldColor DESIGNABLE true)
+	Q_PROPERTY(QColor clipColor1 READ getClipColor1 WRITE setClipColor1 DESIGNABLE true)
+	Q_PROPERTY(QColor clipColor2 READ getClipColor2 WRITE setClipColor2 DESIGNABLE true)
 
 private:
 	static QWeakPointer<VolumeMeterTimer> updateTimer;
@@ -46,6 +48,10 @@ public:
 	void setPeakColor(QColor c);
 	QColor getPeakHoldColor() const;
 	void setPeakHoldColor(QColor c);
+	QColor getClipColor1() const;
+	void setClipColor1(QColor c);
+	QColor getClipColor2() const;
+	void setClipColor2(QColor c);
 
 protected:
 	void paintEvent(QPaintEvent *event);


### PR DESCRIPTION
With the addition of the peak volume indicator, themes may wish to change
these colors but there was no way to do so. This change updates the
VolumeControl widget to allow a stylesheet to adjust all possible colors
for the volume bar. In addtion, the Rachni theme is updated to demonstrate
this new capability.