### PR TITLE
CI: Update Travis script to target OSX 10.10+

### DIFF
--- a/CI/before-script-osx.sh
+++ b/CI/before-script-osx.sh
@@ -3,4 +3,4 @@ export PATH=/usr/local/opt/ccache/libexec:$PATH
 
 mkdir build
 cd build
-cmake -DENABLE_SPARKLE_UPDATER=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DDepsPath=/tmp/obsdeps -DVLCPath=$PWD/../../vlc-master -DBUILD_BROWSER=ON -DCEF_ROOT_DIR=$PWD/../../cef_binary_${CEF_BUILD_VERSION}_macosx64 ..
+cmake -DENABLE_SPARKLE_UPDATER=ON -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 -DDepsPath=/tmp/obsdeps -DVLCPath=$PWD/../../vlc-master -DBUILD_BROWSER=ON -DCEF_ROOT_DIR=$PWD/../../cef_binary_${CEF_BUILD_VERSION}_macosx64 ..


### PR DESCRIPTION
Since OSX 10.10 is now the officially supported minimum OS version on Mac, update the CI script.  This is may not be necessary, strictly speaking.  As far as I know, the build scripts have still been producing Mac builds, though I don't know if those builds actually run.  Testing the build artifacts before and after this PR/commit might be informative.

Tagging @DDRBoxman and @Gol-D-Ace since they've done a lot of the work with CI.