### PR TITLE
rtmp-services: Add Garena platform

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 73,
+	"version": 74,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 73
+			"version": 74
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1068,6 +1068,27 @@
                 "max video bitrate": 6000,
                 "max audio bitrate": 160
             }
+        },
+        {
+            "name": "Garena LIVE",
+            "servers": [
+                {
+                    "name": "Thailand",
+                    "url": "rtmp://th.rtmp.garena.tv/live"
+                },
+                {
+                    "name": "Vietnam",
+                    "url": "rtmp://vn.rtmp.garena.tv/live"
+                },
+                {
+                    "name": "Taiwan",
+                    "url": "rtmp://tw.rtmp.garena.tv/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 4000
+            }
         }
     ]
 }


### PR DESCRIPTION
This PR aims at adding Garena Live as a streaming platform. Garena Live is one of the largest streaming platform in South East Asia. This is our official site: [https://garena.live/](https://garena.live/). Thank you very much!