### PR TITLE
Video recording with audio : sounds like in the toilet...

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1301,7 +1301,7 @@ static bool initialize_interleaved_packets(struct obs_output *output)
 	}
 
 	/* get new offsets */
-	output->video_offset = video->dts;
+	output->video_offset = video->pts;
 	for (size_t i = 0; i < audio_mixes; i++)
 		output->audio_offsets[i] = audio[i]->dts;
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -523,7 +523,9 @@ static inline void video_sleep(struct obs_core_video *video,
 	video->total_frames += count;
 	video->lagged_frames += count - 1;
 
-	vframe_info.timestamp = cur_time;
+	/* XXX: subtracting the interval is a (hopefully temporary) hack to fix
+	 * video frames being one frame off. */
+	vframe_info.timestamp = cur_time - interval_ns;
 	vframe_info.count = count;
 	circlebuf_push_back(&video->vframe_info_buffer, &vframe_info,
 			sizeof(vframe_info));

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -347,6 +347,16 @@ static int send_packet(struct rtmp_stream *stream,
 		}
 	}
 
+	if (packet->type == OBS_ENCODER_VIDEO) {
+		if (!stream->got_first_video) {
+			stream->start_video_dts_offset = packet->dts;
+			stream->got_first_video = true;
+		}
+
+		packet->dts -= stream->start_video_dts_offset;
+		packet->pts -= stream->start_video_dts_offset;
+	}
+
 	flv_packet_mux(packet, &data, &size, is_header);
 
 #ifdef TEST_FRAMEDROPS
@@ -876,6 +886,7 @@ static bool init_connect(struct rtmp_stream *stream)
 	stream->total_bytes_sent = 0;
 	stream->dropped_frames   = 0;
 	stream->min_priority     = 0;
+	stream->got_first_video  = false;
 
 	settings = obs_output_get_settings(stream->output);
 	dstr_copy(&stream->path,     obs_service_get_url(service));

--- a/plugins/obs-outputs/rtmp-stream.h
+++ b/plugins/obs-outputs/rtmp-stream.h
@@ -51,6 +51,9 @@ struct rtmp_stream {
 	struct circlebuf packets;
 	bool             sent_headers;
 
+	bool             got_first_video;
+	int64_t          start_video_dts_offset;
+
 	volatile bool    connecting;
 	pthread_t        connect_thread;
 


### PR DESCRIPTION
Hello,

I have a little issue.. 

As I'm not english speaker, I will make it simple : 

- I'm trying to record video with its original audio with OBS
- The video quality is perfect
- The sound is terrible... 

I have the choice between speakers or mic, I chose speakers but the sound is terrible, it's like it's been recorded from the toilets or any other closed and empty place.. 

Would it be possible to help me with that, or to add a third choice : "incoming audio" or "original audio" so that it would record the audio from the desktop window or the software, instead of the speakers ? 

Thanks a lot !