### PR TITLE
UI: Enable Replay Buffer in Advanced Mode

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -666,106 +666,20 @@
           <number>0</number>
          </property>
          <item>
-         <widget class="QScrollArea" name="scrollArea_3">
-          <property name="widgetResizable">
-           <bool>true</bool>
-          </property>
-          <widget class="QWidget" name="scrollAreaWidgetContents_3">
-           <property name="geometry">
-            <rect>
-             <x>0</x>
-             <y>0</y>
-             <width>818</width>
-             <height>697</height>
-            </rect>
+          <widget class="QScrollArea" name="scrollArea_3">
+           <property name="widgetResizable">
+            <bool>true</bool>
            </property>
-           <layout class="QVBoxLayout" name="verticalLayout_21">
-            <property name="leftMargin">
-             <number>0</number>
+           <widget class="QWidget" name="scrollAreaWidgetContents_3">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>818</width>
+              <height>697</height>
+             </rect>
             </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="rightMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>9</number>
-            </property>
-         <item alignment="Qt::AlignTop">
-          <widget class="QWidget" name="widget" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <layout class="QFormLayout" name="formLayout_5">
-            <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="outputModeLabel">
-              <property name="minimumSize">
-               <size>
-                <width>170</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Basic.Settings.Output.Mode</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="buddy">
-               <cstring>outputMode</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="outputMode">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="currentIndex">
-               <number>0</number>
-              </property>
-              <item>
-               <property name="text">
-                <string>Basic.Settings.Output.Mode.Simple</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Basic.Settings.Output.Mode.Adv</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="Line" name="line_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QStackedWidget" name="outputModePages">
-           <property name="currentIndex">
-            <number>0</number>
-           </property>
-           <widget class="QWidget" name="easyOutputsPage">
-            <layout class="QVBoxLayout" name="verticalLayout_3">
+            <layout class="QVBoxLayout" name="verticalLayout_21">
              <property name="leftMargin">
               <number>0</number>
              </property>
@@ -776,28 +690,22 @@
               <number>0</number>
              </property>
              <property name="bottomMargin">
-              <number>0</number>
+              <number>9</number>
              </property>
-             <item>
-              <widget class="QGroupBox" name="groupBox_8">
+             <item alignment="Qt::AlignTop">
+              <widget class="QWidget" name="widget" native="true">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
-               <property name="title">
-                <string>Basic.Settings.Output.Adv.Streaming</string>
-               </property>
-               <layout class="QFormLayout" name="formLayout_20">
+               <layout class="QFormLayout" name="formLayout_5">
                 <property name="fieldGrowthPolicy">
                  <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                 </property>
-                <property name="labelAlignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
                 <item row="0" column="0">
-                 <widget class="QLabel" name="label_19">
+                 <widget class="QLabel" name="outputModeLabel">
                   <property name="minimumSize">
                    <size>
                     <width>170</width>
@@ -805,496 +713,526 @@
                    </size>
                   </property>
                   <property name="text">
-                   <string>Basic.Settings.Output.VideoBitrate</string>
+                   <string>Basic.Settings.Output.Mode</string>
                   </property>
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                   </property>
                   <property name="buddy">
-                   <cstring>simpleOutputVBitrate</cstring>
+                   <cstring>outputMode</cstring>
                   </property>
                  </widget>
                 </item>
                 <item row="0" column="1">
-                 <widget class="QSpinBox" name="simpleOutputVBitrate">
-                  <property name="minimum">
-                   <number>200</number>
-                  </property>
-                  <property name="maximum">
-                   <number>1000000</number>
-                  </property>
-                  <property name="value">
-                   <number>2000</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="label_20">
-                  <property name="text">
-                   <string>Basic.Settings.Output.AudioBitrate</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutputABitrate</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="1">
-                 <widget class="QComboBox" name="simpleOutputABitrate">
-                  <property name="currentIndex">
-                   <number>8</number>
-                  </property>
-                  <item>
-                   <property name="text">
-                    <string>32</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>48</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>64</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>80</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>96</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>112</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>128</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>160</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>192</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>256</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>320</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QCheckBox" name="simpleOutAdvanced">
-                  <property name="text">
-                   <string>Basic.Settings.Output.Advanced</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item row="5" column="1">
-                 <widget class="QComboBox" name="simpleOutPreset"/>
-                </item>
-                <item row="5" column="0">
-                 <widget class="QLabel" name="label_24">
+                 <widget class="QComboBox" name="outputMode">
                   <property name="enabled">
                    <bool>true</bool>
                   </property>
-                  <property name="text">
-                   <string>Basic.Settings.Output.EncoderPreset</string>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
-                  <property name="buddy">
-                   <cstring>simpleOutPreset</cstring>
+                  <property name="currentIndex">
+                   <number>0</number>
                   </property>
-                 </widget>
-                </item>
-                <item row="6" column="0">
-                 <widget class="QLabel" name="label_23">
-                  <property name="text">
-                   <string>Basic.Settings.Output.CustomEncoderSettings</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutCustom</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="6" column="1">
-                 <widget class="QLineEdit" name="simpleOutCustom"/>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QCheckBox" name="simpleOutEnforce">
-                  <property name="text">
-                   <string>Basic.Settings.Output.EnforceBitrate</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QComboBox" name="simpleOutStrEncoder"/>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="simpleOutRecEncoderLabel_2">
-                  <property name="text">
-                   <string>Basic.Settings.Output.Encoder</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutRecEncoder</cstring>
-                  </property>
+                  <item>
+                   <property name="text">
+                    <string>Basic.Settings.Output.Mode.Simple</string>
+                   </property>
+                  </item>
+                  <item>
+                   <property name="text">
+                    <string>Basic.Settings.Output.Mode.Adv</string>
+                   </property>
+                  </item>
                  </widget>
                 </item>
                </layout>
               </widget>
              </item>
              <item>
-              <widget class="QGroupBox" name="simpleRecordingGroupBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="title">
-                <string>Basic.Settings.Output.Adv.Recording</string>
-               </property>
-               <layout class="QFormLayout" name="formLayout_6">
-                <property name="fieldGrowthPolicy">
-                 <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                </property>
-                <property name="labelAlignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="label_18">
-                  <property name="minimumSize">
-                   <size>
-                    <width>170</width>
-                    <height>0</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Basic.Settings.Output.Simple.SavePath</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutputPath</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <layout class="QHBoxLayout" name="horizontalLayout_5">
-                  <item>
-                   <widget class="QLineEdit" name="simpleOutputPath">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="simpleOutputBrowse">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="text">
-                     <string>Browse</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QCheckBox" name="simpleNoSpace">
-                  <property name="text">
-                   <string>Basic.Settings.Output.NoSpaceFileName</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="0">
-                 <widget class="QLabel" name="label_26">
-                  <property name="text">
-                   <string>Basic.Settings.Output.Simple.RecordingQuality</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutRecQuality</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="1">
-                 <widget class="QComboBox" name="simpleOutRecQuality"/>
-                </item>
-                <item row="3" column="0">
-                 <widget class="QLabel" name="simpleOutRecFormatLabel">
-                  <property name="text">
-                   <string>Basic.Settings.Output.Format</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutRecFormat</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QComboBox" name="simpleOutRecFormat">
-                  <item>
-                   <property name="text">
-                    <string notr="true">flv</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">mp4</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">mov</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">mkv</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">ts</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string notr="true">m3u8</string>
-                   </property>
-                  </item>
-                 </widget>
-                </item>
-                <item row="4" column="0">
-                 <widget class="QLabel" name="simpleOutRecEncoderLabel">
-                  <property name="text">
-                   <string>Basic.Settings.Output.Encoder</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutRecEncoder</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="4" column="1">
-                 <widget class="QComboBox" name="simpleOutRecEncoder"/>
-                </item>
-                <item row="5" column="0">
-                 <widget class="QLabel" name="label_420">
-                  <property name="text">
-                   <string>Basic.Settings.Output.CustomMuxerSettings</string>
-                  </property>
-                  <property name="buddy">
-                   <cstring>simpleOutMuxCustom</cstring>
-                  </property>
-                 </widget>
-                </item>
-                <item row="5" column="1">
-                 <widget class="QLineEdit" name="simpleOutMuxCustom"/>
-                </item>
-                <item row="6" column="1">
-                 <widget class="QCheckBox" name="simpleReplayBuf">
-                  <property name="text">
-                   <string>Basic.Settings.Output.UseReplayBuffer</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QGroupBox" name="replayBufferGroupBox">
-               <property name="title">
-                <string>ReplayBuffer</string>
-               </property>
-               <layout class="QFormLayout" name="formLayout_24">
-                <property name="fieldGrowthPolicy">
-                 <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                </property>
-                <property name="labelAlignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <item row="0" column="0">
-                 <widget class="QLabel" name="label_35">
-                  <property name="text">
-                   <string>Basic.Settings.Output.ReplayBuffer.SecondsMax</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="0" column="1">
-                 <widget class="QSpinBox" name="simpleRBSecMax">
-                  <property name="suffix">
-                   <string notr="true"> sec</string>
-                  </property>
-                  <property name="minimum">
-                   <number>5</number>
-                  </property>
-                  <property name="maximum">
-                   <number>21600</number>
-                  </property>
-                  <property name="value">
-                   <number>15</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="0">
-                 <widget class="QLabel" name="simpleRBMegsMaxLabel">
-                  <property name="text">
-                   <string>Basic.Settings.Output.ReplayBuffer.MegabytesMax</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="1" column="1">
-                 <widget class="QSpinBox" name="simpleRBMegsMax">
-                  <property name="suffix">
-                   <string notr="true"> MB</string>
-                  </property>
-                  <property name="minimum">
-                   <number>20</number>
-                  </property>
-                  <property name="maximum">
-                   <number>8192</number>
-                  </property>
-                  <property name="value">
-                   <number>512</number>
-                  </property>
-                 </widget>
-                </item>
-                <item row="2" column="1">
-                 <widget class="QLabel" name="label_45">
-                  <property name="text">
-                   <string>Basic.Settings.Output.ReplayBuffer.HotkeyMessage</string>
-                  </property>
-                 </widget>
-                </item>
-                <item row="3" column="1">
-                 <widget class="QLabel" name="simpleRBEstimate">
-                  <property name="text">
-                   <string notr="true"/>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <layout class="QVBoxLayout" name="simpleOutInfoLayout">
-               <property name="leftMargin">
-                <number>10</number>
-               </property>
-               <property name="topMargin">
-                <number>10</number>
-               </property>
-               <property name="rightMargin">
-                <number>10</number>
-               </property>
-               <property name="bottomMargin">
-                <number>10</number>
-               </property>
-              </layout>
-             </item>
-             <item>
-              <spacer name="verticalSpacer_2">
+              <widget class="Line" name="line_2">
                <property name="orientation">
-                <enum>Qt::Vertical</enum>
+                <enum>Qt::Horizontal</enum>
                </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item alignment="Qt::AlignTop">
-              <widget class="QWidget" name="simpleOutputContainer" native="true">
-               <layout class="QVBoxLayout" name="verticalLayout_4">
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-               </layout>
               </widget>
              </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="advOutputsPage">
-            <layout class="QVBoxLayout" name="verticalLayout_8">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
              <item>
