### PR TITLE
UI: Use Qt standard buttons for source properties dialog

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -49,13 +49,9 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	int cy = (int)config_get_int(App()->GlobalConfig(), "PropertiesWindow",
 			"cy");
 
-	QPushButton *b;
-	b = buttonBox->addButton(QTStr("OK"), QDialogButtonBox::AcceptRole);
-	buttonBox->addButton(QTStr("Cancel"), QDialogButtonBox::RejectRole);
-	buttonBox->addButton(QTStr("Defaults"), QDialogButtonBox::ResetRole);
 	buttonBox->setObjectName(QStringLiteral("buttonBox"));
-
-	b->setDefault(true);
+	buttonBox->setStandardButtons(QDialogButtonBox::Ok |
+			QDialogButtonBox::Cancel | QDialogButtonBox::RestoreDefaults);
 
 	if (cx > 400 && cy > 400)
 		resize(cx, cy);
@@ -92,7 +88,7 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	setLayout(new QVBoxLayout(this));
 	layout()->addWidget(windowSplitter);
 	layout()->addWidget(buttonBox);
-	layout()->setAlignment(buttonBox, Qt::AlignRight | Qt::AlignBottom);
+	layout()->setAlignment(buttonBox, Qt::AlignBottom);
 
 	view->show();
 	installEventFilter(CreateShortcutFilter());


### PR DESCRIPTION
Use the Qt standard buttons in the source properties dialog to make
the UI consistent. Also remove the right alignment of the button box
to allow Qt to align standard buttons on the left side of the dialog.

![obs_buttons](https://user-images.githubusercontent.com/141426/29566105-e1c8d10c-8748-11e7-9a03-1ba813a62c7c.png)

Inspired by https://twitter.com/dayzrustream/status/899792397504139264 :smiley: