### PR TITLE
UI: Add Frontend API function to save replay buffer

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -239,6 +239,11 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		QMetaObject::invokeMethod(main, "StartReplayBuffer");
 	}
 
+	void obs_frontend_replay_buffer_save(void) override
+	{
+		QMetaObject::invokeMethod(main, "ReplayBufferSave");
+	}
+
 	void obs_frontend_replay_buffer_stop(void) override
 	{
 		QMetaObject::invokeMethod(main, "StopReplayBuffer");

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -210,6 +210,11 @@ void obs_frontend_replay_buffer_start(void)
 	if (callbacks_valid()) c->obs_frontend_replay_buffer_start();
 }
 
+void obs_frontend_replay_buffer_save(void)
+{
+	if (callbacks_valid()) c->obs_frontend_replay_buffer_save();
+}
+
 void obs_frontend_replay_buffer_stop(void)
 {
 	if (callbacks_valid()) c->obs_frontend_replay_buffer_stop();

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -71,6 +71,7 @@ EXPORT void obs_frontend_recording_stop(void);
 EXPORT bool obs_frontend_recording_active(void);
 
 EXPORT void obs_frontend_replay_buffer_start(void);
+EXPORT void obs_frontend_replay_buffer_save(void);
 EXPORT void obs_frontend_replay_buffer_stop(void);
 EXPORT bool obs_frontend_replay_buffer_active(void);
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -41,6 +41,7 @@ struct obs_frontend_callbacks {
 	virtual bool obs_frontend_recording_active(void)=0;
 
 	virtual void obs_frontend_replay_buffer_start(void)=0;
+	virtual void obs_frontend_replay_buffer_save(void) = 0;
 	virtual void obs_frontend_replay_buffer_stop(void)=0;
 	virtual bool obs_frontend_replay_buffer_active(void)=0;
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4639,6 +4639,20 @@ void OBSBasic::ReplayBufferStart()
 	blog(LOG_INFO, REPLAY_BUFFER_START);
 }
 
+void OBSBasic::ReplayBufferSave()
+{
+	if (!outputHandler || !outputHandler->replayBuffer)
+		return;
+	if (!outputHandler->ReplayBufferActive())
+		return;
+
+	calldata_t cd = {0};
+	proc_handler_t *ph = obs_output_get_proc_handler(
+			outputHandler->replayBuffer);
+	proc_handler_call(ph, "save", &cd);
+	calldata_free(&cd);
+}
+
 void OBSBasic::ReplayBufferStop(int code)
 {
 	if (!outputHandler || !outputHandler->replayBuffer)

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -380,6 +380,7 @@ public slots:
 	void StopReplayBuffer();
 
 	void ReplayBufferStart();
+	void ReplayBufferSave();
 	void ReplayBufferStopping();
 	void ReplayBufferStop(int code);
 


### PR DESCRIPTION
This PR addresses [Mantis Issue 955](https://obsproject.com/mantis/view.php?id=955).

I'm admittedly not familiar with the naming conventions for the recording/streaming start/stop/stopping functions in `UI/window-basic-main.cpp`, so I'm not sure if "ReplayBufferSave" is the most appropriate name.  I was unsure if I needed to add more functions in `UI/window-basic-main.cpp` and `UI/window-basic-main-outputs.cpp` similar to the other recording/streaming start/stop functions.

I was also unsure about the need for a function attached to OBSBasic, since saving the replay buffer doesn't seem to interact with the UI at all.  I mostly added it for the future consideration of the third item in [Mantis Issue 761](https://obsproject.com/mantis/view.php?id=761).  I suppose it could be useful if there were ever a UI button for saving the replay buffer.  Similarly, I didn't know if I needed to add an API event for this, like `api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED);`.

I wasn't sure if I needed to call `calldata_free` if the calldata struct didn't receive any data from `proc_handler_call`.  For example, in the stinger transition's code, `calldata_free` isn't called in one spot when the struct hasn't received data.  For now, I've put it here anyway to be safe.

I've compiled and tested this on Windows 10 Pro 64-bit, and I tested the API calls with a modified version of the obs-websocket plugin.  As always, feedback and reviews are appreciated.