-              <widget class="QTabWidget" name="advOutTabs">
+              <widget class="QStackedWidget" name="outputModePages">
                <property name="currentIndex">
                 <number>0</number>
                </property>
-               <property name="usesScrollButtons">
-                <bool>true</bool>
-               </property>
-               <widget class="QWidget" name="advOutputStreamTab">
-                <attribute name="title">
-                 <string>Basic.Settings.Output.Adv.Streaming</string>
-                </attribute>
-                <layout class="QVBoxLayout" name="verticalLayout_12">
+               <widget class="QWidget" name="easyOutputsPage">
+                <layout class="QVBoxLayout" name="verticalLayout_3">
                  <property name="leftMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
                  <property name="topMargin">
                   <number>0</number>
                  </property>
                  <property name="rightMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
                  <property name="bottomMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
-                 <item alignment="Qt::AlignTop">
-                  <widget class="QWidget" name="widget_4" native="true">
-                   <layout class="QVBoxLayout" name="verticalLayout_14">
-                    <property name="spacing">
-                     <number>0</number>
+                 <item>
+                  <widget class="QGroupBox" name="groupBox_8">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="title">
+                    <string>Basic.Settings.Output.Adv.Streaming</string>
+                   </property>
+                   <layout class="QFormLayout" name="formLayout_20">
+                    <property name="fieldGrowthPolicy">
+                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                     </property>
+                    <property name="labelAlignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_19">
+                      <property name="minimumSize">
+                       <size>
+                        <width>170</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>Basic.Settings.Output.VideoBitrate</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutputVBitrate</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QSpinBox" name="simpleOutputVBitrate">
+                      <property name="minimum">
+                       <number>200</number>
+                      </property>
+                      <property name="maximum">
+                       <number>1000000</number>
+                      </property>
+                      <property name="value">
+                       <number>2000</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_20">
+                      <property name="text">
+                       <string>Basic.Settings.Output.AudioBitrate</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutputABitrate</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QComboBox" name="simpleOutputABitrate">
+                      <property name="currentIndex">
+                       <number>8</number>
+                      </property>
+                      <item>
+                       <property name="text">
+                        <string>32</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>48</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>64</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>80</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>96</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>112</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>128</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>160</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>192</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>256</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>320</string>
+                       </property>
+                      </item>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QCheckBox" name="simpleOutAdvanced">
+                      <property name="text">
+                       <string>Basic.Settings.Output.Advanced</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="5" column="1">
+                     <widget class="QComboBox" name="simpleOutPreset"/>
+                    </item>
+                    <item row="5" column="0">
+                     <widget class="QLabel" name="label_24">
+                      <property name="enabled">
+                       <bool>true</bool>
+                      </property>
+                      <property name="text">
+                       <string>Basic.Settings.Output.EncoderPreset</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutPreset</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="6" column="0">
+                     <widget class="QLabel" name="label_23">
+                      <property name="text">
+                       <string>Basic.Settings.Output.CustomEncoderSettings</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutCustom</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="6" column="1">
+                     <widget class="QLineEdit" name="simpleOutCustom"/>
+                    </item>
+                    <item row="4" column="1">
+                     <widget class="QCheckBox" name="simpleOutEnforce">
+                      <property name="text">
+                       <string>Basic.Settings.Output.EnforceBitrate</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QComboBox" name="simpleOutStrEncoder"/>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="simpleOutRecEncoderLabel_2">
+                      <property name="text">
+                       <string>Basic.Settings.Output.Encoder</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutRecEncoder</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="simpleRecordingGroupBox">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="title">
+                    <string>Basic.Settings.Output.Adv.Recording</string>
+                   </property>
+                   <layout class="QFormLayout" name="formLayout_6">
+                    <property name="fieldGrowthPolicy">
+                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                    </property>
+                    <property name="labelAlignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_18">
+                      <property name="minimumSize">
+                       <size>
+                        <width>170</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>Basic.Settings.Output.Simple.SavePath</string>
+                      </property>
+                      <property name="alignment">
+                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutputPath</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <layout class="QHBoxLayout" name="horizontalLayout_5">
+                      <item>
+                       <widget class="QLineEdit" name="simpleOutputPath">
+                        <property name="enabled">
+                         <bool>true</bool>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QPushButton" name="simpleOutputBrowse">
+                        <property name="enabled">
+                         <bool>true</bool>
+                        </property>
+                        <property name="text">
+                         <string>Browse</string>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QCheckBox" name="simpleNoSpace">
+                      <property name="text">
+                       <string>Basic.Settings.Output.NoSpaceFileName</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="0">
+                     <widget class="QLabel" name="label_26">
+                      <property name="text">
+                       <string>Basic.Settings.Output.Simple.RecordingQuality</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutRecQuality</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QComboBox" name="simpleOutRecQuality"/>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QLabel" name="simpleOutRecFormatLabel">
+                      <property name="text">
+                       <string>Basic.Settings.Output.Format</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutRecFormat</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QComboBox" name="simpleOutRecFormat">
+                      <item>
+                       <property name="text">
+                        <string notr="true">flv</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string notr="true">mp4</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string notr="true">mov</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string notr="true">mkv</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string notr="true">ts</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string notr="true">m3u8</string>
+                       </property>
+                      </item>
+                     </widget>
+                    </item>
+                    <item row="4" column="0">
+                     <widget class="QLabel" name="simpleOutRecEncoderLabel">
+                      <property name="text">
+                       <string>Basic.Settings.Output.Encoder</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutRecEncoder</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="4" column="1">
+                     <widget class="QComboBox" name="simpleOutRecEncoder"/>
+                    </item>
+                    <item row="5" column="0">
+                     <widget class="QLabel" name="label_420">
+                      <property name="text">
+                       <string>Basic.Settings.Output.CustomMuxerSettings</string>
+                      </property>
+                      <property name="buddy">
+                       <cstring>simpleOutMuxCustom</cstring>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="5" column="1">
+                     <widget class="QLineEdit" name="simpleOutMuxCustom"/>
+                    </item>
+                    <item row="6" column="1">
+                     <widget class="QCheckBox" name="simpleReplayBuf">
+                      <property name="text">
+                       <string>Basic.Settings.Output.UseReplayBuffer</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="replayBufferGroupBox">
+                   <property name="title">
+                    <string>ReplayBuffer</string>
+                   </property>
+                   <layout class="QFormLayout" name="formLayout_24">
+                    <property name="fieldGrowthPolicy">
+                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                    </property>
+                    <property name="labelAlignment">
+                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                    </property>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_35">
+                      <property name="text">
+                       <string>Basic.Settings.Output.ReplayBuffer.SecondsMax</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="1">
+                     <widget class="QSpinBox" name="simpleRBSecMax">
+                      <property name="suffix">
+                       <string notr="true"> sec</string>
+                      </property>
+                      <property name="minimum">
+                       <number>5</number>
+                      </property>
+                      <property name="maximum">
+                       <number>21600</number>
+                      </property>
+                      <property name="value">
+                       <number>15</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QLabel" name="simpleRBMegsMaxLabel">
+                      <property name="text">
+                       <string>Basic.Settings.Output.ReplayBuffer.MegabytesMax</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <widget class="QSpinBox" name="simpleRBMegsMax">
+                      <property name="suffix">
+                       <string notr="true"> MB</string>
+                      </property>
+                      <property name="minimum">
+                       <number>20</number>
+                      </property>
+                      <property name="maximum">
+                       <number>8192</number>
+                      </property>
+                      <property name="value">
+                       <number>512</number>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="2" column="1">
+                     <widget class="QLabel" name="label_45">
+                      <property name="text">
+                       <string>Basic.Settings.Output.ReplayBuffer.HotkeyMessage</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="3" column="1">
+                     <widget class="QLabel" name="simpleRBEstimate">
+                      <property name="text">
+                       <string notr="true"/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <layout class="QVBoxLayout" name="simpleOutInfoLayout">
+                   <property name="leftMargin">
+                    <number>10</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>10</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>10</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>10</number>
+                   </property>
+                  </layout>
+                 </item>
+                 <item>
+                  <spacer name="verticalSpacer_2">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>40</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item alignment="Qt::AlignTop">
+                  <widget class="QWidget" name="simpleOutputContainer" native="true">
+                   <layout class="QVBoxLayout" name="verticalLayout_4">
                     <property name="leftMargin">
                      <number>0</number>
                     </property>
@@ -1307,260 +1245,56 @@
                     <property name="bottomMargin">
                      <number>0</number>
                     </property>
-                    <item>
-                     <widget class="QWidget" name="advOutTopContainer" native="true">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_7">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_28">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.Adv.AudioTrack</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QWidget" name="widget_8" native="true">
-                         <property name="sizePolicy">
-                          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                           <horstretch>0</horstretch>
-                           <verstretch>0</verstretch>
-                          </sizepolicy>
-                         </property>
-                         <layout class="QHBoxLayout" name="horizontalLayout_7">
-                          <property name="leftMargin">
-                           <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                           <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                           <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                           <number>0</number>
-                          </property>
-                          <item>
-                           <widget class="QRadioButton" name="advOutTrack1">
-                            <property name="text">
-                             <string notr="true">1</string>
-                            </property>
-                            <property name="checked">
-                             <bool>true</bool>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QRadioButton" name="advOutTrack2">
-                            <property name="text">
-                             <string notr="true">2</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QRadioButton" name="advOutTrack3">
-                            <property name="text">
-                             <string notr="true">3</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QRadioButton" name="advOutTrack4">
-                            <property name="text">
-                             <string notr="true">4</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QRadioButton" name="advOutTrack5">
-                            <property name="text">
-                             <string notr="true">5</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QRadioButton" name="advOutTrack6">
-                            <property name="text">
-                             <string notr="true">6</string>
-                            </property>
-                           </widget>
-                          </item>
-                         </layout>
-                        </widget>
-                       </item>
-                       <item row="2" column="0">
-                        <widget class="QLabel" name="advOutEncLabel">
-                         <property name="text">
-                          <string>Basic.Settings.Output.Encoder</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutEncoder</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="1">
-                        <widget class="QComboBox" name="advOutEncoder"/>
-                       </item>
-                       <item row="3" column="1">
-                        <widget class="QCheckBox" name="advOutApplyService">
-                         <property name="text">
-                          <string>Basic.Settings.Output.Adv.ApplyServiceSettings</string>
-                         </property>
-                         <property name="checked">
-                          <bool>true</bool>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="4" column="0">
-                        <widget class="QCheckBox" name="advOutUseRescale">
-                         <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                           <horstretch>0</horstretch>
-                           <verstretch>0</verstretch>
-                          </sizepolicy>
-                         </property>
-                         <property name="layoutDirection">
-                          <enum>Qt::RightToLeft</enum>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.Adv.Rescale</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="4" column="1">
-                        <widget class="QComboBox" name="advOutRescale">
-                         <property name="enabled">
-                          <bool>false</bool>
-                         </property>
-                         <property name="editable">
-                          <bool>true</bool>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
                    </layout>
                   </widget>
                  </item>
                 </layout>
                </widget>
