### PR TITLE
linux-alsa: Display the "Custom" entry once only

### DIFF
--- a/plugins/linux-alsa/alsa-input.c
+++ b/plugins/linux-alsa/alsa-input.c
@@ -312,8 +312,6 @@ obs_properties_t * alsa_get_properties(void *unused)
 
 		obs_property_list_add_string(devices, descr, name);
 
-	obs_property_list_add_string(devices, "Custom", "__custom__");
-
 	next:
 		if (name != NULL)
 			free(name), name = NULL;
@@ -326,6 +324,8 @@ obs_properties_t * alsa_get_properties(void *unused)
 
 		++hint;
 	}
+	obs_property_list_add_string(devices, "Custom", "__custom__");
+
 	snd_device_name_free_hint(hints);
 
 	return props;


### PR DESCRIPTION
The "Custom" device entry was added inside the loop that runs for each device; this causes "Custom" to be added once for each device detected, or not at all if no device was detected. Moving this outside the loop (as would appear to have been the original intent, judging by the indentation) fixes this by adding the entry only after all devices have been processed.

This pull request fixes the above problem.

Steps to reproduce:

1. Using a Linux computer which has more than one ALSA audio device detected by OBS (ie. more than one `front:` PCM listed by `arecord -L`), add the "Audio Capture Device (ALSA)" source to a scene. (Alternatively, on a computer with no `front:` PCMs at all.)
2. Right click the new source, choose "Properties", and show the "Device" dropdown.

Expected results:

* OBS displays the "Custom" option, once, at the end of the list, as specified in #599.

Actual results:

* OBS displays multiple "Custom" options (or none at all), one after every detected device.

[edit: Oh, I just realised I misnamed the plugin in the commit summary; it should be "linux-alsa", not "alsa-input". My mistake. Should I force-push the correction to this PR?]