### PR TITLE
Add an option to disable seeking in Media Source

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -531,6 +531,9 @@ static bool init_avformat(mp_media_t *m)
 	if (m->buffering && m->is_network)
 		av_dict_set_int(&opts, "buffer_size", m->buffering, 0);
 
+	if (m->not_seekable)
+		av_dict_set(&opts, "seekable", "0", 0);
+
 	m->fmt = avformat_alloc_context();
 	m->fmt->interrupt_callback.callback = interrupt_callback;
 	m->fmt->interrupt_callback.opaque = m;
@@ -674,6 +677,7 @@ bool mp_media_init(mp_media_t *media,
 		mp_stop_cb stop_cb,
 		mp_video_cb v_preload_cb,
 		bool hw_decoding,
+		bool not_seekable,
 		enum video_range_type force_range)
 {
 	memset(media, 0, sizeof(*media));
@@ -685,6 +689,7 @@ bool mp_media_init(mp_media_t *media,
 	media->v_preload_cb = v_preload_cb;
 	media->force_range = force_range;
 	media->buffering = buffering;
+	media->not_seekable = not_seekable;
 
 	if (path && *path)
 		media->is_network = !!strstr(path, "://");

--- a/deps/media-playback/media-playback/media.h
+++ b/deps/media-playback/media-playback/media.h
@@ -69,6 +69,7 @@ struct mp_media {
 	bool is_file;
 	bool eof;
 	bool hw;
+	bool not_seekable;
 
 	struct obs_source_frame obsframe;
 	enum video_colorspace cur_space;
@@ -107,6 +108,7 @@ extern bool mp_media_init(mp_media_t *media,
 		mp_stop_cb stop_cb,
 		mp_video_cb v_preload_cb,
 		bool hardware_decoding,
+		bool not_seekable,
 		enum video_range_type force_range);
 extern void mp_media_free(mp_media_t *media);
 

--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -35,6 +35,7 @@ ColorRange="YUV Color Range"
 ColorRange.Auto="Auto"
 ColorRange.Partial="Partial"
 ColorRange.Full="Full"
+DisableSeeking="Disable seeking"
 RestartMedia="Restart Media"
 
 MediaFileFilter.AllMediaFiles="All Media Files"


### PR DESCRIPTION
This PR adds an option to Media Source that disables seeking. This translates to the 'seekable' option of ffmpeg http protocol handler (https://ffmpeg.org/ffmpeg-protocols.html#http). Disabling seeking causes ffmpeg to not include Range header in the request.

I have a Sony DSC-QX10 camera that exposes its preview as a HTTP MJPEG stream. Unfortunaltely, it does not work when the Range header is included in the request (it responds with 406 Not Acceptable). Disabling seeking makes it work, though. :)