### PR TITLE
UI: Handle update_properties signal in OBSBasicFilters window

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -175,9 +175,9 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 			(PropertiesUpdateCallback)obs_source_update);
 
 	updatePropertiesSignal.Connect(obs_source_get_signal_handler(filter),
-		"update_properties",
-		OBSBasicFilters::UpdateProperties,
-		this);
+			"update_properties",
+			OBSBasicFilters::UpdateProperties,
+			this);
 
 	obs_data_release(settings);
 
@@ -190,7 +190,7 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 void OBSBasicFilters::UpdateProperties(void *data, calldata_t *)
 {
 	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(data)->view,
-		"ReloadProperties");
+			"ReloadProperties");
 }
 
 void OBSBasicFilters::AddFilter(OBSSource filter)

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -158,6 +158,7 @@ inline OBSSource OBSBasicFilters::GetFilter(int row, bool async)
 void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 {
 	if (view) {
+		updatePropertiesSignal.Disconnect();
 		ui->rightLayout->removeWidget(view);
 		view->deleteLater();
 		view = nullptr;
@@ -173,12 +174,23 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 			(PropertiesReloadCallback)obs_source_properties,
 			(PropertiesUpdateCallback)obs_source_update);
 
+	updatePropertiesSignal.Connect(obs_source_get_signal_handler(filter),
+		"update_properties",
+		OBSBasicFilters::UpdateProperties,
+		this);
+
 	obs_data_release(settings);
 
 	view->setMaximumHeight(250);
 	view->setMinimumHeight(150);
 	ui->rightLayout->addWidget(view);
 	view->show();
+}
+
+void OBSBasicFilters::UpdateProperties(void *data, calldata_t *)
+{
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters*>(data)->view,
+		"ReloadProperties");
 }
 
 void OBSBasicFilters::AddFilter(OBSSource filter)

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -45,6 +45,7 @@ private:
 
 	OBSSignal removeSourceSignal;
 	OBSSignal renameSourceSignal;
+	OBSSignal updatePropertiesSignal;
 
 	inline OBSSource GetFilter(int row, bool async);
 
@@ -56,6 +57,7 @@ private:
 	static void OBSSourceReordered(void *param, calldata_t *data);
 	static void SourceRemoved(void *param, calldata_t *data);
 	static void SourceRenamed(void *param, calldata_t *data);
+	static void UpdateProperties(void *data, calldata_t *params);
 	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
 
 	QMenu *CreateAddFilterPopupMenu(bool async);


### PR DESCRIPTION
The OBSBasicFilters window did not register a handler for the
"update_properties" signal. Now it does. Addresses [issue #1028](https://obsproject.com/mantis/view.php?id=1028) .