### PR TITLE
UI: Disable source copy if no sources are selected

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -182,6 +182,9 @@
      <addaction name="actionScaleOutput"/>
     </widget>
     <action name="actionCopySource">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
       <string>Copy</string>
      </property>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2663,6 +2663,8 @@ void OBSBasic::SceneItemSelected(void *data, calldata_t *params)
 	QMetaObject::invokeMethod(window, "SelectSceneItem",
 			Q_ARG(OBSScene, scene), Q_ARG(OBSSceneItem, item),
 			Q_ARG(bool, true));
+
+	window->ui->actionCopySource->setEnabled(true);
 }
 
 void OBSBasic::SceneItemDeselected(void *data, calldata_t *params)
@@ -2675,6 +2677,8 @@ void OBSBasic::SceneItemDeselected(void *data, calldata_t *params)
 	QMetaObject::invokeMethod(window, "SelectSceneItem",
 			Q_ARG(OBSScene, scene), Q_ARG(OBSSceneItem, item),
 			Q_ARG(bool, false));
+
+	window->ui->actionCopySource->setEnabled(false);
 }
 
 void OBSBasic::SourceLoaded(void *data, obs_source_t *source)


### PR DESCRIPTION
This commit addresses [Mantis Bug 993](https://obsproject.com/mantis/view.php?id=993). If no source was selected, the "Copy" context menu item was enabled, but selecting it would do nothing. This commit disables that menu item when no sources are selected.

This PR is a follow-up to PR #860 and its commits.  I've compiled and tested this PR on Windows 10 Pro 64-bit.  As always, feedback and reviews are welcome.