-               <widget class="QWidget" name="advOutputRecordTab">
-                <attribute name="title">
-                 <string>Basic.Settings.Output.Adv.Recording</string>
-                </attribute>
-                <layout class="QVBoxLayout" name="verticalLayout_11">
+               <widget class="QWidget" name="advOutputsPage">
+                <layout class="QVBoxLayout" name="verticalLayout_8">
                  <property name="leftMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
                  <property name="topMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
                  <property name="rightMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
                  <property name="bottomMargin">
-                  <number>9</number>
+                  <number>0</number>
                  </property>
                  <item>
-                  <widget class="QWidget" name="advOutRecTypeContainer" native="true">
-                   <layout class="QFormLayout" name="formLayout_9">
-                    <property name="fieldGrowthPolicy">
-                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                    </property>
-                    <property name="labelAlignment">
-                     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                    </property>
-                    <property name="topMargin">
-                     <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                     <number>0</number>
-                    </property>
-                    <item row="0" column="0">
-                     <widget class="QLabel" name="label_31">
-                      <property name="minimumSize">
-                       <size>
-                        <width>170</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>Basic.Settings.Output.Adv.Recording.Type</string>
-                      </property>
-                      <property name="alignment">
-                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                      </property>
-                      <property name="buddy">
-                       <cstring>advOutRecType</cstring>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QComboBox" name="advOutRecType">
-                      <item>
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.Recording.Type.Standard</string>
-                       </property>
-                      </item>
-                      <item>
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.Recording.Type.FFmpegOutput</string>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="Line" name="line_3">
-                   <property name="orientation">
-                    <enum>Qt::Horizontal</enum>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QStackedWidget" name="stackedWidget">
+                  <widget class="QTabWidget" name="advOutTabs">
                    <property name="currentIndex">
                     <number>0</number>
                    </property>
-                   <widget class="QWidget" name="advOutRecStandard">
-                    <layout class="QVBoxLayout" name="verticalLayout_13">
+                   <property name="usesScrollButtons">
+                    <bool>true</bool>
+                   </property>
+                   <widget class="QWidget" name="advOutputStreamTab">
+                    <attribute name="title">
+                     <string>Basic.Settings.Output.Adv.Streaming</string>
+                    </attribute>
+                    <layout class="QVBoxLayout" name="verticalLayout_12">
                      <property name="leftMargin">
-                      <number>0</number>
+                      <number>9</number>
                      </property>
                      <property name="topMargin">
                       <number>0</number>
                      </property>
                      <property name="rightMargin">
-                      <number>0</number>
+                      <number>9</number>
                      </property>
                      <property name="bottomMargin">
-                      <number>0</number>
+                      <number>9</number>
                      </property>
                      <item alignment="Qt::AlignTop">
-                      <widget class="QWidget" name="widget_7" native="true">
-                       <layout class="QVBoxLayout" name="verticalLayout_15">
+                      <widget class="QWidget" name="widget_4" native="true">
+                       <layout class="QVBoxLayout" name="verticalLayout_14">
+                        <property name="spacing">
+                         <number>0</number>
+                        </property>
                         <property name="leftMargin">
                          <number>0</number>
                         </property>
@@ -1574,31 +1308,22 @@
                          <number>0</number>
                         </property>
                         <item>
-                         <widget class="QWidget" name="advOutRecTopContainer" native="true">
+                         <widget class="QWidget" name="advOutTopContainer" native="true">
                           <property name="sizePolicy">
                            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                             <horstretch>0</horstretch>
                             <verstretch>0</verstretch>
                            </sizepolicy>
                           </property>
-                          <layout class="QFormLayout" name="formLayout_16">
+                          <layout class="QFormLayout" name="formLayout_7">
                            <property name="fieldGrowthPolicy">
                             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
                            </property>
                            <property name="labelAlignment">
                             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                            </property>
-                           <property name="topMargin">
-                            <number>0</number>
-                           </property>
-                           <item row="0" column="0">
-                            <widget class="QLabel" name="label_32">
-                             <property name="sizePolicy">
-                              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                               <horstretch>0</horstretch>
-                               <verstretch>0</verstretch>
-                              </sizepolicy>
-                             </property>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_28">
                              <property name="minimumSize">
                               <size>
                                <width>170</width>
@@ -1606,107 +1331,22 @@
                               </size>
                              </property>
                              <property name="text">
-                              <string>Basic.Settings.Output.Simple.SavePath</string>
+                              <string>Basic.Settings.Output.Adv.AudioTrack</string>
                              </property>
                              <property name="alignment">
                               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                              </property>
-                             <property name="buddy">
-                              <cstring>advOutRecPath</cstring>
-                             </property>
                             </widget>
-                           </item>
-                           <item row="0" column="1">
-                            <layout class="QHBoxLayout" name="horizontalLayout_6">
-                             <item>
-                              <widget class="QLineEdit" name="advOutRecPath">
-                               <property name="enabled">
-                                <bool>true</bool>
-                               </property>
-                              </widget>
-                             </item>
-                             <item>
-                              <widget class="QPushButton" name="advOutRecPathBrowse">
-                               <property name="enabled">
-                                <bool>true</bool>
-                               </property>
-                               <property name="text">
-                                <string>Browse</string>
-                               </property>
-                              </widget>
-                             </item>
-                            </layout>
                            </item>
                            <item row="1" column="1">
-                            <widget class="QCheckBox" name="advOutNoSpace">
-                             <property name="text">
-                              <string>Basic.Settings.Output.NoSpaceFileName</string>
-                             </property>
-                             <property name="checked">
-                              <bool>true</bool>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="2" column="0">
-                            <widget class="QLabel" name="label_43">
-                             <property name="text">
-                              <string>Basic.Settings.Output.Format</string>
-                             </property>
-                             <property name="buddy">
-                              <cstring>advOutRecFormat</cstring>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="2" column="1">
-                            <widget class="QComboBox" name="advOutRecFormat">
-                             <item>
-                              <property name="text">
-                               <string notr="true">flv</string>
-                              </property>
-                             </item>
-                             <item>
-                              <property name="text">
-                               <string notr="true">mp4</string>
-                              </property>
-                             </item>
-                             <item>
-                              <property name="text">
-                               <string notr="true">mov</string>
-                              </property>
-                             </item>
-                             <item>
-                              <property name="text">
-                               <string notr="true">mkv</string>
-                              </property>
-                             </item>
-                             <item>
-                              <property name="text">
-                               <string notr="true">ts</string>
-                              </property>
-                             </item>
-                             <item>
-                              <property name="text">
-                               <string notr="true">m3u8</string>
-                              </property>
-                             </item>
-                            </widget>
-                           </item>
-                           <item row="3" column="0">
-                            <widget class="QLabel" name="label_29">
-                             <property name="text">
-                              <string>Basic.Settings.Output.Adv.AudioTrack</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="3" column="1">
-                            <widget class="QWidget" name="widget_9" native="true">
+                            <widget class="QWidget" name="widget_8" native="true">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                                <horstretch>0</horstretch>
                                <verstretch>0</verstretch>
                               </sizepolicy>
                              </property>
-                             <layout class="QHBoxLayout" name="horizontalLayout_9">
+                             <layout class="QHBoxLayout" name="horizontalLayout_7">
                               <property name="leftMargin">
                                <number>0</number>
                               </property>
@@ -1720,42 +1360,45 @@
                                <number>0</number>
                               </property>
                               <item>
-                               <widget class="QCheckBox" name="advOutRecTrack1">
+                               <widget class="QRadioButton" name="advOutTrack1">
                                 <property name="text">
                                  <string notr="true">1</string>
+                                </property>
+                                <property name="checked">
+                                 <bool>true</bool>
                                 </property>
                                </widget>
                               </item>
                               <item>
-                               <widget class="QCheckBox" name="advOutRecTrack2">
+                               <widget class="QRadioButton" name="advOutTrack2">
                                 <property name="text">
                                  <string notr="true">2</string>
                                 </property>
                                </widget>
                               </item>
                               <item>
-                               <widget class="QCheckBox" name="advOutRecTrack3">
+                               <widget class="QRadioButton" name="advOutTrack3">
                                 <property name="text">
                                  <string notr="true">3</string>
                                 </property>
                                </widget>
                               </item>
                               <item>
-                               <widget class="QCheckBox" name="advOutRecTrack4">
+                               <widget class="QRadioButton" name="advOutTrack4">
                                 <property name="text">
                                  <string notr="true">4</string>
                                 </property>
                                </widget>
                               </item>
                               <item>
-                               <widget class="QCheckBox" name="advOutRecTrack5">
+                               <widget class="QRadioButton" name="advOutTrack5">
                                 <property name="text">
                                  <string notr="true">5</string>
                                 </property>
                                </widget>
                               </item>
                               <item>
-                               <widget class="QCheckBox" name="advOutRecTrack6">
+                               <widget class="QRadioButton" name="advOutTrack6">
                                 <property name="text">
                                  <string notr="true">6</string>
                                 </property>
@@ -1764,21 +1407,31 @@
                              </layout>
                             </widget>
                            </item>
-                           <item row="4" column="0">
-                            <widget class="QLabel" name="advOutRecEncLabel">
+                           <item row="2" column="0">
+                            <widget class="QLabel" name="advOutEncLabel">
                              <property name="text">
                               <string>Basic.Settings.Output.Encoder</string>
                              </property>
                              <property name="buddy">
-                              <cstring>advOutRecEncoder</cstring>
+                              <cstring>advOutEncoder</cstring>
                              </property>
                             </widget>
                            </item>
-                           <item row="4" column="1">
-                            <widget class="QComboBox" name="advOutRecEncoder"/>
+                           <item row="2" column="1">
+                            <widget class="QComboBox" name="advOutEncoder"/>
                            </item>
-                           <item row="5" column="0">
-                            <widget class="QCheckBox" name="advOutRecUseRescale">
+                           <item row="3" column="1">
+                            <widget class="QCheckBox" name="advOutApplyService">
+                             <property name="text">
+                              <string>Basic.Settings.Output.Adv.ApplyServiceSettings</string>
+                             </property>
+                             <property name="checked">
+                              <bool>true</bool>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="4" column="0">
+                            <widget class="QCheckBox" name="advOutUseRescale">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
                                <horstretch>0</horstretch>
@@ -1793,46 +1446,15 @@
                              </property>
                             </widget>
                            </item>
-                           <item row="5" column="1">
-                            <widget class="QWidget" name="advOutRecRescaleContainer" native="true">
-                             <layout class="QHBoxLayout" name="horizontalLayout_4">
-                              <property name="leftMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="topMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="rightMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="bottomMargin">
-                               <number>0</number>
-                              </property>
-                              <item>
-                               <widget class="QComboBox" name="advOutRecRescale">
-                                <property name="enabled">
-                                 <bool>false</bool>
-                                </property>
-                                <property name="editable">
-                                 <bool>true</bool>
-                                </property>
-                               </widget>
-                              </item>
-                             </layout>
-                            </widget>
-                           </item>
-                           <item row="6" column="0">
-                            <widget class="QLabel" name="label_9001">
-                             <property name="text">
-                              <string>Basic.Settings.Output.CustomMuxerSettings</string>
+                           <item row="4" column="1">
+                            <widget class="QComboBox" name="advOutRescale">
+                             <property name="enabled">
+                              <bool>false</bool>
                              </property>
