### PR TITLE
rtmp-services: Update ingest list for Restream.io

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 68,
+	"version": 69,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 68
+			"version": 69
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -627,12 +627,20 @@
                     "url": "rtmp://eu-ams.restream.io/live"
                 },
                 {
+                    "name": "EU-West (Luxembourg)",
+                    "url": "rtmp://eu-luxembourg.restream.io/live"
+                },
+                {
                     "name": "EU-Central (Frankfurt, DE)",
                     "url": "rtmp://eu-central.restream.io/live"
                 },
                 {
                     "name": "EU-East (Falkenstein, DE)",
                     "url": "rtmp://eu-east.restream.io/live"
+                },
+                {
+                    "name": "EU-South (Madrid, Spain)",
+                    "url": "rtmp://eu-madrid.restream.io/live"
                 },
                 {
                     "name": "Russia (Moscow)",


### PR DESCRIPTION
Update ingest list for Restream.io:
- add new Restream ingests: EU-South (Madrid, Spain), EU-West (Luxembourg)
- update rtmp-services version

Restream ingests could be checked at: https://restream.io/ingests
