### PR TITLE
Feature: Monitor each input stream

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -68,6 +68,7 @@ static bool unfiltered_log = false;
 bool opt_start_streaming = false;
 bool opt_start_recording = false;
 bool opt_studio_mode = false;
+bool opt_disable_ui = false;
 bool opt_start_replaybuffer = false;
 bool opt_minimize_tray = false;
 bool opt_allow_opengl = false;
@@ -1896,6 +1897,9 @@ int main(int argc, char *argv[])
 
 		} else if (arg_is(argv[i], "--studio-mode", nullptr)) {
 			opt_studio_mode = true;
+
+		} else if (arg_is(argv[i], "--disable-ui", nullptr)) {
+			opt_disable_ui = true;
 
 		} else if (arg_is(argv[i], "--allow-opengl", nullptr)) {
 			opt_allow_opengl = true;

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -182,6 +182,7 @@ extern bool opt_start_recording;
 extern bool opt_start_replaybuffer;
 extern bool opt_minimize_tray;
 extern bool opt_studio_mode;
+extern bool opt_disable_ui;
 extern bool opt_allow_opengl;
 extern bool opt_always_on_top;
 extern std::string opt_starting_scene;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1338,7 +1338,7 @@ void OBSBasic::OBSInit()
 	}
 
 	/* load audio monitoring */
-#if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
 	const char *device_name = config_get_string(basicConfig, "Audio",
 			"MonitoringDeviceName");
 	const char *device_id = config_get_string(basicConfig, "Audio",

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1338,7 +1338,7 @@ void OBSBasic::OBSInit()
 	}
 
 	/* load audio monitoring */
-#if defined(_WIN32) || defined(__APPLE__) || HAVE_PULSEAUDIO
+#if defined(_WIN32) || defined(__APPLE__)
 	const char *device_name = config_get_string(basicConfig, "Audio",
 			"MonitoringDeviceName");
 	const char *device_id = config_get_string(basicConfig, "Audio",
@@ -1447,7 +1447,10 @@ void OBSBasic::OBSInit()
 
 #ifdef _WIN32
 	SetWin32DropStyle(this);
-	show();
+  if (!opt_disable_ui)
+    opt_disable_ui = false;
+  if (opt_disable_ui == false)
+	  show();
 #endif
 
 	bool alwaysOnTop = config_get_bool(App()->GlobalConfig(), "BasicWindow",
@@ -1458,7 +1461,8 @@ void OBSBasic::OBSInit()
 	}
 
 #ifndef _WIN32
-	show();
+  if (opt_disable_ui == false)
+	  show();
 #endif
 
 	const char *dockStateStr = config_get_string(App()->GlobalConfig(),

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -562,8 +562,12 @@ struct obs_source {
 	uint64_t                        next_audio_ts_min;
 	uint64_t                        next_audio_sys_ts_min;
 	uint64_t                        last_frame_ts;
+	uint64_t                        former_frame_ts;
 	uint64_t                        last_sys_timestamp;
 	bool                            async_rendered;
+	double                          video_fps;
+	double                          video_avg_fps;
+	int                             total_frames;
 
 	/* audio */
 	bool                            audio_failed;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2383,17 +2383,24 @@ void obs_source_output_video(obs_source_t *source,
 		source->async_active = true;
 	}
 	
+	/* Calculate the average frame rate,
+	 * current frame rate and frame counter
+	 */
+	
 	if (source->last_frame_ts >= 1000000000ULL) {
-                source->video_avg_fps = (
-			source->total_frames / 
-			(source->last_frame_ts / 1000000000));
-                float frame_time_delta_ms = (
+		source->video_avg_fps = (
+			(double)source->total_frames /
+			(source->last_frame_ts / 1000000000ULL));
+
+		float frame_time_delta_ms = (
 			source->last_frame_ts - 
-			source->former_frame_ts)/1000000;
-                if (frame_time_delta_ms > 0) {
-                    source->video_fps = 1000 / frame_time_delta_ms;
-                }
+			source->former_frame_ts);
+
+		if (frame_time_delta_ms > 0) {
+			source->video_fps = 1000000000ULL / frame_time_delta_ms;
+        	}
 	}
+
 	source->total_frames++;
 	source->former_frame_ts = source->last_frame_ts;
 }

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2394,6 +2394,7 @@ void obs_source_output_video(obs_source_t *source,
                     source->video_fps = 1000 / frame_time_delta_ms;
                 }
 	}
+	source->total_frames++;
 	source->former_frame_ts = source->last_frame_ts;
 }
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -140,6 +140,10 @@ bool obs_source_init(struct obs_source *source)
 	source->user_volume = 1.0f;
 	source->volume = 1.0f;
 	source->sync_offset = 0;
+	source->total_frames = 0;
+	source->former_frame_ts = 0;
+	source->video_fps = 0;
+	source->video_avg_fps = 0;
 	pthread_mutex_init_value(&source->filter_mutex);
 	pthread_mutex_init_value(&source->async_mutex);
 	pthread_mutex_init_value(&source->audio_mutex);
@@ -2378,6 +2382,19 @@ void obs_source_output_video(obs_source_t *source,
 		pthread_mutex_unlock(&source->async_mutex);
 		source->async_active = true;
 	}