-                             <property name="buddy">
-                              <cstring>advOutMuxCustom</cstring>
+                             <property name="editable">
+                              <bool>true</bool>
                              </property>
                             </widget>
-                           </item>
-                           <item row="6" column="1">
-                            <widget class="QLineEdit" name="advOutMuxCustom"/>
                            </item>
                           </layout>
                          </widget>
@@ -1842,1147 +1464,1621 @@
                      </item>
                     </layout>
                    </widget>
-                   <widget class="QWidget" name="advOutRecFFmpeg">
-                    <layout class="QFormLayout" name="formLayout_15">
-                     <property name="fieldGrowthPolicy">
-                      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                     </property>
-                     <property name="labelAlignment">
-                      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   <widget class="QWidget" name="advOutputRecordTab">
+                    <attribute name="title">
+                     <string>Basic.Settings.Output.Adv.Recording</string>
+                    </attribute>
+                    <layout class="QVBoxLayout" name="verticalLayout_11">
+                     <property name="leftMargin">
+                      <number>9</number>
                      </property>
                      <property name="topMargin">
-                      <number>0</number>
+                      <number>9</number>
                      </property>
-                     <item row="1" column="0">
-                      <widget class="QLabel" name="label_36">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>170</width>
-                         <height>0</height>
-                        </size>
-                       </property>
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.SavePathURL</string>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QStackedWidget" name="stackedWidget_2">
-                       <property name="currentIndex">
-                        <number>0</number>
-                       </property>
-                       <widget class="QWidget" name="page_5">
-                        <layout class="QHBoxLayout" name="horizontalLayout_12">
-                         <property name="spacing">
-                          <number>3</number>
-                         </property>
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item>
-                          <widget class="QLineEdit" name="advOutFFRecPath">
-                           <property name="readOnly">
-                            <bool>true</bool>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QPushButton" name="advOutFFPathBrowse">
-                           <property name="text">
-                            <string>Browse</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                       <widget class="QWidget" name="page_4">
-                        <layout class="QHBoxLayout" name="horizontalLayout_8">
-                         <property name="spacing">
-                          <number>0</number>
-                         </property>
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item>
-                          <widget class="QLineEdit" name="advOutFFURL">
-                           <property name="enabled">
-                            <bool>true</bool>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </widget>
-                      </widget>
-                     </item>
-                     <item row="3" column="0">
-                      <widget class="QLabel" name="label_16">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.Format</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFFormat</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="3" column="1">
-                      <widget class="QComboBox" name="advOutFFFormat"/>
-                     </item>
-                     <item row="4" column="0">
-                      <widget class="QLabel" name="label_44">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.FormatDesc</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="4" column="1">
-                      <widget class="QLabel" name="advOutFFFormatDesc">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="7" column="0">
-                      <widget class="QLabel" name="label_40">
-                       <property name="text">
-                        <string>Basic.Settings.Output.VideoBitrate</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFVBitrate</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="7" column="1">
-                      <widget class="QSpinBox" name="advOutFFVBitrate">
-                       <property name="minimum">
-                        <number>0</number>
-                       </property>
-                       <property name="maximum">
-                        <number>1000000000</number>
-                       </property>
-                       <property name="value">
-                        <number>2500</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="1">
-                      <widget class="QSpinBox" name="advOutFFVGOPSize">
-                       <property name="maximum">
-                        <number>1000000000</number>
-                       </property>
-                       <property name="value">
-                        <number>250</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="8" column="0">
-                      <widget class="QLabel" name="label_63">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.GOPSize</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFVGOPSize</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="0">
-                      <widget class="QCheckBox" name="advOutFFUseRescale">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="layoutDirection">
-                        <enum>Qt::RightToLeft</enum>
-                       </property>
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.Rescale</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="9" column="1">
-                      <widget class="QComboBox" name="advOutFFRescale">
-                       <property name="enabled">
-                        <bool>false</bool>
-                       </property>
-                       <property name="editable">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="10" column="1">
-                      <widget class="QCheckBox" name="advOutFFIgnoreCompat">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.IgnoreCodecCompat</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="11" column="0">
-                      <widget class="QLabel" name="label_37">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.VEncoder</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFVEncoder</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="11" column="1">
-                      <widget class="QComboBox" name="advOutFFVEncoder"/>
-                     </item>
-                     <item row="13" column="0">
-                      <widget class="QLabel" name="label_38">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.VEncoderSettings</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFVCfg</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="13" column="1">
-                      <widget class="QLineEdit" name="advOutFFVCfg"/>
-                     </item>
-                     <item row="14" column="0">
-                      <widget class="QLabel" name="label_41">
-                       <property name="text">
-                        <string>Basic.Settings.Output.AudioBitrate</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFABitrate</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="14" column="1">
-                      <widget class="QSpinBox" name="advOutFFABitrate">
-                       <property name="minimum">
-                        <number>32</number>
-                       </property>
-                       <property name="maximum">
-                        <number>4096</number>
-                       </property>
-                       <property name="singleStep">
-                        <number>16</number>
-                       </property>
-                       <property name="value">
-                        <number>128</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="15" column="0">
-                      <widget class="QLabel" name="label_47">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.AudioTrack</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="15" column="1">
-                      <widget class="QWidget" name="widget_10" native="true">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <layout class="QHBoxLayout" name="horizontalLayout_10">
-                        <property name="leftMargin">
-                         <number>0</number>
+                     <property name="rightMargin">
+                      <number>9</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>9</number>
+                     </property>
+                     <item>
+                      <widget class="QWidget" name="advOutRecTypeContainer" native="true">
+                       <layout class="QFormLayout" name="formLayout_9">
+                        <property name="fieldGrowthPolicy">
+                         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                        </property>
+                        <property name="labelAlignment">
+                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                         </property>
                         <property name="topMargin">
-                         <number>0</number>
-                        </property>
-                        <property name="rightMargin">
                          <number>0</number>
                         </property>
                         <property name="bottomMargin">
                          <number>0</number>
                         </property>
-                        <item>
-                         <widget class="QRadioButton" name="advOutFFTrack1">
-                          <property name="text">
-                           <string notr="true">1</string>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_31">
+                          <property name="minimumSize">
+                           <size>
+                            <width>170</width>
+                            <height>0</height>
+                           </size>
                           </property>
-                          <property name="checked">
-                           <bool>true</bool>
-                          </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QRadioButton" name="advOutFFTrack2">
                           <property name="text">
-                           <string notr="true">2</string>
+                           <string>Basic.Settings.Output.Adv.Recording.Type</string>
                           </property>
-                         </widget>
-                        </item>
-                        <item>
-                         <widget class="QRadioButton" name="advOutFFTrack3">
-                          <property name="text">
-                           <string notr="true">3</string>
+                          <property name="alignment">
+                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                          </property>
+                          <property name="buddy">
+                           <cstring>advOutRecType</cstring>
                           </property>
                          </widget>
                         </item>
