### PR TITLE
ui: Change default recording format to MKV from FLV

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -989,7 +989,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_string(basicConfig, "SimpleOutput", "FilePath",
 			GetDefaultVideoSavePath().c_str());
 	config_set_default_string(basicConfig, "SimpleOutput", "RecFormat",
-			"flv");
+			"mkv");
 	config_set_default_uint  (basicConfig, "SimpleOutput", "VBitrate",
 			2500);
 	config_set_default_string(basicConfig, "SimpleOutput", "StreamEncoder",
@@ -1021,7 +1021,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 
 	config_set_default_string(basicConfig, "AdvOut", "RecFilePath",
 			GetDefaultVideoSavePath().c_str());
-	config_set_default_string(basicConfig, "AdvOut", "RecFormat", "flv");
+	config_set_default_string(basicConfig, "AdvOut", "RecFormat", "mkv");
 	config_set_default_bool  (basicConfig, "AdvOut", "RecUseRescale",
 			false);
 	config_set_default_uint  (basicConfig, "AdvOut", "RecTracks", (1<<0));


### PR DESCRIPTION
Each day someone records with OBS and doesn't know what FLV is or why they have one now. Even worse, someone will then deliver that FLV to someone else without having any idea what to do with it.

For just one commit a month you could end this silent tragedy happening in your neighborhoods.

![please help my adorable spongey brained friends](https://i.imgur.com/5iRRlKd.png)