### PR TITLE
rtmp-services: Update ingest list for Restream.io

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 71,
+	"version": 72,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 71
+			"version": 72
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -671,6 +671,10 @@
                     "url": "rtmp://us-east.restream.io/live"
                 },
                 {
+                    "name": "US-East (Miami, FL)",
+                    "url": "rtmp://us-miami.restream.io/live"
+                },
+                {
                     "name": "NA-East (Toronto, Canada)",
                     "url": "rtmp://na-toronto.restream.io/live"
                 },


### PR DESCRIPTION
Update ingest list for Restream.io:
- add new Restream ingest: US-East (Miami, FL)
- update rtmp-services version

Restream ingests could be checked at: https://restream.io/ingests