+                        <item row="0" column="1">
+                         <widget class="QComboBox" name="advOutRecType">
+                          <item>
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.Recording.Type.Standard</string>
+                           </property>
+                          </item>
+                          <item>
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.Recording.Type.FFmpegOutput</string>
+                           </property>
+                          </item>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="Line" name="line_3">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QStackedWidget" name="stackedWidget">
+                       <property name="currentIndex">
+                        <number>0</number>
+                       </property>
+                       <widget class="QWidget" name="advOutRecStandard">
+                        <layout class="QVBoxLayout" name="verticalLayout_13">
+                         <property name="leftMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="topMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="rightMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <item alignment="Qt::AlignTop">
+                          <widget class="QWidget" name="widget_7" native="true">
+                           <layout class="QVBoxLayout" name="verticalLayout_15">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item>
+                             <widget class="QWidget" name="advOutRecTopContainer" native="true">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <layout class="QFormLayout" name="formLayout_16">
+                               <property name="fieldGrowthPolicy">
+                                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                               </property>
+                               <property name="labelAlignment">
+                                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                               </property>
+                               <property name="topMargin">
+                                <number>0</number>
+                               </property>
+                               <item row="0" column="0">
+                                <widget class="QLabel" name="label_32">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                 </property>
+                                 <property name="minimumSize">
+                                  <size>
+                                   <width>170</width>
+                                   <height>0</height>
+                                  </size>
+                                 </property>
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Simple.SavePath</string>
+                                 </property>
+                                 <property name="alignment">
+                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                                 </property>
+                                 <property name="buddy">
+                                  <cstring>advOutRecPath</cstring>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="0" column="1">
+                                <layout class="QHBoxLayout" name="horizontalLayout_6">
+                                 <item>
+                                  <widget class="QLineEdit" name="advOutRecPath">
+                                   <property name="enabled">
+                                    <bool>true</bool>
+                                   </property>
+                                  </widget>
+                                 </item>
+                                 <item>
+                                  <widget class="QPushButton" name="advOutRecPathBrowse">
+                                   <property name="enabled">
+                                    <bool>true</bool>
+                                   </property>
+                                   <property name="text">
+                                    <string>Browse</string>
+                                   </property>
+                                  </widget>
+                                 </item>
+                                </layout>
+                               </item>
+                               <item row="1" column="1">
+                                <widget class="QCheckBox" name="advOutNoSpace">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.NoSpaceFileName</string>
+                                 </property>
+                                 <property name="checked">
+                                  <bool>true</bool>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="2" column="0">
+                                <widget class="QLabel" name="label_43">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Format</string>
+                                 </property>
+                                 <property name="buddy">
+                                  <cstring>advOutRecFormat</cstring>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="2" column="1">
+                                <widget class="QComboBox" name="advOutRecFormat">
+                                 <item>
+                                  <property name="text">
+                                   <string notr="true">flv</string>
+                                  </property>
+                                 </item>
+                                 <item>
+                                  <property name="text">
+                                   <string notr="true">mp4</string>
+                                  </property>
+                                 </item>
+                                 <item>
+                                  <property name="text">
+                                   <string notr="true">mov</string>
+                                  </property>
+                                 </item>
+                                 <item>
+                                  <property name="text">
+                                   <string notr="true">mkv</string>
+                                  </property>
+                                 </item>
+                                 <item>
+                                  <property name="text">
+                                   <string notr="true">ts</string>
+                                  </property>
+                                 </item>
+                                 <item>
+                                  <property name="text">
+                                   <string notr="true">m3u8</string>
+                                  </property>
+                                 </item>
+                                </widget>
+                               </item>
+                               <item row="3" column="0">
+                                <widget class="QLabel" name="label_29">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Adv.AudioTrack</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="3" column="1">
+                                <widget class="QWidget" name="widget_9" native="true">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                 </property>
+                                 <layout class="QHBoxLayout" name="horizontalLayout_9">
+                                  <property name="leftMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <property name="topMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <property name="bottomMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <item>
+                                   <widget class="QCheckBox" name="advOutRecTrack1">
+                                    <property name="text">
+                                     <string notr="true">1</string>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QCheckBox" name="advOutRecTrack2">
+                                    <property name="text">
+                                     <string notr="true">2</string>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QCheckBox" name="advOutRecTrack3">
+                                    <property name="text">
+                                     <string notr="true">3</string>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QCheckBox" name="advOutRecTrack4">
+                                    <property name="text">
+                                     <string notr="true">4</string>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QCheckBox" name="advOutRecTrack5">
+                                    <property name="text">
+                                     <string notr="true">5</string>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                  <item>
+                                   <widget class="QCheckBox" name="advOutRecTrack6">
+                                    <property name="text">
+                                     <string notr="true">6</string>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </widget>
+                               </item>
+                               <item row="4" column="0">
+                                <widget class="QLabel" name="advOutRecEncLabel">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Encoder</string>
+                                 </property>
+                                 <property name="buddy">
+                                  <cstring>advOutRecEncoder</cstring>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="4" column="1">
+                                <widget class="QComboBox" name="advOutRecEncoder"/>
+                               </item>
+                               <item row="5" column="0">
+                                <widget class="QCheckBox" name="advOutRecUseRescale">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                 </property>
+                                 <property name="layoutDirection">
+                                  <enum>Qt::RightToLeft</enum>
+                                 </property>
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Adv.Rescale</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="5" column="1">
+                                <widget class="QWidget" name="advOutRecRescaleContainer" native="true">
+                                 <layout class="QHBoxLayout" name="horizontalLayout_4">
+                                  <property name="leftMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <property name="topMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <property name="rightMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <property name="bottomMargin">
+                                   <number>0</number>
+                                  </property>
+                                  <item>
+                                   <widget class="QComboBox" name="advOutRecRescale">
+                                    <property name="enabled">
+                                     <bool>false</bool>
+                                    </property>
+                                    <property name="editable">
+                                     <bool>true</bool>
+                                    </property>
+                                   </widget>
+                                  </item>
+                                 </layout>
+                                </widget>
+                               </item>
+                               <item row="6" column="0">
+                                <widget class="QLabel" name="label_9001">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.CustomMuxerSettings</string>
+                                 </property>
+                                 <property name="buddy">
+                                  <cstring>advOutMuxCustom</cstring>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="6" column="1">
+                                <widget class="QLineEdit" name="advOutMuxCustom"/>
+                               </item>
+                              </layout>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
+                       <widget class="QWidget" name="advOutRecFFmpeg">
+                        <layout class="QFormLayout" name="formLayout_15">
+                         <property name="fieldGrowthPolicy">
+                          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                         </property>
+                         <property name="labelAlignment">
+                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                         </property>
+                         <property name="topMargin">
+                          <number>0</number>
+                         </property>
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="label_36">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>170</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.SavePathURL</string>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="1">
+                          <widget class="QStackedWidget" name="stackedWidget_2">
+                           <property name="currentIndex">
+                            <number>1</number>
+                           </property>
+                           <widget class="QWidget" name="page_5">
+                            <layout class="QHBoxLayout" name="horizontalLayout_12">
+                             <property name="spacing">
+                              <number>3</number>
+                             </property>
+                             <property name="leftMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="topMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="rightMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="bottomMargin">
+                              <number>0</number>
+                             </property>
+                             <item>
+                              <widget class="QLineEdit" name="advOutFFRecPath">
+                               <property name="readOnly">
+                                <bool>true</bool>
+                               </property>
+                              </widget>
+                             </item>
+                             <item>
+                              <widget class="QPushButton" name="advOutFFPathBrowse">
+                               <property name="text">
+                                <string>Browse</string>
+                               </property>
+                              </widget>
+                             </item>
+                            </layout>
+                           </widget>
+                           <widget class="QWidget" name="page_4">
+                            <layout class="QHBoxLayout" name="horizontalLayout_8">
+                             <property name="spacing">
+                              <number>0</number>
+                             </property>
+                             <property name="leftMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="topMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="rightMargin">
+                              <number>0</number>
+                             </property>
+                             <property name="bottomMargin">
+                              <number>0</number>
+                             </property>
+                             <item>
+                              <widget class="QLineEdit" name="advOutFFURL">
+                               <property name="enabled">
+                                <bool>true</bool>
+                               </property>
+                              </widget>
+                             </item>
+                            </layout>
+                           </widget>
+                          </widget>
+                         </item>
+                         <item row="3" column="0">
+                          <widget class="QLabel" name="label_16">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.Format</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFFormat</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="1">
+                          <widget class="QComboBox" name="advOutFFFormat"/>
+                         </item>
+                         <item row="4" column="0">
+                          <widget class="QLabel" name="label_44">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.FormatDesc</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="4" column="1">
+                          <widget class="QLabel" name="advOutFFFormatDesc">
+                           <property name="text">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="7" column="0">
+                          <widget class="QLabel" name="label_40">
+                           <property name="text">
+                            <string>Basic.Settings.Output.VideoBitrate</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFVBitrate</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="7" column="1">
+                          <widget class="QSpinBox" name="advOutFFVBitrate">
+                           <property name="minimum">
+                            <number>0</number>
+                           </property>
+                           <property name="maximum">
+                            <number>1000000000</number>
+                           </property>
+                           <property name="value">
+                            <number>2500</number>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="8" column="1">
+                          <widget class="QSpinBox" name="advOutFFVGOPSize">
+                           <property name="maximum">
+                            <number>1000000000</number>
+                           </property>
+                           <property name="value">
+                            <number>250</number>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="8" column="0">
+                          <widget class="QLabel" name="label_63">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.GOPSize</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFVGOPSize</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="9" column="0">
+                          <widget class="QCheckBox" name="advOutFFUseRescale">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="layoutDirection">
+                            <enum>Qt::RightToLeft</enum>
+                           </property>
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.Rescale</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="9" column="1">
+                          <widget class="QComboBox" name="advOutFFRescale">
+                           <property name="enabled">
+                            <bool>false</bool>
+                           </property>
+                           <property name="editable">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="10" column="1">
+                          <widget class="QCheckBox" name="advOutFFIgnoreCompat">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.IgnoreCodecCompat</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="11" column="0">
+                          <widget class="QLabel" name="label_37">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.VEncoder</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFVEncoder</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="11" column="1">
+                          <widget class="QComboBox" name="advOutFFVEncoder"/>
+                         </item>
+                         <item row="13" column="0">
+                          <widget class="QLabel" name="label_38">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.VEncoderSettings</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFVCfg</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="13" column="1">
+                          <widget class="QLineEdit" name="advOutFFVCfg"/>
+                         </item>
+                         <item row="14" column="0">
+                          <widget class="QLabel" name="label_41">
+                           <property name="text">
+                            <string>Basic.Settings.Output.AudioBitrate</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFABitrate</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="14" column="1">
+                          <widget class="QSpinBox" name="advOutFFABitrate">
+                           <property name="minimum">
+                            <number>32</number>
+                           </property>
+                           <property name="maximum">
+                            <number>4096</number>
+                           </property>
+                           <property name="singleStep">
+                            <number>16</number>
+                           </property>
+                           <property name="value">
+                            <number>128</number>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="15" column="0">
+                          <widget class="QLabel" name="label_47">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.AudioTrack</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="15" column="1">
+                          <widget class="QWidget" name="widget_10" native="true">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <layout class="QHBoxLayout" name="horizontalLayout_10">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item>
+                             <widget class="QRadioButton" name="advOutFFTrack1">
+                              <property name="text">
+                               <string notr="true">1</string>
+                              </property>
+                              <property name="checked">
+                               <bool>true</bool>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QRadioButton" name="advOutFFTrack2">
+                              <property name="text">
+                               <string notr="true">2</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QRadioButton" name="advOutFFTrack3">
+                              <property name="text">
+                               <string notr="true">3</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QRadioButton" name="advOutFFTrack4">
+                              <property name="text">
+                               <string notr="true">4</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QRadioButton" name="advOutFFTrack5">
+                              <property name="text">
+                               <string notr="true">5</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="QRadioButton" name="advOutFFTrack6">
+                              <property name="text">
+                               <string notr="true">6</string>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="17" column="0">
+                          <widget class="QLabel" name="label_39">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.AEncoder</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFAEncoder</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="17" column="1">
+                          <widget class="QComboBox" name="advOutFFAEncoder"/>
+                         </item>
+                         <item row="18" column="0">
+                          <widget class="QLabel" name="label_46">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.AEncoderSettings</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFACfg</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="18" column="1">
+                          <widget class="QLineEdit" name="advOutFFACfg"/>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_48">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>170</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.Type</string>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFType</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="1">
+                          <widget class="QComboBox" name="advOutFFType">
+                           <item>
+                            <property name="text">
+                             <string>Basic.Settings.Output.Adv.FFmpeg.Type.RecordToFile</string>
+                            </property>
+                           </item>
+                           <item>
+                            <property name="text">
+                             <string>Basic.Settings.Output.Adv.FFmpeg.Type.URL</string>
+                            </property>
+                           </item>
+                          </widget>
+                         </item>
+                         <item row="5" column="0">
+                          <widget class="QLabel" name="label_1337">
+                           <property name="text">
+                            <string>Basic.Settings.Output.Adv.FFmpeg.MuxerSettings</string>
+                           </property>
+                           <property name="buddy">
+                            <cstring>advOutFFMCfg</cstring>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="5" column="1">
+                          <widget class="QLineEdit" name="advOutFFMCfg"/>
+                         </item>
+                         <item row="2" column="1">
+                          <widget class="QCheckBox" name="advOutFFNoSpace">
+                           <property name="text">
+                            <string>Basic.Settings.Output.NoSpaceFileName</string>
+                           </property>
+                           <property name="checked">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                   <widget class="QWidget" name="advOutputAudioTracksTab">
+                    <attribute name="title">
+                     <string>Basic.Settings.Audio</string>
+                    </attribute>
+                    <layout class="QVBoxLayout" name="verticalLayout_9">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item alignment="Qt::AlignTop">
+                      <widget class="QWidget" name="widget_3" native="true">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <layout class="QVBoxLayout" name="verticalLayout_10">
                         <item>
-                         <widget class="QRadioButton" name="advOutFFTrack4">
-                          <property name="text">
-                           <string notr="true">4</string>
+                         <widget class="QGroupBox" name="groupBox">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
                           </property>
+                          <property name="title">
+                           <string>Basic.Settings.Output.Adv.Audio.Track1</string>
+                          </property>
+                          <layout class="QFormLayout" name="formLayout_10">
+                           <property name="fieldGrowthPolicy">
+                            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                           </property>
+                           <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <item row="0" column="1">
+                            <widget class="QComboBox" name="advOutTrack1Bitrate">
+                             <property name="currentIndex">
+                              <number>8</number>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>32</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>48</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>64</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>80</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>96</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>112</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>128</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>160</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>192</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>256</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>320</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_25">
+                             <property name="minimumSize">
+                              <size>
+                               <width>170</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="text">
+                              <string>Basic.Settings.Output.AudioBitrate</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack1Bitrate</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_55">
+                             <property name="text">
+                              <string>Name</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack1Name</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="1">
+                            <widget class="QLineEdit" name="advOutTrack1Name"/>
+                           </item>
+                          </layout>
                          </widget>
                         </item>
                         <item>
-                         <widget class="QRadioButton" name="advOutFFTrack5">
-                          <property name="text">
-                           <string notr="true">5</string>
+                         <widget class="QGroupBox" name="groupBox_2">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
                           </property>
