### PR TITLE
UI: Disallow pasting duplicates of sources with DO_NOT_DUPLICATE

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5757,7 +5757,12 @@ void OBSBasic::on_actionCopySource_triggered()
 	copyVisible = obs_sceneitem_visible(item);
 
 	ui->actionPasteRef->setEnabled(true);
-	ui->actionPasteDup->setEnabled(true);
+
+	uint32_t output_flags = obs_source_get_output_flags(source);
+	if ((output_flags & OBS_SOURCE_DO_NOT_DUPLICATE) == 0)
+		ui->actionPasteDup->setEnabled(true);
+	else
+		ui->actionPasteDup->setEnabled(false);
 }
 
 void OBSBasic::on_actionPasteRef_triggered()


### PR DESCRIPTION
This commit prevents users from being able to use the "Paste (Duplicate)" context menu option after copying a source that has the OBS_SOURCE_DO_NOT_DUPLICATE flag set. Though OBS would correctly paste the source as a reference, it seems that this behavior was confusing some users. This fixes [Mantis Bug 1034](https://obsproject.com/mantis/view.php?id=1034).

I decided to disable/enable the option instead of hiding/showing it because I thought that changing the context menu too often might also be confusing for users.  This was also the easiest change to make (just slightly fewer lines of code).  However, I'm not completely against the hide/show idea, and I'm definitely open to hearing feedback or rationale for hiding/showing the context menu item as needed.  Tagging @Fenrirthviti since he asked for this patch.

I'm a bit rusty on bitwise operations, so I'd appreciate a sanity check on the code I used for this test.  I've compiled and tested on Windows 10 Pro 64-bit, and my tests seemed to work correctly.  As always, feedback and reviews are appreciated.