+	
+	if (source->last_frame_ts >= 1000000000ULL) {
+                source->video_avg_fps = (
+			source->total_frames / 
+			(source->last_frame_ts / 1000000000));
+                float frame_time_delta_ms = (
+			source->last_frame_ts - 
+			source->former_frame_ts)/1000000;
+                if (frame_time_delta_ms > 0) {
+                    source->video_fps = 1000 / frame_time_delta_ms;
+                }
+	}
+	source->former_frame_ts = source->last_frame_ts;
 }
 
 static inline bool preload_frame_changed(obs_source_t *source,
@@ -2783,6 +2800,26 @@ const char *obs_source_get_name(const obs_source_t *source)
 {
 	return obs_source_valid(source, "obs_source_get_name") ?
 		source->context.name : NULL;
+}
+
+double obs_source_get_video_fps(const obs_source_t *source)
+{
+    return source->video_fps;
+}
+
+double obs_source_get_video_avg_fps(const obs_source_t *source)
+{
+    return source->video_avg_fps;
+}
+
+double obs_source_get_total_frames(const obs_source_t *source)
+{
+    return source->total_frames;
+}
+
+long long obs_source_get_last_frame_ts(const obs_source_t *source)
+{
+    return source->last_frame_ts;
 }
 
 void obs_source_set_name(obs_source_t *source, const char *name)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -801,6 +801,18 @@ EXPORT const char *obs_source_get_name(const obs_source_t *source);
 /** Sets the name of a source */
 EXPORT void obs_source_set_name(obs_source_t *source, const char *name);
 
+/** Gets the video fps of a source */
+EXPORT double obs_source_get_video_fps(const obs_source_t *source);
+
+/** Gets the video average fps of a source */
+EXPORT double obs_source_get_video_avg_fps(const obs_source_t *source);
+
+/** Gets the total frames of a source */
+EXPORT double obs_source_get_total_frames(const obs_source_t *source);
+
+/** Gets the last frame timestamp of a source */
+EXPORT long long obs_source_get_last_frame_ts(const obs_source_t *source);
+
 /** Gets the source type */
 EXPORT enum obs_source_type obs_source_get_type(const obs_source_t *source);
 

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -1,16 +1,16 @@
 #include <obs-module.h>
-#include <libvlc.h>
+#include <vlc/libvlc.h>
 
 #ifdef _MSC_VER
 #include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 
-#include <libvlc_media.h>
-#include <libvlc_events.h>
-#include <libvlc_media_list.h>
-#include <libvlc_media_player.h>
-#include <libvlc_media_list_player.h>
+#include <vlc/libvlc_media.h>
+#include <vlc/libvlc_events.h>
+#include <vlc/libvlc_media_list.h>
+#include <vlc/libvlc_media_player.h>
+#include <vlc/libvlc_media_list_player.h>
 
 extern libvlc_instance_t *libvlc;
 extern uint64_t time_start;

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -3,10 +3,12 @@
 #include <util/threading.h>
 #include <util/platform.h>
 #include <util/dstr.h>
+#include <inttypes.h>
+#include <time.h>
 
 #define do_log(level, format, ...) \
-	blog(level, "[vlc_source: '%s'] " format, \
-			obs_source_get_name(ss->source), ##__VA_ARGS__)
+  blog(level, "[vlc_source: '%s'] " format, \
+      obs_source_get_name(ss->source), ##__VA_ARGS__)
 
 #define warn(format, ...)  do_log(LOG_WARNING, format, ##__VA_ARGS__)
 
@@ -32,892 +34,992 @@
 /* ------------------------------------------------------------------------- */
 
 struct media_file_data {
-	char *path;
-	libvlc_media_t *media;
+  char *path;
+  libvlc_media_t *media;
 };
 
 enum behavior {
-	BEHAVIOR_STOP_RESTART,
-	BEHAVIOR_PAUSE_UNPAUSE,
-	BEHAVIOR_ALWAYS_PLAY,
+  BEHAVIOR_STOP_RESTART,
+  BEHAVIOR_PAUSE_UNPAUSE,
+  BEHAVIOR_ALWAYS_PLAY,
 };
 
 struct vlc_source {
-	obs_source_t *source;
+  obs_source_t *source;
 
-	libvlc_media_player_t *media_player;
-	libvlc_media_list_player_t *media_list_player;
+  libvlc_media_player_t *media_player;
+  libvlc_media_list_player_t *media_list_player;
 
-	struct obs_source_frame frame;
-	struct obs_source_audio audio;
-	size_t audio_capacity;
+  uint64_t vlc_time;
+  unsigned long last_frame_at;
+  bool restarted;
 
-	pthread_mutex_t mutex;
-	DARRAY(struct media_file_data) files;
-	enum behavior behavior;
-	bool loop;
-	bool shuffle;
+  struct obs_source_frame frame;
+  struct obs_source_audio audio;
+  size_t audio_capacity;
 
-	obs_hotkey_id play_pause_hotkey;
-	obs_hotkey_id restart_hotkey;
-	obs_hotkey_id stop_hotkey;
-	obs_hotkey_id playlist_next_hotkey;
-	obs_hotkey_id playlist_prev_hotkey;
+  pthread_mutex_t mutex;
+  DARRAY(struct media_file_data) files;
+  enum behavior behavior;
+  bool loop;
+  bool shuffle;
+
+  obs_hotkey_id play_pause_hotkey;
+  obs_hotkey_id restart_hotkey;
+  obs_hotkey_id stop_hotkey;
+  obs_hotkey_id playlist_next_hotkey;
+  obs_hotkey_id playlist_prev_hotkey;
 };
+
+static obs_data_t *setting_storage;
+static void *data_storage;
 
 static libvlc_media_t *get_media(struct darray *array, const char *path)
 {
-	DARRAY(struct media_file_data) files;
-	libvlc_media_t *media = NULL;
+  DARRAY(struct media_file_data) files;
+  libvlc_media_t *media = NULL;
 
-	files.da = *array;
+  files.da = *array;
 
-	for (size_t i = 0; i < files.num; i++) {
-		const char *cur_path = files.array[i].path;
+  for (size_t i = 0; i < files.num; i++) {
+    const char *cur_path = files.array[i].path;
 
-		if (strcmp(path, cur_path) == 0) {
-			media = files.array[i].media;
-			libvlc_media_retain_(media);
-			break;
-		}
-	}
+    if (strcmp(path, cur_path) == 0) {
+      media = files.array[i].media;
+      libvlc_media_retain_(media);
+      break;
+    }
+  }
 
-	return media;
+  return media;
 }
 
 static inline libvlc_media_t *create_media_from_file(const char *file)
 {
-	return (file && strstr(file, "://") != NULL)
-		? libvlc_media_new_location_(libvlc, file)
-		: libvlc_media_new_path_(libvlc, file);
+  return (file && strstr(file, "://") != NULL)
+    ? libvlc_media_new_location_(libvlc, file)
+    : libvlc_media_new_path_(libvlc, file);
 }
 
 static void free_files(struct darray *array)
 {
-	DARRAY(struct media_file_data) files;
-	files.da = *array;
+  DARRAY(struct media_file_data) files;
+  files.da = *array;
 
-	for (size_t i = 0; i < files.num; i++) {
-		bfree(files.array[i].path);
-		libvlc_media_release_(files.array[i].media);
-	}
+  for (size_t i = 0; i < files.num; i++) {
+    bfree(files.array[i].path);
+    libvlc_media_release_(files.array[i].media);
+  }
 
-	da_free(files);
+  da_free(files);
 }
 
 static inline bool chroma_is(const char *chroma, const char *val)
 {
-	return *(uint32_t*)chroma == *(uint32_t*)val;
+  return *(uint32_t*)chroma == *(uint32_t*)val;
 }
 
 static enum video_format convert_vlc_video_format(char *chroma, bool *full)
 {
-	*full = false;
+  *full = false;
 
 #define CHROMA_TEST(val, ret) \
-	if (chroma_is(chroma, val)) return ret
+  if (chroma_is(chroma, val)) return ret
 #define CHROMA_CONV(val, new_val, ret) \
-	do { \
-		if (chroma_is(chroma, val)) { \
-			*(uint32_t*)chroma = *(uint32_t*)new_val; \
-			return ret; \
-		} \
-	} while (false)
+  do { \
+    if (chroma_is(chroma, val)) { \
+      *(uint32_t*)chroma = *(uint32_t*)new_val; \
+      return ret; \
+    } \
+  } while (false)
 #define CHROMA_CONV_FULL(val, new_val, ret) \
-	do { \
-		*full = true; \
-		CHROMA_CONV(val, new_val, ret); \
-	} while (false)
+  do { \
+    *full = true; \
+    CHROMA_CONV(val, new_val, ret); \
+  } while (false)
 
-	CHROMA_TEST("RGBA", VIDEO_FORMAT_RGBA);
-	CHROMA_TEST("BGRA", VIDEO_FORMAT_BGRA);
+  CHROMA_TEST("RGBA", VIDEO_FORMAT_RGBA);
+  CHROMA_TEST("BGRA", VIDEO_FORMAT_BGRA);
 
-	/* 4:2:0 formats */
-	CHROMA_TEST("NV12", VIDEO_FORMAT_NV12);
-	CHROMA_TEST("I420", VIDEO_FORMAT_I420);
-	CHROMA_TEST("IYUV", VIDEO_FORMAT_I420);
-	CHROMA_CONV("NV21", "NV12", VIDEO_FORMAT_NV12);
-	CHROMA_CONV("I422", "NV12", VIDEO_FORMAT_NV12);
-	CHROMA_CONV("Y42B", "NV12", VIDEO_FORMAT_NV12);
-	CHROMA_CONV("YV12", "NV12", VIDEO_FORMAT_NV12);
-	CHROMA_CONV("yv12", "NV12", VIDEO_FORMAT_NV12);
+  /* 4:2:0 formats */
+  CHROMA_TEST("NV12", VIDEO_FORMAT_NV12);
+  CHROMA_TEST("I420", VIDEO_FORMAT_I420);
+  CHROMA_TEST("IYUV", VIDEO_FORMAT_I420);
+  CHROMA_CONV("NV21", "NV12", VIDEO_FORMAT_NV12);
+  CHROMA_CONV("I422", "NV12", VIDEO_FORMAT_NV12);
+  CHROMA_CONV("Y42B", "NV12", VIDEO_FORMAT_NV12);
+  CHROMA_CONV("YV12", "NV12", VIDEO_FORMAT_NV12);
+  CHROMA_CONV("yv12", "NV12", VIDEO_FORMAT_NV12);
 
-	CHROMA_CONV_FULL("J420", "J420", VIDEO_FORMAT_I420);
+  CHROMA_CONV_FULL("J420", "J420", VIDEO_FORMAT_I420);
 
-	/* 4:2:2 formats */
-	CHROMA_TEST("UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("UYNV", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("UYNY", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("Y422", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("HDYC", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("AVUI", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("uyv1", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("2vuy", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("2Vuy", VIDEO_FORMAT_UYVY);
-	CHROMA_TEST("2Vu1", VIDEO_FORMAT_UYVY);
+  /* 4:2:2 formats */
+  CHROMA_TEST("UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("UYNV", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("UYNY", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("Y422", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("HDYC", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("AVUI", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("uyv1", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("2vuy", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("2Vuy", VIDEO_FORMAT_UYVY);
+  CHROMA_TEST("2Vu1", VIDEO_FORMAT_UYVY);
 
-	CHROMA_TEST("YUY2", VIDEO_FORMAT_YUY2);
-	CHROMA_TEST("YUYV", VIDEO_FORMAT_YUY2);
-	CHROMA_TEST("YUNV", VIDEO_FORMAT_YUY2);
-	CHROMA_TEST("V422", VIDEO_FORMAT_YUY2);
+  CHROMA_TEST("YUY2", VIDEO_FORMAT_YUY2);
+  CHROMA_TEST("YUYV", VIDEO_FORMAT_YUY2);
+  CHROMA_TEST("YUNV", VIDEO_FORMAT_YUY2);
+  CHROMA_TEST("V422", VIDEO_FORMAT_YUY2);
 
-	CHROMA_TEST("YVYU", VIDEO_FORMAT_YVYU);
+  CHROMA_TEST("YVYU", VIDEO_FORMAT_YVYU);
 
-	CHROMA_CONV("v210", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("cyuv", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("CYUV", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("VYUY", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("NV16", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("NV61", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("I410", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("I422", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("Y42B", "UYVY", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("J422", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("v210", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("cyuv", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("CYUV", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("VYUY", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("NV16", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("NV61", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("I410", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("I422", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("Y42B", "UYVY", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("J422", "UYVY", VIDEO_FORMAT_UYVY);
 
-	/* 4:4:4 formats */
-	CHROMA_TEST("I444", VIDEO_FORMAT_I444);
-	CHROMA_CONV_FULL("J444", "J444", VIDEO_FORMAT_I444);
-	CHROMA_CONV("YUVA", "RGBA", VIDEO_FORMAT_RGBA);
+  /* 4:4:4 formats */
+  CHROMA_TEST("I444", VIDEO_FORMAT_I444);
+  CHROMA_CONV_FULL("J444", "J444", VIDEO_FORMAT_I444);
+  CHROMA_CONV("YUVA", "RGBA", VIDEO_FORMAT_RGBA);
 
-	/* 4:4:0 formats */
-	CHROMA_CONV("I440", "I444", VIDEO_FORMAT_I444);
-	CHROMA_CONV("J440", "I444", VIDEO_FORMAT_I444);
+  /* 4:4:0 formats */
+  CHROMA_CONV("I440", "I444", VIDEO_FORMAT_I444);
+  CHROMA_CONV("J440", "I444", VIDEO_FORMAT_I444);
 
-	/* 4:1:0 formats */
-	CHROMA_CONV("YVU9", "NV12", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("I410", "NV12", VIDEO_FORMAT_UYVY);
+  /* 4:1:0 formats */
+  CHROMA_CONV("YVU9", "NV12", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("I410", "NV12", VIDEO_FORMAT_UYVY);
 
-	/* 4:1:1 formats */
-	CHROMA_CONV("I411", "NV12", VIDEO_FORMAT_UYVY);
-	CHROMA_CONV("Y41B", "NV12", VIDEO_FORMAT_UYVY);
+  /* 4:1:1 formats */
+  CHROMA_CONV("I411", "NV12", VIDEO_FORMAT_UYVY);
+  CHROMA_CONV("Y41B", "NV12", VIDEO_FORMAT_UYVY);
 
-	/* greyscale formats */
-	CHROMA_TEST("GREY", VIDEO_FORMAT_Y800);
-	CHROMA_TEST("Y800", VIDEO_FORMAT_Y800);
-	CHROMA_TEST("Y8  ", VIDEO_FORMAT_Y800);
+  /* greyscale formats */
+  CHROMA_TEST("GREY", VIDEO_FORMAT_Y800);
+  CHROMA_TEST("Y800", VIDEO_FORMAT_Y800);
+  CHROMA_TEST("Y8  ", VIDEO_FORMAT_Y800);
 #undef CHROMA_CONV_FULL
 #undef CHROMA_CONV
 #undef CHROMA_TEST
 
-	*(uint32_t*)chroma = *(uint32_t*)"BGRA";
-	return VIDEO_FORMAT_BGRA;
+  *(uint32_t*)chroma = *(uint32_t*)"BGRA";
+  return VIDEO_FORMAT_BGRA;
 }
 
 static inline unsigned get_format_lines(enum video_format format,
-		unsigned height, size_t plane)
+    unsigned height, size_t plane)
 {
-	switch (format) {
-	case VIDEO_FORMAT_I420:
-	case VIDEO_FORMAT_NV12:
-		return (plane == 0) ? height : height / 2;
-	case VIDEO_FORMAT_YVYU:
-	case VIDEO_FORMAT_YUY2:
-	case VIDEO_FORMAT_UYVY:
-	case VIDEO_FORMAT_I444:
-	case VIDEO_FORMAT_RGBA:
-	case VIDEO_FORMAT_BGRA:
-	case VIDEO_FORMAT_BGRX:
-	case VIDEO_FORMAT_Y800:
-		return height;
-	case VIDEO_FORMAT_NONE:;
-	}
+  switch (format) {
+    case VIDEO_FORMAT_I420:
+    case VIDEO_FORMAT_NV12:
+      return (plane == 0) ? height : height / 2;
+    case VIDEO_FORMAT_YVYU:
+    case VIDEO_FORMAT_YUY2:
+    case VIDEO_FORMAT_UYVY:
+    case VIDEO_FORMAT_I444:
+    case VIDEO_FORMAT_RGBA:
+    case VIDEO_FORMAT_BGRA:
+    case VIDEO_FORMAT_BGRX:
+    case VIDEO_FORMAT_Y800:
+      return height;
+    case VIDEO_FORMAT_NONE:;
+  }
 
-	return 0;
+  return 0;
 }
 
 static enum audio_format convert_vlc_audio_format(char *format)
 {
 #define AUDIO_TEST(val, ret) \
-	if (chroma_is(format, val)) return ret
+  if (chroma_is(format, val)) return ret
 #define AUDIO_CONV(val, new_val, ret) \
-	do { \
-		if (chroma_is(format, val)) { \
-			*(uint32_t*)format = *(uint32_t*)new_val; \
-			return ret; \
-		} \
-	} while (false)
+  do { \
+    if (chroma_is(format, val)) { \
+      *(uint32_t*)format = *(uint32_t*)new_val; \
+      return ret; \
+    } \
+  } while (false)
 
-	AUDIO_TEST("S16N", AUDIO_FORMAT_16BIT);
-	AUDIO_TEST("S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_TEST("FL32", AUDIO_FORMAT_FLOAT);
+  AUDIO_TEST("S16N", AUDIO_FORMAT_16BIT);
+  AUDIO_TEST("S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_TEST("FL32", AUDIO_FORMAT_FLOAT);
 
-	AUDIO_CONV("U16N", "S16N", AUDIO_FORMAT_16BIT);
-	AUDIO_CONV("U32N", "S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_CONV("S24N", "S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_CONV("U24N", "S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_CONV("FL64", "FL32", AUDIO_FORMAT_FLOAT);
+  AUDIO_CONV("U16N", "S16N", AUDIO_FORMAT_16BIT);
+  AUDIO_CONV("U32N", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("S24N", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("U24N", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("FL64", "FL32", AUDIO_FORMAT_FLOAT);
 
-	AUDIO_CONV("S16I", "S16N", AUDIO_FORMAT_16BIT);
-	AUDIO_CONV("U16I", "S16N", AUDIO_FORMAT_16BIT);
-	AUDIO_CONV("S24I", "S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_CONV("U24I", "S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_CONV("S32I", "S32N", AUDIO_FORMAT_32BIT);
-	AUDIO_CONV("U32I", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("S16I", "S16N", AUDIO_FORMAT_16BIT);
+  AUDIO_CONV("U16I", "S16N", AUDIO_FORMAT_16BIT);
+  AUDIO_CONV("S24I", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("U24I", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("S32I", "S32N", AUDIO_FORMAT_32BIT);
+  AUDIO_CONV("U32I", "S32N", AUDIO_FORMAT_32BIT);
 #undef AUDIO_CONV
 #undef AUDIO_TEST
 
-	*(uint32_t*)format = *(uint32_t*)"FL32";
-	return AUDIO_FORMAT_FLOAT;
+  *(uint32_t*)format = *(uint32_t*)"FL32";
+  return AUDIO_FORMAT_FLOAT;
 }
 
 /* ------------------------------------------------------------------------- */
 
 static const char *vlcs_get_name(void *unused)
 {
-	UNUSED_PARAMETER(unused);
-	return obs_module_text("VLCSource");
+  UNUSED_PARAMETER(unused);
+  return obs_module_text("VLCSource");
 }
 
 static void vlcs_destroy(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (c->media_list_player) {
-		libvlc_media_list_player_stop_(c->media_list_player);
-		libvlc_media_list_player_release_(c->media_list_player);
-	}
-	if (c->media_player) {
-		libvlc_media_player_release_(c->media_player);
-	}
+  if (c->media_list_player) {
+    libvlc_media_list_player_stop_(c->media_list_player);
+    libvlc_media_list_player_release_(c->media_list_player);
+  }
+  if (c->media_player) {
+    libvlc_media_player_release_(c->media_player);
+  }
 
-	bfree((void*)c->audio.data[0]);
-	obs_source_frame_free(&c->frame);
+  bfree((void*)c->audio.data[0]);
+  obs_source_frame_free(&c->frame);
 
-	free_files(&c->files.da);
-	pthread_mutex_destroy(&c->mutex);
-	bfree(c);
+  free_files(&c->files.da);
+  pthread_mutex_destroy(&c->mutex);
+  bfree(c);
 }
 
 static void *vlcs_video_lock(void *data, void **planes)
 {
-	struct vlc_source *c = data;
-	for (size_t i = 0; i < MAX_AV_PLANES && c->frame.data[i] != NULL; i++)
-		planes[i] = c->frame.data[i];
-	return NULL;
+  struct vlc_source *c = data;
+  for (size_t i = 0; i < MAX_AV_PLANES && c->frame.data[i] != NULL; i++) {
+    planes[i] = c->frame.data[i];
+  }
+  return NULL;
+}
+
+static void source_restart (void *data, bool debug);
+
+static bool rescue (void *data, bool debug)
+{
+  struct vlc_source *c = data;
+  uint64_t vlc_time = (uint64_t) libvlc_media_player_get_time_(c->media_player);
+  int64_t diff;
+  time_t current_time = time(NULL);
+  struct tm * time_info;
+  char timeString[9];
+  bool attempting_restart;
+
+  if ( c->vlc_time != NULL ) {
+
+    diff = (int64_t) vlc_time - c->vlc_time;
+
+    if ( diff > 0 && c->last_frame_at != current_time ) {
+      
+      c->last_frame_at = current_time;
+      c->restarted = false;
+
+      if ( debug ) {
+        time_info = localtime((time_t) &current_time);
+        strftime(timeString, sizeof(timeString), "%H:%M:%S", time_info);
+        printf("last_frame_at: %s, id: %s\n", timeString, obs_source_get_name(c->source));
+      }
+
+    }
+    
+    if ( diff < 0 ) {
+      if ( debug )
+        printf("%s skipped to the past!\n", obs_source_get_name(c->source));
+
+      source_restart(c, debug);
+    }
+
+    if ( c->last_frame_at != NULL && (current_time - c->last_frame_at) > 10 ) {
+      if ( debug )
+        printf("%s 10 seconds without new frames!\n", obs_source_get_name(c->source));
+
+      source_restart(c, debug);
+
+      // restart the counter so that the log message will appear again in the next 10 seconds
+      c->last_frame_at = current_time;
+    }
+  }
+
+  // update vlc_time
+  c->vlc_time = vlc_time;
+
+  switch ( attempting_restart ) {
+    case true:
+      // stop 
+      return false;
+    
+    default:
+    case false:
+      // proceed
+      return true;
+  }
+
+}
+
+static void source_restart (void *data, bool debug)
+{
+
+  struct vlc_source *c = data;
+  
+  if ( c->restarted == false ) {
+    if ( debug )
+      printf("%s restarting...\n", obs_source_get_name(c->source));
+    c->restarted = true;
+    
+    obs_source_output_video(c->source, NULL);
+    obs_source_update(c->source, NULL);
+
+    return true;
+  } else {
+    if ( debug )
+      printf("%s already restarted, nothing to do\n", obs_source_get_name(c->source));
+    return false;
+  }
 }
 
 static void vlcs_video_display(void *data, void *picture)
 {
-	struct vlc_source *c = data;
-	c->frame.timestamp = (uint64_t)libvlc_clock_() * 1000ULL - time_start;
-	obs_source_output_video(c->source, &c->frame);
+  if ( !rescue(data, true) ) 
+    return;
 
-	UNUSED_PARAMETER(picture);
+  struct vlc_source *c = data;
+  c->frame.timestamp = (uint64_t)libvlc_clock_() * 1000ULL - time_start;
+  obs_source_output_video(c->source, &c->frame);
+
+  UNUSED_PARAMETER(picture);
 }
 
 static unsigned vlcs_video_format(void **p_data, char *chroma, unsigned *width,
-		unsigned *height, unsigned *pitches, unsigned *lines)
+    unsigned *height, unsigned *pitches, unsigned *lines)
 {
-	struct vlc_source *c = *p_data;
-	enum video_format new_format;
-	enum video_range_type range;
-	bool new_range;
-	unsigned new_width = 0;
-	unsigned new_height = 0;
-	size_t i = 0;
+  struct vlc_source *c = *p_data;
+  enum video_format new_format;
+  enum video_range_type range;
+  bool new_range;
+  unsigned new_width = 0;
+  unsigned new_height = 0;
+  size_t i = 0;
 
-	new_format = convert_vlc_video_format(chroma, &new_range);
+  new_format = convert_vlc_video_format(chroma, &new_range);
 
-	/* This is used because VLC will by default try to use a different
-	 * scaling than what the file uses (probably for optimization reasons).
-	 * For example, if the file is 1920x1080, it will try to render it by
-	 * 1920x1088, which isn't what we want.  Calling libvlc_video_get_size
-	 * gets the actual video file's size, and thus fixes the problem.
-	 * However this doesn't work with URLs, so if it returns a 0 value, it
-	 * shouldn't be used. */
-	libvlc_video_get_size_(c->media_player, 0, &new_width, &new_height);
+  /* This is used because VLC will by default try to use a different
+   * scaling than what the file uses (probably for optimization reasons).
+   * For example, if the file is 1920x1080, it will try to render it by
+   * 1920x1088, which isn't what we want.  Calling libvlc_video_get_size
+   * gets the actual video file's size, and thus fixes the problem.
+   * However this doesn't work with URLs, so if it returns a 0 value, it
+   * shouldn't be used. */
+  libvlc_video_get_size_(c->media_player, 0, &new_width, &new_height);
 
-	if (new_width && new_height) {
-		*width  = new_width;
-		*height = new_height;
-	}
+  if (new_width && new_height) {
+    *width  = new_width;
+    *height = new_height;
+  }
 
-	/* don't allocate a new frame if format/width/height hasn't changed */
-	if (c->frame.format != new_format ||
-	    c->frame.width  != *width     ||
-	    c->frame.height != *height) {
-		obs_source_frame_free(&c->frame);
-		obs_source_frame_init(&c->frame, new_format, *width, *height);
+  /* don't allocate a new frame if format/width/height hasn't changed */
+  if (c->frame.format != new_format ||
+      c->frame.width  != *width     ||
+      c->frame.height != *height) {
+    obs_source_frame_free(&c->frame);
+    obs_source_frame_init(&c->frame, new_format, *width, *height);
 
-		c->frame.format = new_format;
-		c->frame.full_range = new_range;
-		range = c->frame.full_range ?
-			VIDEO_RANGE_FULL : VIDEO_RANGE_PARTIAL;
-		video_format_get_parameters(VIDEO_CS_DEFAULT, range,
-				c->frame.color_matrix,
-				c->frame.color_range_min,
-				c->frame.color_range_max);
-	}
+    c->frame.format = new_format;
+    c->frame.full_range = new_range;
+    range = c->frame.full_range ?
+      VIDEO_RANGE_FULL : VIDEO_RANGE_PARTIAL;
+    video_format_get_parameters(VIDEO_CS_DEFAULT, range,
+        c->frame.color_matrix,
+        c->frame.color_range_min,
+        c->frame.color_range_max);
+  }
 
-	while (c->frame.data[i]) {
-		pitches[i] = (unsigned)c->frame.linesize[i];
-		lines[i] = get_format_lines(c->frame.format, *height, i);
-		i++;
-	}
+  while (c->frame.data[i]) {
+    pitches[i] = (unsigned)c->frame.linesize[i];
+    lines[i] = get_format_lines(c->frame.format, *height, i);
+    i++;
+  }
 
-	return 1;
+  return 1;
 }
 
 static void vlcs_audio_play(void *data, const void *samples, unsigned count,
-		int64_t pts)
+    int64_t pts)
 {
-	struct vlc_source *c = data;
-	size_t size = get_audio_size(c->audio.format, c->audio.speakers, count);
+  struct vlc_source *c = data;
+  size_t size = get_audio_size(c->audio.format, c->audio.speakers, count);
 
-	if (c->audio_capacity < count) {
-		c->audio.data[0] = brealloc((void*)c->audio.data[0], size);
-		c->audio_capacity = count;
-	}
+  if (c->audio_capacity < count) {
+    c->audio.data[0] = brealloc((void*)c->audio.data[0], size);
+    c->audio_capacity = count;
+  }
 
-	memcpy((void*)c->audio.data[0], samples, size);
-	c->audio.timestamp = (uint64_t)pts * 1000ULL - time_start;
-	c->audio.frames = count;
+  memcpy((void*)c->audio.data[0], samples, size);
+  c->audio.timestamp = (uint64_t)pts * 1000ULL - time_start;
+  c->audio.frames = count;
 
-	obs_source_output_audio(c->source, &c->audio);
+  obs_source_output_audio(c->source, &c->audio);
 }
 
 static int vlcs_audio_setup(void **p_data, char *format, unsigned *rate,
-		unsigned *channels)
+    unsigned *channels)
 {
-	struct vlc_source *c = *p_data;
-	enum audio_format new_audio_format;
+  struct vlc_source *c = *p_data;
+  enum audio_format new_audio_format;
 
-	new_audio_format = convert_vlc_audio_format(format);
-	if (*channels > 2)
-		*channels = 2;
+  new_audio_format = convert_vlc_audio_format(format);
+  if (*channels > 2)
+    *channels = 2;
 
-	/* don't free audio data if the data is the same format */
-	if (c->audio.format == new_audio_format &&
-	    c->audio.samples_per_sec == *rate &&
-	    c->audio.speakers == (enum speaker_layout)*channels)
-		return 0;
+  /* don't free audio data if the data is the same format */
+  if (c->audio.format == new_audio_format &&
+      c->audio.samples_per_sec == *rate &&
+      c->audio.speakers == (enum speaker_layout)*channels)
+    return 0;
 
-	c->audio_capacity = 0;
-	bfree((void*)c->audio.data[0]);
+  c->audio_capacity = 0;
+  bfree((void*)c->audio.data[0]);
 
-	memset(&c->audio, 0, sizeof(c->audio));
-	c->audio.speakers = (enum speaker_layout)*channels;
-	c->audio.samples_per_sec = *rate;
-	c->audio.format = new_audio_format;
-	return 0;
+  memset(&c->audio, 0, sizeof(c->audio));
+  c->audio.speakers = (enum speaker_layout)*channels;
+  c->audio.samples_per_sec = *rate;
+  c->audio.format = new_audio_format;
+  return 0;
 }
 
 static void add_file(struct vlc_source *c, struct darray *array,
-		const char *path, int network_caching)
+    const char *path, int network_caching)
 {
-	DARRAY(struct media_file_data) new_files;
-	struct media_file_data data;
-	struct dstr new_path = {0};
-	libvlc_media_t *new_media;
-	bool is_url = path && strstr(path, "://") != NULL;
+  DARRAY(struct media_file_data) new_files;
+  struct media_file_data data;
+  struct dstr new_path = {0};
+  libvlc_media_t *new_media;
+  bool is_url = path && strstr(path, "://") != NULL;
 
-	new_files.da = *array;
+  new_files.da = *array;
 
-	dstr_copy(&new_path, path);
+  dstr_copy(&new_path, path);
 #ifdef _WIN32
-	if (!is_url)
-		dstr_replace(&new_path, "/", "\\");
+  if (!is_url)
+    dstr_replace(&new_path, "/", "\\");
 #endif
-	path = new_path.array;
+  path = new_path.array;
 
-	new_media = get_media(&c->files.da, path);
+  new_media = get_media(&c->files.da, path);
 
-	if (!new_media)
-		new_media = get_media(&new_files.da, path);
-	if (!new_media)
-		new_media = create_media_from_file(path);
+  if (!new_media)
+    new_media = get_media(&new_files.da, path);
+  if (!new_media)
+    new_media = create_media_from_file(path);
 
-	if (new_media) {
-		if (is_url) {
-			struct dstr network_caching_option = {0};
-			dstr_catf(&network_caching_option,
-					":network-caching=%d", network_caching);
-			libvlc_media_add_option_(new_media,
-					network_caching_option.array);
-			dstr_free(&network_caching_option);
-		}
+  if (new_media) {
+    if (is_url) {
+      struct dstr network_caching_option = {0};
+      dstr_catf(&network_caching_option,
+          ":network-caching=%d", network_caching);
+      libvlc_media_add_option_(new_media,
+          network_caching_option.array);
+      dstr_free(&network_caching_option);
+    }
 
-		data.path = new_path.array;
-		data.media = new_media;
-		da_push_back(new_files, &data);
-	} else {
-		dstr_free(&new_path);
-	}
+    data.path = new_path.array;
+    data.media = new_media;
+    da_push_back(new_files, &data);
+  } else {
+    dstr_free(&new_path);
+  }
 
-	*array = new_files.da;
+  *array = new_files.da;
 }
 
 static bool valid_extension(const char *ext)
 {
-	struct dstr test = {0};
-	bool valid = false;
-	const char *b;
-	const char *e;
+  struct dstr test = {0};
+  bool valid = false;
+  const char *b;
+  const char *e;
 
-	if (!ext || !*ext)
-		return false;
+  if (!ext || !*ext)
+    return false;
 
-	b = EXTENSIONS_MEDIA + 1;
-	e = strchr(b, ';');
+  b = EXTENSIONS_MEDIA + 1;
+  e = strchr(b, ';');
 
-	for (;;) {
-		if (e) dstr_ncopy(&test, b, e - b);
-		else   dstr_copy(&test, b);
+  for (;;) {
+    if (e) dstr_ncopy(&test, b, e - b);
+    else   dstr_copy(&test, b);
 
-		if (dstr_cmp(&test, ext) == 0) {
-			valid = true;
-			break;
-		}
+    if (dstr_cmp(&test, ext) == 0) {
+      valid = true;
+      break;
+    }
 
-		if (!e)
-			break;
+    if (!e)
+      break;
 
-		b = e + 2;
-		e = strchr(b, ';');
-	}
+    b = e + 2;
+    e = strchr(b, ';');
+  }
 
-	dstr_free(&test);
-	return valid;
+  dstr_free(&test);
+  return valid;
 }
 
 static void vlcs_update(void *data, obs_data_t *settings)
 {
-	DARRAY(struct media_file_data) new_files;
-	DARRAY(struct media_file_data) old_files;
-	libvlc_media_list_t *media_list;
-	struct vlc_source *c = data;
-	obs_data_array_t *array;
-	const char *behavior;
-	size_t count;
-	int network_caching;
+  setting_storage = settings;
+  data_storage = data;
 
-	da_init(new_files);
-	da_init(old_files);
+  DARRAY(struct media_file_data) new_files;
+  DARRAY(struct media_file_data) old_files;
+  libvlc_media_list_t *media_list;
+  struct vlc_source *c = data;
+  obs_data_array_t *array;
+  const char *behavior;
+  size_t count;
+  int network_caching;
 
-	array = obs_data_get_array(settings, S_PLAYLIST);
-	count = obs_data_array_count(array);
+  da_init(new_files);
+  da_init(old_files);
 
-	c->loop = obs_data_get_bool(settings, S_LOOP);
+  array = obs_data_get_array(settings, S_PLAYLIST);
+  count = obs_data_array_count(array);
 
-	behavior = obs_data_get_string(settings, S_BEHAVIOR);
+  c->loop = obs_data_get_bool(settings, S_LOOP);
 
-	network_caching = (int)obs_data_get_int(settings, S_NETWORK_CACHING);
+  behavior = obs_data_get_string(settings, S_BEHAVIOR);
 
-	if (astrcmpi(behavior, S_BEHAVIOR_PAUSE_UNPAUSE) == 0) {
-		c->behavior = BEHAVIOR_PAUSE_UNPAUSE;
-	} else if (astrcmpi(behavior, S_BEHAVIOR_ALWAYS_PLAY) == 0) {
-		c->behavior = BEHAVIOR_ALWAYS_PLAY;
-	} else { /* S_BEHAVIOR_STOP_RESTART */
-		c->behavior = BEHAVIOR_STOP_RESTART;
-	}
+  network_caching = (int)obs_data_get_int(settings, S_NETWORK_CACHING);
 
-	/* ------------------------------------- */
-	/* create new list of sources */
+  if (astrcmpi(behavior, S_BEHAVIOR_PAUSE_UNPAUSE) == 0) {
+    c->behavior = BEHAVIOR_PAUSE_UNPAUSE;
+  } else if (astrcmpi(behavior, S_BEHAVIOR_ALWAYS_PLAY) == 0) {
+    c->behavior = BEHAVIOR_ALWAYS_PLAY;
+  } else { /* S_BEHAVIOR_STOP_RESTART */
+    c->behavior = BEHAVIOR_STOP_RESTART;
+  }
 
-	for (size_t i = 0; i < count; i++) {
-		obs_data_t *item = obs_data_array_item(array, i);
-		const char *path = obs_data_get_string(item, "value");
-		os_dir_t *dir = os_opendir(path);
+  /* ------------------------------------- */
+  /* create new list of sources */
 
-		if (dir) {
-			struct dstr dir_path = {0};
-			struct os_dirent *ent;
+  for (size_t i = 0; i < count; i++) {
+    obs_data_t *item = obs_data_array_item(array, i);
+    const char *path = obs_data_get_string(item, "value");
+    os_dir_t *dir = os_opendir(path);
 
-			for (;;) {
-				const char *ext;
+    if (dir) {
+      struct dstr dir_path = {0};
+      struct os_dirent *ent;
 
-				ent = os_readdir(dir);
-				if (!ent)
-					break;
-				if (ent->directory)
-					continue;
+      for (;;) {
+        const char *ext;
 
-				ext = os_get_path_extension(ent->d_name);
-				if (!valid_extension(ext))
-					continue;
+        ent = os_readdir(dir);
+        if (!ent)
+          break;
+        if (ent->directory)
+          continue;
 
-				dstr_copy(&dir_path, path);
-				dstr_cat_ch(&dir_path, '/');
-				dstr_cat(&dir_path, ent->d_name);
-				add_file(c, &new_files.da, dir_path.array,
-						network_caching);
-			}
+        ext = os_get_path_extension(ent->d_name);
+        if (!valid_extension(ext))
+          continue;
 
-			dstr_free(&dir_path);
-			os_closedir(dir);
-		} else {
-			add_file(c, &new_files.da, path, network_caching);
-		}
+        dstr_copy(&dir_path, path);
+        dstr_cat_ch(&dir_path, '/');
+        dstr_cat(&dir_path, ent->d_name);
+        add_file(c, &new_files.da, dir_path.array,
+            network_caching);
+      }
 
-		obs_data_release(item);
-	}
+      dstr_free(&dir_path);
+      os_closedir(dir);
+    } else {
+      add_file(c, &new_files.da, path, network_caching);
+    }
 
-	/* ------------------------------------- */
-	/* update settings data */
+    obs_data_release(item);
+  }
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+  /* ------------------------------------- */
+  /* update settings data */
 
-	pthread_mutex_lock(&c->mutex);
-	old_files.da = c->files.da;
-	c->files.da = new_files.da;
-	pthread_mutex_unlock(&c->mutex);
+  libvlc_media_list_player_stop_(c->media_list_player);
 
-	/* ------------------------------------- */
-	/* shuffle playlist */
+  pthread_mutex_lock(&c->mutex);
+  old_files.da = c->files.da;
+  c->files.da = new_files.da;
+  pthread_mutex_unlock(&c->mutex);
 
-	c->shuffle = obs_data_get_bool(settings, S_SHUFFLE);
+  /* ------------------------------------- */
+  /* shuffle playlist */
 
-	if (c->files.num > 1 && c->shuffle) {
-		DARRAY(struct media_file_data) new_files;
-		DARRAY(size_t) idxs;
+  c->shuffle = obs_data_get_bool(settings, S_SHUFFLE);
 
-		da_init(new_files);
-		da_init(idxs);
-		da_resize(idxs, c->files.num);
-		da_reserve(new_files, c->files.num);
+  if (c->files.num > 1 && c->shuffle) {
+    DARRAY(struct media_file_data) new_files;
+    DARRAY(size_t) idxs;
 
-		for (size_t i = 0; i < c->files.num; i++) {
-			idxs.array[i] = i;
-		}
-		for (size_t i = idxs.num; i > 0; i--) {
-			size_t val = rand() % i;
-			size_t idx = idxs.array[val];
-			da_push_back(new_files, &c->files.array[idx]);
-			da_erase(idxs, val);
-		}
+    da_init(new_files);
+    da_init(idxs);
+    da_resize(idxs, c->files.num);
+    da_reserve(new_files, c->files.num);
 
-		da_free(c->files);
-		da_free(idxs);
-		c->files.da = new_files.da;
-	}
+    for (size_t i = 0; i < c->files.num; i++) {
+      idxs.array[i] = i;
+    }
+    for (size_t i = idxs.num; i > 0; i--) {
+      size_t val = rand() % i;
+      size_t idx = idxs.array[val];
+      da_push_back(new_files, &c->files.array[idx]);
+      da_erase(idxs, val);
+    }
 
-	/* ------------------------------------- */
-	/* clean up and restart playback */
+    da_free(c->files);
+    da_free(idxs);
+    c->files.da = new_files.da;
+  }
 
-	free_files(&old_files.da);
+  /* ------------------------------------- */
+  /* clean up and restart playback */
 
-	media_list = libvlc_media_list_new_(libvlc);
+  free_files(&old_files.da);
 
-	libvlc_media_list_lock_(media_list);
-	for (size_t i = 0; i < c->files.num; i++)
-		libvlc_media_list_add_media_(media_list,
-				c->files.array[i].media);
-	libvlc_media_list_unlock_(media_list);
+  media_list = libvlc_media_list_new_(libvlc);
 
-	libvlc_media_list_player_set_media_list_(c->media_list_player,
-			media_list);
-	libvlc_media_list_release_(media_list);
+  libvlc_media_list_lock_(media_list);
+  for (size_t i = 0; i < c->files.num; i++)
+    libvlc_media_list_add_media_(media_list,
+        c->files.array[i].media);
+  libvlc_media_list_unlock_(media_list);
 
-	libvlc_media_list_player_set_playback_mode_(c->media_list_player,
-			c->loop ? libvlc_playback_mode_loop :
-			          libvlc_playback_mode_default);
+  libvlc_media_list_player_set_media_list_(c->media_list_player,
+      media_list);
+  libvlc_media_list_release_(media_list);
 
-	if (c->files.num &&
-	    (c->behavior == BEHAVIOR_ALWAYS_PLAY || obs_source_active(c->source)))
-		libvlc_media_list_player_play_(c->media_list_player);
-	else
-		obs_source_output_video(c->source, NULL);
+  libvlc_media_list_player_set_playback_mode_(c->media_list_player,
+      c->loop ? libvlc_playback_mode_loop :
+      libvlc_playback_mode_default);
 
-	obs_data_array_release(array);
+  if (c->files.num &&
+      (c->behavior == BEHAVIOR_ALWAYS_PLAY || obs_source_active(c->source))) {
+    libvlc_media_list_player_play_(c->media_list_player);
+  }
+  else {
+    obs_source_output_video(c->source, NULL);
+  }
+
+  obs_data_array_release(array);
 }
 
 static void vlcs_stopped(const struct libvlc_event_t *event, void *data)
 {
-	struct vlc_source *c = data;
-	if (!c->loop)
-		obs_source_output_video(c->source, NULL);
+  struct vlc_source *c = data;
+  if (!c->loop)
+    obs_source_output_video(c->source, NULL);
 
-	UNUSED_PARAMETER(event);
+  UNUSED_PARAMETER(event);
 }
 
 static void vlcs_play_pause(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	libvlc_media_list_player_pause_(c->media_list_player);
+  libvlc_media_list_player_pause_(c->media_list_player);
 }
 
 static void vlcs_restart(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	libvlc_media_list_player_stop_(c->media_list_player);
-	libvlc_media_list_player_play_(c->media_list_player);
+  libvlc_media_list_player_stop_(c->media_list_player);
+  libvlc_media_list_player_play_(c->media_list_player);
 }
 
 static void vlcs_stop(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	libvlc_media_list_player_stop_(c->media_list_player);
-	obs_source_output_video(c->source, NULL);
+  libvlc_media_list_player_stop_(c->media_list_player);
+  obs_source_output_video(c->source, NULL);
 }
 
 static void vlcs_playlist_next(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	libvlc_media_list_player_next_(c->media_list_player);
+  libvlc_media_list_player_next_(c->media_list_player);
 }
 
 static void vlcs_playlist_prev(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	libvlc_media_list_player_previous_(c->media_list_player);
+  libvlc_media_list_player_previous_(c->media_list_player);
 }
 
 static void vlcs_play_pause_hotkey(void *data, obs_hotkey_id id,
-		obs_hotkey_t *hotkey, bool pressed)
+    obs_hotkey_t *hotkey, bool pressed)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
+  UNUSED_PARAMETER(id);
+  UNUSED_PARAMETER(hotkey);
 
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
-		vlcs_play_pause(c);
+  if (pressed && obs_source_active(c->source))
+    vlcs_play_pause(c);
 }
 
 static void vlcs_restart_hotkey(void *data, obs_hotkey_id id,
-		obs_hotkey_t *hotkey, bool pressed)
+    obs_hotkey_t *hotkey, bool pressed)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
+  UNUSED_PARAMETER(id);
+  UNUSED_PARAMETER(hotkey);
 
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
-		vlcs_restart(c);
+  if (pressed && obs_source_active(c->source))
+    vlcs_restart(c);
 }
 
 static void vlcs_stop_hotkey(void *data, obs_hotkey_id id,
-		obs_hotkey_t *hotkey, bool pressed)
+    obs_hotkey_t *hotkey, bool pressed)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
+  UNUSED_PARAMETER(id);
+  UNUSED_PARAMETER(hotkey);
 
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
-		vlcs_stop(c);
+  if (pressed && obs_source_active(c->source))
+    vlcs_stop(c);
 }
 
 static void vlcs_playlist_next_hotkey(void *data, obs_hotkey_id id,
-		obs_hotkey_t *hotkey, bool pressed)
+    obs_hotkey_t *hotkey, bool pressed)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
+  UNUSED_PARAMETER(id);
+  UNUSED_PARAMETER(hotkey);
 
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
-		vlcs_playlist_next(c);
+  if (pressed && obs_source_active(c->source))
+    vlcs_playlist_next(c);
 }
 
 static void vlcs_playlist_prev_hotkey(void *data, obs_hotkey_id id,
-		obs_hotkey_t *hotkey, bool pressed)
+    obs_hotkey_t *hotkey, bool pressed)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
+  UNUSED_PARAMETER(id);
+  UNUSED_PARAMETER(hotkey);
 
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (pressed && obs_source_active(c->source))
-		vlcs_playlist_prev(c);
+  if (pressed && obs_source_active(c->source))
+    vlcs_playlist_prev(c);
 }
 
 static void *vlcs_create(obs_data_t *settings, obs_source_t *source)
 {
-	struct vlc_source *c = bzalloc(sizeof(*c));
-	c->source = source;
+  struct vlc_source *c = bzalloc(sizeof(*c));
+  c->source = source;
 
-	c->play_pause_hotkey = obs_hotkey_register_source(source,
-			"VLCSource.PlayPause",
-			obs_module_text("PlayPause"),
-			vlcs_play_pause_hotkey, c);
+  c->play_pause_hotkey = obs_hotkey_register_source(source,
+      "VLCSource.PlayPause",
+      obs_module_text("PlayPause"),
+      vlcs_play_pause_hotkey, c);
 
-	c->restart_hotkey = obs_hotkey_register_source(source,
-			"VLCSource.Restart",
-			obs_module_text("Restart"),
-			vlcs_restart_hotkey, c);
+  c->restart_hotkey = obs_hotkey_register_source(source,
+      "VLCSource.Restart",
+      obs_module_text("Restart"),
+      vlcs_restart_hotkey, c);
 
-	c->stop_hotkey = obs_hotkey_register_source(source,
-			"VLCSource.Stop",
-			obs_module_text("Stop"),
-			vlcs_stop_hotkey, c);
+  c->stop_hotkey = obs_hotkey_register_source(source,
+      "VLCSource.Stop",
+      obs_module_text("Stop"),
+      vlcs_stop_hotkey, c);
 
-	c->playlist_next_hotkey = obs_hotkey_register_source(source,
-			"VLCSource.PlaylistNext",
-			obs_module_text("PlaylistNext"),
-			vlcs_playlist_next_hotkey, c);
+  c->playlist_next_hotkey = obs_hotkey_register_source(source,
+      "VLCSource.PlaylistNext",
+      obs_module_text("PlaylistNext"),
+      vlcs_playlist_next_hotkey, c);
 
-	c->playlist_prev_hotkey = obs_hotkey_register_source(source,
-			"VLCSource.PlaylistPrev",
-			obs_module_text("PlaylistPrev"),
-			vlcs_playlist_prev_hotkey, c);
+  c->playlist_prev_hotkey = obs_hotkey_register_source(source,
+      "VLCSource.PlaylistPrev",
+      obs_module_text("PlaylistPrev"),
+      vlcs_playlist_prev_hotkey, c);
 
-	pthread_mutex_init_value(&c->mutex);
-	if (pthread_mutex_init(&c->mutex, NULL) != 0)
-		goto error;
+  pthread_mutex_init_value(&c->mutex);
+  if (pthread_mutex_init(&c->mutex, NULL) != 0)
+    goto error;
 
-	if (!load_libvlc())
-		goto error;
+  if (!load_libvlc())
+    goto error;
 
-	c->media_list_player = libvlc_media_list_player_new_(libvlc);
-	if (!c->media_list_player)
-		goto error;
+  c->media_list_player = libvlc_media_list_player_new_(libvlc);
+  if (!c->media_list_player)
+    goto error;
 
-	c->media_player = libvlc_media_player_new_(libvlc);
-	if (!c->media_player)
-		goto error;
+  c->media_player = libvlc_media_player_new_(libvlc);
+  if (!c->media_player)
+    goto error;
 
-	libvlc_media_list_player_set_media_player_(c->media_list_player,
-			c->media_player);
+  libvlc_media_list_player_set_media_player_(c->media_list_player,
+      c->media_player);
 
-	libvlc_video_set_callbacks_(c->media_player,
-			vlcs_video_lock, NULL, vlcs_video_display,
-			c);
-	libvlc_video_set_format_callbacks_(c->media_player,
-			vlcs_video_format, NULL);
+  libvlc_video_set_callbacks_(c->media_player,
+      vlcs_video_lock, NULL, vlcs_video_display,
+      c);
+  libvlc_video_set_format_callbacks_(c->media_player,
+      vlcs_video_format, NULL);
 
-	libvlc_audio_set_callbacks_(c->media_player,
-			vlcs_audio_play, NULL, NULL, NULL, NULL, c);
-	libvlc_audio_set_format_callbacks_(c->media_player,
-			vlcs_audio_setup, NULL);
+  libvlc_audio_set_callbacks_(c->media_player,
+      vlcs_audio_play, NULL, NULL, NULL, NULL, c);
+  libvlc_audio_set_format_callbacks_(c->media_player,
+      vlcs_audio_setup, NULL);
 
-	libvlc_event_manager_t *event_manager;
-	event_manager = libvlc_media_player_event_manager_(c->media_player);
-	libvlc_event_attach_(event_manager, libvlc_MediaPlayerEndReached,
-			vlcs_stopped, c);
+  libvlc_event_manager_t *event_manager;
+  event_manager = libvlc_media_player_event_manager_(c->media_player);
+  libvlc_event_attach_(event_manager, libvlc_MediaPlayerEndReached,
+      vlcs_stopped, c);
 
-	obs_source_update(source, NULL);
+  obs_source_update(source, NULL);
 
-	UNUSED_PARAMETER(settings);
-	return c;
+  UNUSED_PARAMETER(settings);
+  return c;
 
 error:
-	vlcs_destroy(c);
-	return NULL;
+  vlcs_destroy(c);
+  return NULL;
 }
 
 static void vlcs_activate(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (c->behavior == BEHAVIOR_STOP_RESTART) {
-		libvlc_media_list_player_play_(c->media_list_player);
+  if (c->behavior == BEHAVIOR_STOP_RESTART) {
+    libvlc_media_list_player_play_(c->media_list_player);
 
-	} else if (c->behavior == BEHAVIOR_PAUSE_UNPAUSE) {
-		libvlc_media_list_player_play_(c->media_list_player);
-	}
+  } else if (c->behavior == BEHAVIOR_PAUSE_UNPAUSE) {
+    libvlc_media_list_player_play_(c->media_list_player);
+  }
 }
 
 static void vlcs_deactivate(void *data)
 {
-	struct vlc_source *c = data;
+  struct vlc_source *c = data;
 
-	if (c->behavior == BEHAVIOR_STOP_RESTART) {
-		libvlc_media_list_player_stop_(c->media_list_player);
-		obs_source_output_video(c->source, NULL);
+  if (c->behavior == BEHAVIOR_STOP_RESTART) {
+    libvlc_media_list_player_stop_(c->media_list_player);
+    obs_source_output_video(c->source, NULL);
 
-	} else if (c->behavior == BEHAVIOR_PAUSE_UNPAUSE) {
-		libvlc_media_list_player_pause_(c->media_list_player);
-	}
+  } else if (c->behavior == BEHAVIOR_PAUSE_UNPAUSE) {
+    libvlc_media_list_player_pause_(c->media_list_player);
+  }
 }
 
 static void vlcs_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_bool(settings, S_LOOP, true);
-	obs_data_set_default_bool(settings, S_SHUFFLE, false);
-	obs_data_set_default_string(settings, S_BEHAVIOR,
-			S_BEHAVIOR_STOP_RESTART);
-	obs_data_set_default_int(settings, S_NETWORK_CACHING, 400);
+  obs_data_set_default_bool(settings, S_LOOP, true);
+  obs_data_set_default_bool(settings, S_SHUFFLE, false);
+  obs_data_set_default_string(settings, S_BEHAVIOR,
+      S_BEHAVIOR_STOP_RESTART);
+  obs_data_set_default_int(settings, S_NETWORK_CACHING, 400);
 }
 
 static obs_properties_t *vlcs_properties(void *data)
 {
-	obs_properties_t *ppts = obs_properties_create();
-	struct vlc_source *c = data;
-	struct dstr filter = {0};
-	struct dstr exts = {0};
-	struct dstr path = {0};
-	obs_property_t *p;
+  obs_properties_t *ppts = obs_properties_create();
+  struct vlc_source *c = data;
+  struct dstr filter = {0};
+  struct dstr exts = {0};
+  struct dstr path = {0};
+  obs_property_t *p;
 
-	obs_properties_set_flags(ppts, OBS_PROPERTIES_DEFER_UPDATE);
-	obs_properties_add_bool(ppts, S_LOOP, T_LOOP);
-	obs_properties_add_bool(ppts, S_SHUFFLE, T_SHUFFLE);
+  obs_properties_set_flags(ppts, OBS_PROPERTIES_DEFER_UPDATE);
+  obs_properties_add_bool(ppts, S_LOOP, T_LOOP);
+  obs_properties_add_bool(ppts, S_SHUFFLE, T_SHUFFLE);
 
-	if (c) {
-		pthread_mutex_lock(&c->mutex);
-		if (c->files.num) {
-			struct media_file_data *last = da_end(c->files);
-			const char *slash;
+  if (c) {
+    pthread_mutex_lock(&c->mutex);
+    if (c->files.num) {
+      struct media_file_data *last = da_end(c->files);
+      const char *slash;
 
-			dstr_copy(&path, last->path);
-			dstr_replace(&path, "\\", "/");
-			slash = strrchr(path.array, '/');
-			if (slash)
-				dstr_resize(&path, slash - path.array + 1);
-		}
-		pthread_mutex_unlock(&c->mutex);
-	}
+      dstr_copy(&path, last->path);
+      dstr_replace(&path, "\\", "/");
+      slash = strrchr(path.array, '/');
+      if (slash)
+        dstr_resize(&path, slash - path.array + 1);
+    }
+    pthread_mutex_unlock(&c->mutex);
+  }
 
-	p = obs_properties_add_list(ppts, S_BEHAVIOR, T_BEHAVIOR,
-			OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
-	obs_property_list_add_string(p, T_BEHAVIOR_STOP_RESTART,
-			S_BEHAVIOR_STOP_RESTART);
-	obs_property_list_add_string(p, T_BEHAVIOR_PAUSE_UNPAUSE,
-			S_BEHAVIOR_PAUSE_UNPAUSE);
-	obs_property_list_add_string(p, T_BEHAVIOR_ALWAYS_PLAY,
-			S_BEHAVIOR_ALWAYS_PLAY);
+  p = obs_properties_add_list(ppts, S_BEHAVIOR, T_BEHAVIOR,
+      OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
+  obs_property_list_add_string(p, T_BEHAVIOR_STOP_RESTART,
+      S_BEHAVIOR_STOP_RESTART);
+  obs_property_list_add_string(p, T_BEHAVIOR_PAUSE_UNPAUSE,
+      S_BEHAVIOR_PAUSE_UNPAUSE);
+  obs_property_list_add_string(p, T_BEHAVIOR_ALWAYS_PLAY,
+      S_BEHAVIOR_ALWAYS_PLAY);
 
-	dstr_cat(&filter, "Media Files (");
-	dstr_copy(&exts, EXTENSIONS_MEDIA);
-	dstr_replace(&exts, ";", " ");
-	dstr_cat_dstr(&filter, &exts);
+  dstr_cat(&filter, "Media Files (");
+  dstr_copy(&exts, EXTENSIONS_MEDIA);
+  dstr_replace(&exts, ";", " ");
+  dstr_cat_dstr(&filter, &exts);
 
-	dstr_cat(&filter, ");;Video Files (");
-	dstr_copy(&exts, EXTENSIONS_VIDEO);
-	dstr_replace(&exts, ";", " ");
-	dstr_cat_dstr(&filter, &exts);
+  dstr_cat(&filter, ");;Video Files (");
+  dstr_copy(&exts, EXTENSIONS_VIDEO);
+  dstr_replace(&exts, ";", " ");
+  dstr_cat_dstr(&filter, &exts);
 
-	dstr_cat(&filter, ");;Audio Files (");
-	dstr_copy(&exts, EXTENSIONS_AUDIO);
-	dstr_replace(&exts, ";", " ");
-	dstr_cat_dstr(&filter, &exts);
+  dstr_cat(&filter, ");;Audio Files (");
+  dstr_copy(&exts, EXTENSIONS_AUDIO);
+  dstr_replace(&exts, ";", " ");
+  dstr_cat_dstr(&filter, &exts);
 
-	dstr_cat(&filter, ");;Playlist Files (");
-	dstr_copy(&exts, EXTENSIONS_PLAYLIST);
-	dstr_replace(&exts, ";", " ");
-	dstr_cat_dstr(&filter, &exts);
-	dstr_cat(&filter, ")");
+  dstr_cat(&filter, ");;Playlist Files (");
+  dstr_copy(&exts, EXTENSIONS_PLAYLIST);
+  dstr_replace(&exts, ";", " ");
+  dstr_cat_dstr(&filter, &exts);
+  dstr_cat(&filter, ")");
 
-	obs_properties_add_editable_list(ppts, S_PLAYLIST, T_PLAYLIST,
-			OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS,
-			filter.array, path.array);
-	dstr_free(&path);
-	dstr_free(&filter);
-	dstr_free(&exts);
+  obs_properties_add_editable_list(ppts, S_PLAYLIST, T_PLAYLIST,
+      OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS,
+      filter.array, path.array);
+  dstr_free(&path);
+  dstr_free(&filter);
+  dstr_free(&exts);
 
-	obs_properties_add_int(ppts, S_NETWORK_CACHING, T_NETWORK_CACHING,
-			100, 60000, 10);
+  obs_properties_add_int(ppts, S_NETWORK_CACHING, T_NETWORK_CACHING,
+      100, 60000, 10);
 
-	return ppts;
+  return ppts;
 }
 
 struct obs_source_info vlc_source_info = {
-	.id = "vlc_source",
-	.type = OBS_SOURCE_TYPE_INPUT,
-	.output_flags = OBS_SOURCE_ASYNC_VIDEO |
-	                OBS_SOURCE_AUDIO |
-	                OBS_SOURCE_DO_NOT_DUPLICATE,
-	.get_name = vlcs_get_name,
-	.create = vlcs_create,
-	.destroy = vlcs_destroy,
-	.update = vlcs_update,
-	.get_defaults = vlcs_defaults,
-	.get_properties = vlcs_properties,
-	.activate = vlcs_activate,
-	.deactivate = vlcs_deactivate
+  .id = "vlc_source",
+  .type = OBS_SOURCE_TYPE_INPUT,
+  .output_flags = OBS_SOURCE_ASYNC_VIDEO |
+    OBS_SOURCE_AUDIO |
+    OBS_SOURCE_DO_NOT_DUPLICATE,
+  .get_name = vlcs_get_name,
+  .create = vlcs_create,
+  .destroy = vlcs_destroy,
+  .update = vlcs_update,
+  .get_defaults = vlcs_defaults,
+  .get_properties = vlcs_properties,
+  .activate = vlcs_activate,
+  .deactivate = vlcs_deactivate
 };


### PR DESCRIPTION
## Dear developers of OBS-Studio, OBS-Websocket and OBS-Websocket (python)

In this request I'd like to ask all three of you to consider approving
my merge requests for the following new feature in OBS-Studio/Websocket:

### Little background:

OBS-Studio/Websocket has great features for monitoring output streams 
and/or recordings but it lacks monitoring on its input streams. This is
for most users not a problem but for real-broadcast tasks this quickly
becomes an issue because input streams are not always reliable. If 
you're running a 24/7 task, OBS-Studio becomes unsuitable. Which is a 
shame I'd like to address in my code contributions/merge-requests. 

The patches (merge-requests) I wrote are three-fold hence I address all
three developer groups!

* OBS-Studio: 
	Pathed to keep a frame-counter for each produced frame by
	an input-source, keep an average-frame-per-second, and frame-per-second.
	Furthermore OBS-Studio is enabled to provide last-frame-time-stamp, 
	average-frame-per-second, frame-per-second, total-produced-frames-by-source-item
	information to 'third parties' e.g. obs-websocket.so
 
* OBS-Websocket (C++, Dependent on patch OBS-Studio):
	Pathed to be able to receive and answer queries for above mentioned information 
	and pass it to a web-socket client (e.g. obs-websocket python implementation)
	by source-name.

* OBS-Websocket (Python, Dependent on patch OBS-Websocket):
	Pathed to be able to query above mentioned information by source-name.

### Merge-requests links
https://github.com/Elektordi/obs-websocket-py/pull/11 (OBS-Websocket Python)
https://github.com/jp9000/obs-studio/pull/1053 (OBS-Studio)
https://github.com/Palakis/obs-websocket/pull/145 (OBS-Websocket C++)

### How to build?
```
CWD="`pwd`"
mkdir TEST && cd TEST
git clone --recursive https://github.com/masikh/obs-studio.git
cd obs-studio/plugins
git clone --recursive https://github.com/masikh/obs-websocket.git
cd ..
cmake .
make
echo "add_subdirectory(obs-websocket)" >> plugins/CMakeLists.txt
cmake -DLIBOBS_INCLUDE_DIR=${CWD}/TEST/obs-studio/libobs .
make && sudo make install
```

### How to use?

Paste below proof of concept code into a new (python) file. See comments in 
code below for setting up OBS for this example code and patching the python 
obs-websocket too!
```
#!/usr/bin/env python

# L.S.
#
# This proof of concept code will demonstrate the output
# of individual input source progress status. It expects
# that the obs-websocket is running on 'localhost:4444'
# with a password set to 'secret'. For ~this~ example to
# work you must configure a source in your scene-config
# named 'source-name'.
#
# This program expects that the requests.py (from obs-websocket)
# has the following class defined:
#
# class GetSourceData(base_classes.BaseRequest):
#     def __init__(self, source_name):
#         base_classes.BaseRequest.__init__(self)
#         self.name = "GetSourceData"
#         self.dataout["source-name"] = source_name
#
# Example output:
#
# run-time: 8207 name: source-name produced-frames: 117688 avg_fps: 14.00 fps: 24.39
# run-time: 8208 name: source-name produced-frames: 117715 avg_fps: 14.00 fps: 24.39
# run-time: 8209 name: source-name produced-frames: 117741 avg_fps: 14.00 fps: 24.39
#
# Note: Each source, also images, can be monitored. But
# only video sources are producing frames. Audio is not
# monitored, yet....)

import logging
import obswebsocket
from obswebsocket import requests

logging.basicConfig(level=logging.CRITICAL)


class OpenBroadcastServer:
    def __init__(self, host, port, password):
        self.host = host
        self.port = port
        self.password = password
        self.websocket = obswebsocket.obsws(self.host, self.port, self.password)
        self.connect()

    def connect(self):
        self.websocket.connect()

    def get_source_data(self, source_name):
        request = requests.GetSourceData(source_name)
        return self.websocket.call(request)


if __name__ == "__main__":
    from time import sleep
    obs = OpenBroadcastServer('localhost', 4444, 'secret')
    while True:
        result = obs.get_source_data('source-name')
        runtime = result.datain['last_frame_ts'] / 1000000000
        name = result.datain['name']
        produced_frames = int(result.datain['total_frames'])
        avg_fps = "{0:.2f}".format(result.datain['video_avg_fps'])
        fps = "{0:.2f}".format(result.datain['video_fps'])
        print "run-time: %s name: %s produced-frames: %s avg_fps: %s fps: %s" % (runtime,
                                                                                 name,
                                                                                 produced_frames,
                                                                                 avg_fps,
                                                                                 fps)
        sleep(1)


```