+                          <property name="title">
+                           <string>Basic.Settings.Output.Adv.Audio.Track2</string>
+                          </property>
+                          <layout class="QFormLayout" name="formLayout_11">
+                           <property name="fieldGrowthPolicy">
+                            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                           </property>
+                           <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_49">
+                             <property name="minimumSize">
+                              <size>
+                               <width>170</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="text">
+                              <string>Basic.Settings.Output.AudioBitrate</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack2Bitrate</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="0" column="1">
+                            <widget class="QComboBox" name="advOutTrack2Bitrate">
+                             <property name="currentIndex">
+                              <number>8</number>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>32</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>48</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>64</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>80</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>96</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>112</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>128</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>160</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>192</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>256</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>320</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_50">
+                             <property name="text">
+                              <string>Name</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack2Name</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="1">
+                            <widget class="QLineEdit" name="advOutTrack2Name"/>
+                           </item>
+                          </layout>
                          </widget>
                         </item>
                         <item>
-                         <widget class="QRadioButton" name="advOutFFTrack6">
+                         <widget class="QGroupBox" name="groupBox_3">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="title">
+                           <string>Basic.Settings.Output.Adv.Audio.Track3</string>
+                          </property>
+                          <layout class="QFormLayout" name="formLayout_12">
+                           <property name="fieldGrowthPolicy">
+                            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                           </property>
+                           <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_51">
+                             <property name="minimumSize">
+                              <size>
+                               <width>170</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="text">
+                              <string>Basic.Settings.Output.AudioBitrate</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack3Bitrate</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="0" column="1">
+                            <widget class="QComboBox" name="advOutTrack3Bitrate">
+                             <property name="currentIndex">
+                              <number>8</number>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>32</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>48</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>64</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>80</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>96</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>112</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>128</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>160</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>192</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>256</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>320</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_52">
+                             <property name="text">
+                              <string>Name</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack3Name</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="1">
+                            <widget class="QLineEdit" name="advOutTrack3Name"/>
+                           </item>
+                          </layout>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QGroupBox" name="groupBox_4">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="title">
+                           <string>Basic.Settings.Output.Adv.Audio.Track4</string>
+                          </property>
+                          <layout class="QFormLayout" name="formLayout_13">
+                           <property name="fieldGrowthPolicy">
+                            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                           </property>
+                           <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_53">
+                             <property name="minimumSize">
+                              <size>
+                               <width>170</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="text">
+                              <string>Basic.Settings.Output.AudioBitrate</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack4Bitrate</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="0" column="1">
+                            <widget class="QComboBox" name="advOutTrack4Bitrate">
+                             <property name="currentIndex">
+                              <number>8</number>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>32</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>48</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>64</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>80</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>96</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>112</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>128</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>160</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>192</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>256</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>320</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_54">
+                             <property name="text">
+                              <string>Name</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack4Name</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="1">
+                            <widget class="QLineEdit" name="advOutTrack4Name"/>
+                           </item>
+                          </layout>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QGroupBox" name="groupBox_9">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="title">
+                           <string>Basic.Settings.Output.Adv.Audio.Track5</string>
+                          </property>
+                          <layout class="QFormLayout" name="formLayout_25">
+                           <property name="fieldGrowthPolicy">
+                            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                           </property>
+                           <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_59">
+                             <property name="minimumSize">
+                              <size>
+                               <width>170</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="text">
+                              <string>Basic.Settings.Output.AudioBitrate</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack5Bitrate</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="0" column="1">
+                            <widget class="QComboBox" name="advOutTrack5Bitrate">
+                             <property name="currentIndex">
+                              <number>8</number>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>32</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>48</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>64</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>80</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>96</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>112</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>128</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>160</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>192</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>256</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>320</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_60">
+                             <property name="text">
+                              <string>Name</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack5Name</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="1">
+                            <widget class="QLineEdit" name="advOutTrack5Name"/>
+                           </item>
+                          </layout>
+                         </widget>
+                        </item>
+                        <item>
+                         <widget class="QGroupBox" name="groupBox_12">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="title">
+                           <string>Basic.Settings.Output.Adv.Audio.Track6</string>
+                          </property>
+                          <layout class="QFormLayout" name="formLayout_26">
+                           <property name="fieldGrowthPolicy">
+                            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                           </property>
+                           <property name="labelAlignment">
+                            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                           </property>
+                           <item row="0" column="0">
+                            <widget class="QLabel" name="label_61">
+                             <property name="minimumSize">
+                              <size>
+                               <width>170</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                             <property name="text">
+                              <string>Basic.Settings.Output.AudioBitrate</string>
+                             </property>
+                             <property name="alignment">
+                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack6Bitrate</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="0" column="1">
+                            <widget class="QComboBox" name="advOutTrack6Bitrate">
+                             <property name="currentIndex">
+                              <number>8</number>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>32</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>48</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>64</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>80</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>96</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>112</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>128</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>160</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>192</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>256</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>320</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_62">
+                             <property name="text">
+                              <string>Name</string>
+                             </property>
+                             <property name="buddy">
+                              <cstring>advOutTrack6Name</cstring>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="1" column="1">
+                            <widget class="QLineEdit" name="advOutTrack6Name"/>
+                           </item>
+                          </layout>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                   <widget class="QWidget" name="advOutputReplayTab">
+                    <attribute name="title">
+                     <string>ReplayBuffer</string>
+                    </attribute>
+                    <layout class="QVBoxLayout" name="verticalLayout_22">
+                     <item>
+                      <widget class="QCheckBox" name="advReplayBuf">
+                       <property name="text">
+                        <string>Basic.Settings.Output.UseReplayBuffer</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="Line" name="line_4">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QGroupBox" name="advReplayBufferGroupBox">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="title">
+                        <string>ReplayBuffer</string>
+                       </property>
+                       <property name="flat">
+                        <bool>false</bool>
+                       </property>
+                       <property name="checkable">
+                        <bool>false</bool>
+                       </property>
+                       <layout class="QFormLayout" name="formLayout_30">
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="advRBSecMaxLabel">
                           <property name="text">
-                           <string notr="true">6</string>
+                           <string>Basic.Settings.Output.ReplayBuffer.SecondsMax</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="0" column="1">
+                         <widget class="QSpinBox" name="advRBSecMax">
+                          <property name="suffix">
+                           <string notr="true"> sec</string>
+                          </property>
+                          <property name="minimum">
+                           <number>5</number>
+                          </property>
+                          <property name="maximum">
+                           <number>21600</number>
+                          </property>
+                          <property name="value">
+                           <number>15</number>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QLabel" name="advRBHotkeyLabel">
+                          <property name="text">
+                           <string>Basic.Settings.Output.ReplayBuffer.HotkeyMessage</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="1">
+                         <widget class="QLabel" name="advRBEstimate">
+                          <property name="text">
+                           <string notr="true"/>
                           </property>
                          </widget>
                         </item>
                        </layout>
                       </widget>
                      </item>
-                     <item row="17" column="0">
-                      <widget class="QLabel" name="label_39">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.AEncoder</string>
+                     <item>
+                      <spacer name="verticalSpacer">
+                       <property name="orientation">
+                        <enum>Qt::Vertical</enum>
                        </property>
-                       <property name="buddy">
-                        <cstring>advOutFFAEncoder</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="17" column="1">
-                      <widget class="QComboBox" name="advOutFFAEncoder"/>
-                     </item>
-                     <item row="18" column="0">
-                      <widget class="QLabel" name="label_46">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.AEncoderSettings</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFACfg</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="18" column="1">
-                      <widget class="QLineEdit" name="advOutFFACfg"/>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_48">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
+                       <property name="sizeHint" stdset="0">
                         <size>
-                         <width>170</width>
-                         <height>0</height>
+                         <width>20</width>
+                         <height>40</height>
                         </size>
                        </property>
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.Type</string>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFType</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QComboBox" name="advOutFFType">
-                       <item>
-                        <property name="text">
-                         <string>Basic.Settings.Output.Adv.FFmpeg.Type.RecordToFile</string>
-                        </property>
-                       </item>
-                       <item>
-                        <property name="text">
-                         <string>Basic.Settings.Output.Adv.FFmpeg.Type.URL</string>
-                        </property>
-                       </item>
-                      </widget>
-                     </item>
-                     <item row="5" column="0">
-                      <widget class="QLabel" name="label_1337">
-                       <property name="text">
-                        <string>Basic.Settings.Output.Adv.FFmpeg.MuxerSettings</string>
-                       </property>
-                       <property name="buddy">
-                        <cstring>advOutFFMCfg</cstring>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="5" column="1">
-                      <widget class="QLineEdit" name="advOutFFMCfg"/>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QCheckBox" name="advOutFFNoSpace">
-                       <property name="text">
-                        <string>Basic.Settings.Output.NoSpaceFileName</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
+                      </spacer>
                      </item>
                     </layout>
                    </widget>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
