### PR TITLE
libobs/util: Fix Windows 10 revision detection

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -814,7 +814,7 @@ void get_win_ver(struct win_version_info *info)
 		get_dll_ver(L"kernel32", &ver);
 		got_version = true;
 
-		if (ver.major == 10 && ver.revis == 0) {
+		if (ver.major == 10) {
 			HKEY    key;
 			DWORD   size, win10_revision;
 			LSTATUS status;
@@ -829,7 +829,8 @@ void get_win_ver(struct win_version_info *info)
 			status = RegQueryValueExW(key, L"UBR", NULL, NULL,
 					(LPBYTE)&win10_revision, &size);
 			if (status == ERROR_SUCCESS)
-				ver.revis = (int)win10_revision;
+				ver.revis = (int)win10_revision > ver.revis ?
+						(int)win10_revision : ver.revis;
 
 			RegCloseKey(key);
 		}


### PR DESCRIPTION
This is a follow-up to 47aa56b (PR #620).  Windows 10 revision detection broke in Build 15036 (Creators Update) after Revision 296.  For all revisions of Windows 10 Build 15036 after Revision 296 up to Revision 608, OBS will log Revision 296 (Windows Version: 10.0 Build 15063 (revision: 296; 64-bit)).  This aims to further fix revision detection on Windows 10 by forcefully checking the registry for the Windows 10 revision.  To try to ensure we're logging the correct revision, I also compare it against the revision from `kernel32.dll` and logs whichever is higher.

I drafted a few different possible solutions to this and gave rationale in a gist [here](https://gist.github.com/RytoEX/1faa1e0e468e3565ea37df3ca5b5d571).  It may be sufficient to just always log the revision from the registry.  The registry key is available in Windows 10 Build 14393 and Build 15063, but I'm not totally sure about earlier builds.  I'm open to hearing information or opinions on this.

I've compiled and tested this on Windows 10 Pro 64-bit.  As always, feedback and reviews are welcome.