### PR TITLE
Log Windows 10 Gaming Features (Game Mode)

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -83,6 +83,7 @@ if(WIN32)
 		util/platform-windows.c)
 	set(libobs_PLATFORM_HEADERS
 		util/threading-windows.h
+		util/windows/win-registry.h
 		util/windows/win-version.h
 		util/windows/ComPtr.hpp
 		util/windows/CoTaskMemPtr.hpp

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -15,6 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#include "util/windows/win-registry.h"
 #include "util/windows/win-version.h"
 #include "util/platform.h"
 #include "util/dstr.h"
@@ -189,6 +190,49 @@ static void log_aero(void)
 			aeroMessage);
 }
 
+#define WIN10_GAME_BAR_REG_KEY \
+		L"Software\\Microsoft\\Windows\\CurrentVersion\\GameDVR"
+#define WIN10_GAME_DVR_POLICY_REG_KEY \
+		L"SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR"
+#define WIN10_GAME_DVR_REG_KEY L"System\\GameConfigStore"
+#define WIN10_GAME_MODE_REG_KEY L"Software\\Microsoft\\GameBar"
+
+static void log_gaming_features(void)
+{
+	if (win_ver < 0xA00)
+		return;
+
+	struct reg_dword game_bar_enabled;
+	struct reg_dword game_dvr_allowed;
+	struct reg_dword game_dvr_enabled;
+	struct reg_dword game_dvr_bg_recording;
+	struct reg_dword game_mode_enabled;
+
+	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_BAR_REG_KEY,
+			L"AppCaptureEnabled", &game_bar_enabled);
+	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_DVR_POLICY_REG_KEY,
+			L"AllowGameDVR", &game_dvr_allowed);
+	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_DVR_REG_KEY,
+			L"GameDVR_Enabled", &game_dvr_enabled);
+	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_BAR_REG_KEY,
+			L"HistoricalCaptureEnabled", &game_dvr_bg_recording);
+	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
+			L"AllowAutoGameMode", &game_mode_enabled);
+
+	blog(LOG_INFO, "Windows 10 Gaming Features:");
+	blog(LOG_INFO, "\tGame Bar: %s",
+			(bool)game_bar_enabled.return_value ? "On" : "Off");
+	blog(LOG_INFO, "\tGame DVR Allowed: %s",
+			(bool)game_dvr_allowed.return_value ? "Yes" : "No");
+	blog(LOG_INFO, "\tGame DVR: %s",
+			(bool)game_dvr_enabled.return_value ? "On" : "Off");
+	blog(LOG_INFO, "\tGame DVR Background Recording: %s",
+			(bool)game_dvr_bg_recording.return_value ? "On" :
+			"Off");
+	blog(LOG_INFO, "\tGame Mode: %s",
+			(bool)game_mode_enabled.return_value ? "On" : "Off");
+}
+
 void log_system_info(void)
 {
 	struct win_version_info ver;
@@ -202,6 +246,7 @@ void log_system_info(void)
 	log_windows_version();
 	log_admin_status();
 	log_aero();
+	log_gaming_features();
 }
 
 

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -26,6 +26,7 @@
 #include "platform.h"
 #include "darray.h"
 #include "dstr.h"
+#include "windows/win-registry.h"
 #include "windows/win-version.h"
 
 #include "../../deps/w32-pthreads/pthread.h"
@@ -798,6 +799,28 @@ bool is_64_bit_windows(void)
 	BOOL b64 = false;
 	return IsWow64Process(GetCurrentProcess(), &b64) && b64;
 #endif
+}
+
+void get_reg_dword(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name,
+		struct reg_dword *info)
+{
+	struct reg_dword reg = {0};
+	HKEY key;
+	LSTATUS status;
+
+	status = RegOpenKeyEx(hkey, sub_key, 0, KEY_READ, &key);
+
+	if (status != ERROR_SUCCESS)
+		return;
+
+	reg.size = sizeof(reg.return_value);
+
+	reg.status = RegQueryValueExW(key, value_name, NULL, NULL,
+			(LPBYTE)&reg.return_value, &reg.size);
+
+	RegCloseKey(key);
+
+	*info = reg;
 }
 
 #define WINVER_REG_KEY L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion"

--- a/libobs/util/windows/win-registry.h
+++ b/libobs/util/windows/win-registry.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015 Hugh Bailey <obs.jim@gmail.com>
+ * Copyright (c) 2017 Ryan Foster <RytoEX@gmail.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <windows.h>
+#include "../c99defs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct reg_dword {
+	LSTATUS status;
+	DWORD   size;
+	DWORD   return_value;
+};
+
+EXPORT void get_reg_dword(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name,
+		struct reg_dword *info);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This PR aims to add logging for the Windows 10 Gaming Features that can negatively affect OBS performance.  This is to make it easier for support providers to diagnose possible issues with OBS users on Windows 10.  Tagging @Fenrirthviti since this patch is of interest to him.

This PR consists of two commits.  The first adds a wrapper function to libobs/util for Windows to make it easier to query the Windows Registry.  The file `libobs/util/windows/win-registry.h` is based on `libobs/util/windows/win-version.h`.  The second adds logging for Windows 10 Gaming features that may negatively impact the performance of game capture, recording, or streaming.  The logging code attempts to log the status of the following features:
* Game Bar
* Game DVR
* Game DVR Background Recording
* Game Mode

The code only checks the Windows Registry for these settings.  I didn't implement checks for the relevant Group Policy settings, partly because I thought that might be too uncommon.  Though, I'm open to being more thorough in these checks.

I wasn't sure if it would be best to expand the registry functions and structs to include more possibilities (QWORD, SZ, MULTI_SZ, EXPAND_SZ, etc.), or if I should keep the additions constrained to the bare necessities for the scope of this PR.  I'm open to opinions on this particular point.

I've compiled and tested this on Windows 10 Pro 64-bit (Version 1703, Build 15063.674).  I'd be interested in seeing this tested on Windows 10 builds prior to 15063 (before the March 2017 Creators Update).  As always, feedback and reviews are appreciated.

If this PR is accepted, it might be helpful to edit PR #1041 to use the registry functions.