-               <widget class="QWidget" name="advOutputAudioTracksTab">
-                <attribute name="title">
-                 <string>Basic.Settings.Audio</string>
-                </attribute>
-                <layout class="QVBoxLayout" name="verticalLayout_9">
-                 <property name="leftMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>0</number>
-                 </property>
-                 <property name="bottomMargin">
-                  <number>0</number>
-                 </property>
-                 <item alignment="Qt::AlignTop">
-                  <widget class="QWidget" name="widget_3" native="true">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <layout class="QVBoxLayout" name="verticalLayout_10">
-                    <item>
-                     <widget class="QGroupBox" name="groupBox">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="title">
-                       <string>Basic.Settings.Output.Adv.Audio.Track1</string>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_10">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="0" column="1">
-                        <widget class="QComboBox" name="advOutTrack1Bitrate">
-                         <property name="currentIndex">
-                          <number>8</number>
-                         </property>
-                         <item>
-                          <property name="text">
-                           <string>32</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>48</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>64</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>80</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>96</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>112</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>128</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>160</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>192</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>256</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>320</string>
-                          </property>
-                         </item>
-                        </widget>
-                       </item>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="label_25">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.AudioBitrate</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack1Bitrate</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_55">
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack1Name</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="advOutTrack1Name"/>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QGroupBox" name="groupBox_2">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="title">
-                       <string>Basic.Settings.Output.Adv.Audio.Track2</string>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_11">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="label_49">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.AudioBitrate</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack2Bitrate</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
-                        <widget class="QComboBox" name="advOutTrack2Bitrate">
-                         <property name="currentIndex">
-                          <number>8</number>
-                         </property>
-                         <item>
-                          <property name="text">
-                           <string>32</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>48</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>64</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>80</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>96</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>112</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>128</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>160</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>192</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>256</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>320</string>
-                          </property>
-                         </item>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_50">
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack2Name</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="advOutTrack2Name"/>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QGroupBox" name="groupBox_3">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="title">
-                       <string>Basic.Settings.Output.Adv.Audio.Track3</string>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_12">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="label_51">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.AudioBitrate</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack3Bitrate</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
-                        <widget class="QComboBox" name="advOutTrack3Bitrate">
-                         <property name="currentIndex">
-                          <number>8</number>
-                         </property>
-                         <item>
-                          <property name="text">
-                           <string>32</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>48</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>64</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>80</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>96</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>112</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>128</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>160</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>192</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>256</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>320</string>
-                          </property>
-                         </item>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_52">
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack3Name</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="advOutTrack3Name"/>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QGroupBox" name="groupBox_4">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="title">
-                       <string>Basic.Settings.Output.Adv.Audio.Track4</string>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_13">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="label_53">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.AudioBitrate</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack4Bitrate</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
-                        <widget class="QComboBox" name="advOutTrack4Bitrate">
-                         <property name="currentIndex">
-                          <number>8</number>
-                         </property>
-                         <item>
-                          <property name="text">
-                           <string>32</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>48</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>64</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>80</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>96</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>112</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>128</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>160</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>192</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>256</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>320</string>
-                          </property>
-                         </item>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_54">
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack4Name</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="advOutTrack4Name"/>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QGroupBox" name="groupBox_9">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="title">
-                       <string>Basic.Settings.Output.Adv.Audio.Track5</string>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_25">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="label_59">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.AudioBitrate</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack5Bitrate</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
-                        <widget class="QComboBox" name="advOutTrack5Bitrate">
-                         <property name="currentIndex">
-                          <number>8</number>
-                         </property>
-                         <item>
-                          <property name="text">
-                           <string>32</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>48</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>64</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>80</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>96</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>112</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>128</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>160</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>192</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>256</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>320</string>
-                          </property>
-                         </item>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_60">
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack5Name</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="advOutTrack5Name"/>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QGroupBox" name="groupBox_12">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="title">
-                       <string>Basic.Settings.Output.Adv.Audio.Track6</string>
-                      </property>
-                      <layout class="QFormLayout" name="formLayout_26">
-                       <property name="fieldGrowthPolicy">
-                        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-                       </property>
-                       <property name="labelAlignment">
-                        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                       </property>
-                       <item row="0" column="0">
-                        <widget class="QLabel" name="label_61">
-                         <property name="minimumSize">
-                          <size>
-                           <width>170</width>
-                           <height>0</height>
-                          </size>
-                         </property>
-                         <property name="text">
-                          <string>Basic.Settings.Output.AudioBitrate</string>
-                         </property>
-                         <property name="alignment">
-                          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack6Bitrate</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1">
-                        <widget class="QComboBox" name="advOutTrack6Bitrate">
-                         <property name="currentIndex">
-                          <number>8</number>
-                         </property>
-                         <item>
-                          <property name="text">
-                           <string>32</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>48</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>64</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>80</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>96</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>112</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>128</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>160</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>192</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>256</string>
-                          </property>
-                         </item>
-                         <item>
-                          <property name="text">
-                           <string>320</string>
-                          </property>
-                         </item>
-                        </widget>
-                       </item>
-                       <item row="1" column="0">
-                        <widget class="QLabel" name="label_62">
-                         <property name="text">
-                          <string>Name</string>
-                         </property>
-                         <property name="buddy">
-                          <cstring>advOutTrack6Name</cstring>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="1" column="1">
-                        <widget class="QLineEdit" name="advOutTrack6Name"/>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                   </layout>
                   </widget>
                  </item>
                 </layout>
@@ -2992,10 +3088,6 @@
             </layout>
            </widget>
           </widget>
-         </item>
-         </layout>
-         </widget>
-         </widget>
          </item>
         </layout>
        </widget>
@@ -3545,7 +3637,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>593</width>
+              <width>596</width>
               <height>761</height>
              </rect>
             </property>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1009,10 +1009,13 @@ struct AdvancedOutput : BasicOutputHandler {
 
 	virtual bool StartStreaming(obs_service_t *service) override;
 	virtual bool StartRecording() override;
+	virtual bool StartReplayBuffer() override;
 	virtual void StopStreaming(bool force) override;
 	virtual void StopRecording(bool force) override;
+	virtual void StopReplayBuffer(bool force) override;
 	virtual bool StreamingActive() const override;
 	virtual bool RecordingActive() const override;
+	virtual bool ReplayBufferActive() const override;
 };
 
 static OBSData GetDataFromJsonFile(const char *jsonFile)
@@ -1058,11 +1061,37 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			      "(advanced output)";
 		obs_output_release(fileOutput);
 	} else {
+		bool useReplayBuffer = config_get_bool(main->Config(),
+				"AdvOut", "RecRB");
+		if (useReplayBuffer) {
+			const char *str = config_get_string(main->Config(),
+					"Hotkeys", "ReplayBuffer");
+			obs_data_t *hotkey = obs_data_create_from_json(str);
+			replayBuffer = obs_output_create("replay_buffer",
+					Str("ReplayBuffer"), nullptr, hotkey);
+
+			obs_data_release(hotkey);
+			if (!replayBuffer)
+				throw "Failed to create replay buffer output "
+						"(simple output)";
+			obs_output_release(replayBuffer);
+
+			signal_handler_t *signal =
+					obs_output_get_signal_handler(replayBuffer);
+
+			startReplayBuffer.Connect(signal, "start",
+					OBSStartReplayBuffer, this);
+			stopReplayBuffer.Connect(signal, "stop",
+					OBSStopReplayBuffer, this);
+			replayBufferStopping.Connect(signal, "stopping",
+					OBSReplayBufferStopping, this);
+		}
+
 		fileOutput = obs_output_create("ffmpeg_muxer",
 				"adv_file_output", nullptr, nullptr);
 		if (!fileOutput)
 			throw "Failed to create recording output "
-			      "(advanced output)";
+					"(advanced output)";
 		obs_output_release(fileOutput);
 
 		if (!useStreamEncoder) {
@@ -1071,7 +1100,7 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 					nullptr);
 			if (!h264Recording)
 				throw "Failed to create recording h264 "
-				      "encoder (advanced output)";
+						"encoder (advanced output)";
 			obs_encoder_release(h264Recording);
 		}
 	}
@@ -1080,7 +1109,7 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			"streaming_h264", streamEncSettings, nullptr);
 	if (!h264Streaming)
 		throw "Failed to create streaming h264 encoder "
-		      "(advanced output)";
+				"(advanced output)";
 	obs_encoder_release(h264Streaming);
 
 	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
@@ -1088,9 +1117,9 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 		sprintf(name, "adv_aac%d", i);
 
 		if (!CreateAACEncoder(aacTrack[i], aacEncoderID[i],
-					GetAudioBitrate(i), name, i))
+				GetAudioBitrate(i), name, i))
 			throw "Failed to create audio encoder "
-			      "(advanced output)";
+					"(advanced output)";
 	}
 
 	startRecording.Connect(obs_output_get_signal_handler(fileOutput),
@@ -1185,18 +1214,27 @@ inline void AdvancedOutput::SetupRecording()
 		obs_encoder_set_scaled_size(h264Recording, cx, cy);
 		obs_encoder_set_video(h264Recording, obs_get_video());
 		obs_output_set_video_encoder(fileOutput, h264Recording);
+		if (replayBuffer)
+			obs_output_set_video_encoder(replayBuffer,
+					h264Recording);
 	}
 
 	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
 		if ((tracks & (1<<i)) != 0) {
 			obs_output_set_audio_encoder(fileOutput, aacTrack[i],
-					idx++);
+					idx);
+			if (replayBuffer)
+				obs_output_set_audio_encoder(replayBuffer,
+						aacTrack[i], idx);
+			idx++;
 		}
 	}
 
 	obs_data_set_string(settings, "path", path);
 	obs_data_set_string(settings, "muxer_settings", mux);
 	obs_output_update(fileOutput, settings);
+	if (replayBuffer)
+		obs_output_update(replayBuffer, settings);
 	obs_data_release(settings);
 }
 
@@ -1549,6 +1587,117 @@ bool AdvancedOutput::StartRecording()
 	return true;
 }
 
+bool AdvancedOutput::StartReplayBuffer()
+{
+	const char *path;
+	const char *recFormat;
+	const char *filenameFormat;
+	bool noSpace = false;
+	bool overwriteIfExists = false;
+	const char *rbPrefix;
+	const char *rbSuffix;
+	int rbTime;
+
+	if (!useStreamEncoder) {
+		if (!ffmpegOutput)
+			UpdateRecordingSettings();
+	} else if (!obs_output_active(streamOutput)) {
+		UpdateStreamSettings();
+	}
+
+	UpdateAudioSettings();
+
+	if (!Active())
+		SetupOutputs();
+
+	if (!ffmpegOutput || ffmpegRecording) {
+		path = config_get_string(main->Config(), "AdvOut",
+				ffmpegRecording ? "FFFilePath" : "RecFilePath");
+		recFormat = config_get_string(main->Config(), "AdvOut",
+				ffmpegRecording ? "FFExtension" : "RecFormat");
+		filenameFormat = config_get_string(main->Config(), "Output",
+				"FilenameFormatting");
+		overwriteIfExists = config_get_bool(main->Config(), "Output",
+				"OverwriteIfExists");
+		noSpace = config_get_bool(main->Config(), "AdvOut",
+				ffmpegRecording ?
+				"FFFileNameWithoutSpace" :
+				"RecFileNameWithoutSpace");
+		rbPrefix = config_get_string(main->Config(), "SimpleOutput",
+				"RecRBPrefix");
+		rbSuffix = config_get_string(main->Config(), "SimpleOutput",
+				"RecRBSuffix");
+		rbTime = config_get_int(main->Config(), "AdvOut",
+				"RecRBTime");
+
+		os_dir_t *dir = path && path[0] ? os_opendir(path) : nullptr;
+
+		if (!dir) {
+			if (main->isVisible())
+				OBSMessageBox::information(main,
+						QTStr("Output.BadPath.Title"),
+						QTStr("Output.BadPath.Text"));
+			else
+				main->SysTrayNotify(QTStr("Output.BadPath.Text"),
+						QSystemTrayIcon::Warning);
+			return false;
+		}
+
+		os_closedir(dir);
+
+		string strPath;
+		strPath += path;
+
+		char lastChar = strPath.back();
+		if (lastChar != '/' && lastChar != '\\')
+			strPath += "/";
+
+		strPath += GenerateSpecifiedFilename(recFormat, noSpace,
+				filenameFormat);
+		ensure_directory_exists(strPath);
+		if (!overwriteIfExists)
+			FindBestFilename(strPath, noSpace);
+
+		obs_data_t *settings = obs_data_create();
+		string f;
+
+		if (rbPrefix && *rbPrefix) {
+			f += rbPrefix;
+			if (f.back() != ' ')
+				f += " ";
+		}
+
+		f += filenameFormat;
+
+		if (rbSuffix && *rbSuffix) {
+			if (*rbSuffix != ' ')
+				f += " ";
+			f += rbSuffix;
+		}
+
+		remove_reserved_file_characters(f);
+
+		obs_data_set_string(settings, "directory", path);
+		obs_data_set_string(settings, "format", f.c_str());
+		obs_data_set_string(settings, "extension", recFormat);
+		obs_data_set_int(settings, "max_time_sec", rbTime);
+		obs_data_set_int(settings, "max_size_mb",  0);
+
+		obs_output_update(replayBuffer, settings);
+
+		obs_data_release(settings);
+	}
+
+	if (!obs_output_start(replayBuffer)) {
+		QMessageBox::critical(main,
+				QTStr("Output.StartRecordingFailed"),
+				QTStr("Output.StartFailedGeneric"));
+		return false;
+	}
+
+	return true;
+}
+
 void AdvancedOutput::StopStreaming(bool force)
 {
 	if (force)
@@ -1565,6 +1714,14 @@ void AdvancedOutput::StopRecording(bool force)
 		obs_output_stop(fileOutput);
 }
 
