### PR TITLE
file-updater: fix crash due to network timeout

### DIFF
--- a/deps/file-updater/file-updater/file-updater.c
+++ b/deps/file-updater/file-updater/file-updater.c
@@ -117,6 +117,7 @@ static bool do_http_request(struct update_info *info, const char *url,
 	curl_easy_setopt(info->curl, CURLOPT_WRITEFUNCTION, http_write);
 	curl_easy_setopt(info->curl, CURLOPT_WRITEDATA, info);
 	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, true);
+	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1);
 
 	if (!info->remote_url) {
 		// We only care about headers from the main package file


### PR DESCRIPTION
If there is no network connection, OBS crashes after 5 minutes idling
with following crash:

*** longjmp causes uninitialized stack frame ***: obs terminated
======= Backtrace: =========
/lib64/libc.so.6(+0x6f1e3)[0x7f8f95f901e3]
/lib64/libc.so.6(__fortify_fail+0x37)[0x7f8f96018ba7]
/lib64/libc.so.6(+0xf7add)[0x7f8f96018add]
/lib64/libc.so.6(__longjmp_chk+0x29)[0x7f8f96018a39]
/usr/lib64/libcurl.so.4(+0xa5d5)[0x7f8f979b75d5]
/lib64/libpthread.so.0(+0x10e30)[0x7f8f962cae30]
/lib64/libc.so.6(__poll+0x2d)[0x7f8f95fff46d]
/usr/lib64/libglib-2.0.so.0(+0x4a64c)[0x7f8f91b5564c]
/usr/lib64/libglib-2.0.so.0(g_main_context_iteration+0x2c)[0x7f8f91b5575c]
/usr/lib64/libQt5Core.so.5(_ZN20QEventDispatcherGlib13processEventsE6QFlagsIN10QEventLoop17ProcessEventsFlagEE+0x5f)[0x7f8f9706c1ff]
/usr/lib64/libQt5Core.so.5(_ZN10QEventLoop4execE6QFlagsINS_17ProcessEventsFlagEE+0xfa)[0x7f8f9701defa]
/usr/lib64/libQt5Core.so.5(_ZN16QCoreApplication4execEv+0x9c)[0x7f8f970258fc]
obs(main+0x5ac)[0x4773dc]
/lib64/libc.so.6(__libc_start_main+0xf0)[0x7f8f95f41700]
obs(_start+0x29)[0x478389]

Internet search [1] revealed that this is a libcurl bug that can be worked
around by asking curl not to install signal handlers.

[1] https://stackoverflow.com/a/10755612