### PR TITLE
libobs: Add navigation keys to obs_key_event

### DIFF
--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -215,37 +215,35 @@ static int TranslateQtMouseEventModifiers(
 	return modifiers;
 }
 
-static int TranslateQtNavigationKeys(
-	QKeyEvent *event)
+static int TranslateQtNavigationKeys(QKeyEvent *event)
 {
 	int navkeys = NAVKEY_NONE;
 
-	switch (event->key())
-	{
-		case Qt::Key_Up:
-			navkeys |= NAVKEY_UP;
-			break;
-		case Qt::Key_Down:
-			navkeys |= NAVKEY_DOWN;
-			break;
-		case Qt::Key_Left:
-			navkeys |= NAVKEY_LEFT;
-			break;
-		case Qt::Key_Right:
-			navkeys |= NAVKEY_RIGHT;
-			break;
-		case Qt::Key_Home:
-			navkeys |= NAVKEY_START;
-			break;
-		case Qt::Key_End:
-			navkeys |= NAVKEY_END;
-			break;
-		case Qt::Key_PageUp:
-			navkeys |= NAVKEY_PREVPAGE;
-			break;
-		case Qt::Key_PageDown:
-			navkeys |= NAVKEY_NEXTPAGE;
-			break;
+	switch (event->key()) {
+	case Qt::Key_Up:
+		navkeys |= NAVKEY_UP;
+		break;
+	case Qt::Key_Down:
+		navkeys |= NAVKEY_DOWN;
+		break;
+	case Qt::Key_Left:
+		navkeys |= NAVKEY_LEFT;
+		break;
+	case Qt::Key_Right:
+		navkeys |= NAVKEY_RIGHT;
+		break;
+	case Qt::Key_Home:
+		navkeys |= NAVKEY_START;
+		break;
+	case Qt::Key_End:
+		navkeys |= NAVKEY_END;
+		break;
+	case Qt::Key_PageUp:
+		navkeys |= NAVKEY_PREVPAGE;
+		break;
+	case Qt::Key_PageDown:
+		navkeys |= NAVKEY_NEXTPAGE;
+		break;
 	}
 
 	return navkeys;

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -215,6 +215,42 @@ static int TranslateQtMouseEventModifiers(
 	return modifiers;
 }
 
+static int TranslateQtNavigationKeys(
+	QKeyEvent *event)
+{
+	int navkeys = NAVKEY_NONE;
+
+	switch (event->key())
+	{
+		case Qt::Key_Up:
+			navkeys |= NAVKEY_UP;
+			break;
+		case Qt::Key_Down:
+			navkeys |= NAVKEY_DOWN;
+			break;
+		case Qt::Key_Left:
+			navkeys |= NAVKEY_LEFT;
+			break;
+		case Qt::Key_Right:
+			navkeys |= NAVKEY_RIGHT;
+			break;
+		case Qt::Key_Home:
+			navkeys |= NAVKEY_START;
+			break;
+		case Qt::Key_End:
+			navkeys |= NAVKEY_END;
+			break;
+		case Qt::Key_PageUp:
+			navkeys |= NAVKEY_PREVPAGE;
+			break;
+		case Qt::Key_PageDown:
+			navkeys |= NAVKEY_NEXTPAGE;
+			break;
+	}
+
+	return navkeys;
+}
+
 bool OBSBasicInteraction::GetSourceRelativeXY(
       int mouseX, int mouseY, int &relX, int &relY)
 {
@@ -355,7 +391,7 @@ bool OBSBasicInteraction::HandleKeyEvent(QKeyEvent *event)
 	keyEvent.native_modifiers = event->nativeModifiers();
 	keyEvent.native_scancode = event->nativeScanCode();
 	keyEvent.native_vkey = event->nativeVirtualKey();
-
+	keyEvent.navigation_keys = TranslateQtNavigationKeys(event);
 	bool keyUp = event->type() == QEvent::KeyRelease;
 
 	obs_source_send_key_click(source, &keyEvent, keyUp);

--- a/libobs/obs-interaction.h
+++ b/libobs/obs-interaction.h
@@ -41,17 +41,16 @@ enum obs_mouse_button_type {
 	MOUSE_RIGHT
 };
 
-enum obs_navigation_key_flags
-{
-	NAVKEY_NONE		= 0,
-	NAVKEY_LEFT		= 1,
-	NAVKEY_RIGHT	= 1 << 1,
-	NAVKEY_UP		= 1 << 2,
-	NAVKEY_DOWN		= 1 << 3,
-	NAVKEY_START	= 1 << 4,
-	NAVKEY_END		= 1 << 5,
-	NAVKEY_NEXTPAGE = 1 << 6,
-	NAVKEY_PREVPAGE = 1 << 7
+enum obs_navigation_key_flags {
+	NAVKEY_NONE            = 0,
+	NAVKEY_LEFT            = 1,
+	NAVKEY_RIGHT           = 1 << 1,
+	NAVKEY_UP              = 1 << 2,
+	NAVKEY_DOWN            = 1 << 3,
+	NAVKEY_START           = 1 << 4,
+	NAVKEY_END             = 1 << 5,
+	NAVKEY_NEXTPAGE        = 1 << 6,
+	NAVKEY_PREVPAGE        = 1 << 7
 };
 
 struct obs_mouse_event {
@@ -63,7 +62,7 @@ struct obs_mouse_event {
 struct obs_key_event {
 	uint32_t            modifiers;
 	char                *text;
-	uint32_t			navigation_keys;
+	uint32_t            navigation_keys;
 	uint32_t            native_modifiers;
 	uint32_t            native_scancode;
 	uint32_t            native_vkey;

--- a/libobs/obs-interaction.h
+++ b/libobs/obs-interaction.h
@@ -41,6 +41,19 @@ enum obs_mouse_button_type {
 	MOUSE_RIGHT
 };
 
+enum obs_navigation_key_flags
+{
+	NAVKEY_NONE		= 0,
+	NAVKEY_LEFT		= 1,
+	NAVKEY_RIGHT	= 1 << 1,
+	NAVKEY_UP		= 1 << 2,
+	NAVKEY_DOWN		= 1 << 3,
+	NAVKEY_START	= 1 << 4,
+	NAVKEY_END		= 1 << 5,
+	NAVKEY_NEXTPAGE = 1 << 6,
+	NAVKEY_PREVPAGE = 1 << 7
+};
+
 struct obs_mouse_event {
 	uint32_t            modifiers;
 	int32_t             x;
@@ -50,6 +63,7 @@ struct obs_mouse_event {
 struct obs_key_event {
 	uint32_t            modifiers;
 	char                *text;
+	uint32_t			navigation_keys;
 	uint32_t            native_modifiers;
 	uint32_t            native_scancode;
 	uint32_t            native_vkey;


### PR DESCRIPTION
Add the navigation_keys field to obs_key_event and populate it with a
bitfield indicating which navigation keys (arrows, page up/down, etc)
are pressed. This allows sources which provide interaction to handle
these keys without depending on Qt to map them or using native key
codes.