+void AdvancedOutput::StopReplayBuffer(bool force)
+{
+	if (force)
+		obs_output_force_stop(replayBuffer);
+	else
+		obs_output_stop(replayBuffer);
+}
+
 bool AdvancedOutput::StreamingActive() const
 {
 	return obs_output_active(streamOutput);
@@ -1573,6 +1730,11 @@ bool AdvancedOutput::StreamingActive() const
 bool AdvancedOutput::RecordingActive() const
 {
 	return obs_output_active(fileOutput);
+}
+
+bool AdvancedOutput::ReplayBufferActive() const
+{
+	return obs_output_active(replayBuffer);
 }
 
 /* ------------------------------------------------------------------------ */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1049,6 +1049,9 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_uint  (basicConfig, "AdvOut", "Track5Bitrate", 160);
 	config_set_default_uint  (basicConfig, "AdvOut", "Track6Bitrate", 160);
 
+	config_set_default_bool  (basicConfig, "AdvOut", "RecRB", false);
+	config_set_default_uint  (basicConfig, "AdvOut", "RecRBTime", 20);
+
 	config_set_default_uint  (basicConfig, "Video", "BaseCX",   cx);
 	config_set_default_uint  (basicConfig, "Video", "BaseCY",   cy);
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -387,6 +387,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->advOutTrack5Name,     EDIT_CHANGED,   OUTPUTS_CHANGED);
 	HookWidget(ui->advOutTrack6Bitrate,  COMBO_CHANGED,  OUTPUTS_CHANGED);
 	HookWidget(ui->advOutTrack6Name,     EDIT_CHANGED,   OUTPUTS_CHANGED);
+	HookWidget(ui->advReplayBuf,         CHECK_CHANGED,  OUTPUTS_CHANGED);
+	HookWidget(ui->advRBSecMax,          SCROLL_CHANGED, OUTPUTS_CHANGED);
 	HookWidget(ui->channelSetup,         COMBO_CHANGED,  AUDIO_RESTART);
 	HookWidget(ui->sampleRate,           COMBO_CHANGED,  AUDIO_RESTART);
 	HookWidget(ui->desktopAudioDevice1,  COMBO_CHANGED,  AUDIO_CHANGED);
@@ -616,6 +618,36 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 			this, SLOT(SimpleReplayBufferChanged()));
 	connect(ui->simpleRBSecMax, SIGNAL(valueChanged(int)),
 			this, SLOT(SimpleReplayBufferChanged()));
+	connect(ui->advReplayBuf, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecTrack1, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecTrack2, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecTrack3, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecTrack4, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecTrack5, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecTrack6, SIGNAL(toggled(bool)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutTrack1Bitrate, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutTrack2Bitrate, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutTrack3Bitrate, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutTrack4Bitrate, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutTrack5Bitrate, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutTrack6Bitrate, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advOutRecType, SIGNAL(currentIndexChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
+	connect(ui->advRBSecMax, SIGNAL(valueChanged(int)),
+			this, SLOT(AdvReplayBufferChanged()));
 	connect(ui->listWidget, SIGNAL(currentRowChanged(int)),
 			this, SLOT(SimpleRecordingEncoderChanged()));
 
@@ -1495,6 +1527,8 @@ void OBSBasicSettings::LoadAdvOutputStreamingEncoderProperties()
 
 	connect(streamEncoderProps, SIGNAL(Changed()),
 			this, SLOT(UpdateStreamDelayEstimate()));
+	connect(streamEncoderProps, SIGNAL(Changed()),
+			this, SLOT(AdvReplayBufferChanged()));
 
 	curAdvStreamEncoder = type;
 
@@ -1561,6 +1595,8 @@ void OBSBasicSettings::LoadAdvOutputRecordingEncoderProperties()
 		recordEncoderProps = CreateEncoderPropertyView(type,
 				"recordEncoder.json");
 		ui->advOutRecStandard->layout()->addWidget(recordEncoderProps);
+		connect(recordEncoderProps, SIGNAL(Changed()),
+				this, SLOT(AdvReplayBufferChanged()));
 	}
 
 	curAdvRecordEncoder = type;
@@ -2054,6 +2090,10 @@ void OBSBasicSettings::LoadAdvancedSettings()
 			"RecRBPrefix");
 	const char *rbSuffix = config_get_string(main->Config(), "SimpleOutput",
 			"RecRBSuffix");
+	bool replayBuf = config_get_bool(main->Config(), "AdvOut",
+			"RecRB");
+	int rbTime = config_get_int(main->Config(), "AdvOut",
+			"RecRBTime");
 	loading = true;
 
 	LoadRendererList();
@@ -2067,6 +2107,9 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
 	ui->simpleRBPrefix->setText(rbPrefix);
 	ui->simpleRBSuffix->setText(rbSuffix);
+
+	ui->advReplayBuf->setChecked(replayBuf);
+	ui->advRBSecMax->setValue(rbTime);
 
 	ui->reconnectEnable->setChecked(reconnect);
 	ui->reconnectRetryDelay->setValue(retryDelay);
@@ -2858,6 +2901,9 @@ void OBSBasicSettings::SaveOutputSettings()
 	SaveEdit(ui->advOutTrack5Name, "AdvOut", "Track5Name");
 	SaveEdit(ui->advOutTrack6Name, "AdvOut", "Track6Name");
 
+	SaveCheckBox(ui->advReplayBuf, "AdvOut", "RecRB");
+	SaveSpinBox(ui->advRBSecMax, "AdvOut", "RecRBTime");
+
 	WriteJsonData(streamEncoderProps, "streamEncoder.json");
 	WriteJsonData(recordEncoderProps, "recordEncoder.json");
 	main->ResetOutputs();
@@ -3188,6 +3234,8 @@ void OBSBasicSettings::on_advOutRecEncoder_currentIndexChanged(int idx)
 				loadSettings ? "recordEncoder.json" : nullptr,
 				true);
 		ui->advOutRecStandard->layout()->addWidget(recordEncoderProps);
+		connect(recordEncoderProps, SIGNAL(Changed()),
+				this, SLOT(AdvReplayBufferChanged()));
 	}
 }
 
@@ -3734,8 +3782,15 @@ void OBSBasicSettings::SimpleStreamingEncoderChanged()
 
 void OBSBasicSettings::UpdateAutomaticReplayBufferCheckboxes()
 {
-	bool state = ui->simpleReplayBuf->isChecked() &&
-		ui->outputMode->currentIndex() == 0;
+	bool state = false;
+	switch (ui->outputMode->currentIndex()) {
+	case 0:
+		state = ui->simpleReplayBuf->isChecked();
+		break;
+	case 1:
+		state = ui->advReplayBuf->isChecked();
+		break;
+	}
 	ui->replayWhileStreaming->setEnabled(state);
 	ui->keepReplayStreamStops->setEnabled(state &&
 			ui->replayWhileStreaming->isChecked());
@@ -3771,6 +3826,76 @@ void OBSBasicSettings::SimpleReplayBufferChanged()
 
 	UpdateAutomaticReplayBufferCheckboxes();
 
+}
+
+void OBSBasicSettings::AdvReplayBufferChanged()
+{
+	obs_data_t *settings;
+	QString encoder = ui->advOutRecEncoder->currentText();
+	bool useStream = QString::compare(encoder, TEXT_USE_STREAM_ENC) == 0;
+	if (useStream && streamEncoderProps) {
+		settings = streamEncoderProps->GetSettings();
+	} else if (!useStream && recordEncoderProps) {
+		settings = recordEncoderProps->GetSettings();
+	} else {
+		if (useStream)
+			encoder = GetComboData(ui->advOutEncoder);
+		settings = obs_encoder_defaults(encoder.toUtf8().constData());
+
+		if (!settings)
+			return;
+
+		char encoderJsonPath[512];
+		int ret = GetProfilePath(encoderJsonPath,
+				sizeof(encoderJsonPath), "recordEncoder.json");
+		if (ret > 0) {
+			obs_data_t *data = obs_data_create_from_json_file_safe(
+					encoderJsonPath, "bak");
+			obs_data_apply(settings, data);
+			obs_data_release(data);
+		}
+	}
+
+	int vbitrate = (int)obs_data_get_int(settings, "bitrate");
+	const char *rateControl = obs_data_get_string(settings, "rate_control");
+
+	bool lossless = strcmp(rateControl, "lossless") == 0 ||
+			ui->advOutRecType->currentIndex() == 1;
+	bool replayBufferEnabled = ui->advReplayBuf->isChecked();
+
+	int abitrate = 0;
+	if (ui->advOutRecTrack1->isChecked())
+		abitrate += ui->advOutTrack1Bitrate->currentText().toInt();
+	if (ui->advOutRecTrack2->isChecked())
+		abitrate += ui->advOutTrack2Bitrate->currentText().toInt();
+	if (ui->advOutRecTrack3->isChecked())
+		abitrate += ui->advOutTrack3Bitrate->currentText().toInt();
+	if (ui->advOutRecTrack4->isChecked())
+		abitrate += ui->advOutTrack4Bitrate->currentText().toInt();
+	if (ui->advOutRecTrack5->isChecked())
+		abitrate += ui->advOutTrack5Bitrate->currentText().toInt();
+	if (ui->advOutRecTrack6->isChecked())
+		abitrate += ui->advOutTrack6Bitrate->currentText().toInt();
+
+	int seconds = ui->advRBSecMax->value();
+
+	int64_t memMB = int64_t(seconds) * int64_t(vbitrate + abitrate) *
+			1000 / 8 / 1024 / 1024;
+	if (memMB < 1)
+		memMB = 1;
+
+	if (vbitrate > 0)
+		ui->advRBEstimate->setText(
+				QTStr(ESTIMATE_STR).arg(
+				QString::number(int(memMB))));
+	else
+		ui->advRBEstimate->setText(QTStr(ESTIMATE_UNKNOWN_STR));
+
+	ui->advReplayBufferGroupBox->setVisible(!lossless && replayBufferEnabled);
+	ui->line_4->setVisible(!lossless && replayBufferEnabled);
+	ui->advReplayBuf->setEnabled(!lossless);
+
+	UpdateAutomaticReplayBufferCheckboxes();
 }
 
 #define SIMPLE_OUTPUT_WARNING(str) \

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -295,6 +295,7 @@ private slots:
 	void SimpleRecordingQualityLosslessWarning(int idx);
 
 	void SimpleReplayBufferChanged();
+	void AdvReplayBufferChanged();
 
 	void SimpleStreamingEncoderChanged();
 


### PR DESCRIPTION
Replay buffer is currently only supported in simple mode. This change adds support to advanced mode and is, for the most part, a mirror of the addition of replay buffer to simple mode.

There are some things that were left out, such as max time, since advanced mode should always have a target bitrate. As per Jim's request, the options are in a new tab and the buffer is not available with lossless or FFmpeg enabled.

Mantis-bug: https://obsproject.com/mantis/view.php?id=792