### PR TITLE
UI: Add ability to rename audio sources from the mixer

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -344,6 +344,11 @@ AddProfile.Text="Please enter the name of the profile"
 # rename profile dialog
 RenameProfile.Title="Rename Profile"
 
+# rename audio source in mixer
+Basic.Main.MixerRename.Title="Rename Audio Source"
+Basic.Main.MixerRename.Text="Please enter the name of the audio source"
+
+
 # preview window disabled
 Basic.Main.PreviewDisabled="Preview is currently disabled"
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -433,6 +433,8 @@ private slots:
 	void UnhideAllAudioControls();
 	void ToggleHideMixer();
 
+	void MixerRenameSource();
+
 	void on_mixerScrollArea_customContextMenuRequested();
 
 	void on_actionCopySource_triggered();


### PR DESCRIPTION
This adds the ability for users to change the names of audio sources from the mixer including desktop and mic/aux sources.