### PR TITLE
Fix build failed to find X11 for the OSX 10.11.6

### DIFF
--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -5,7 +5,7 @@ if(APPLE)
 	include_directories(${COCOA})
 endif()
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	link_libraries(${X11_LIBRARIES})
 	include_directories(${X11_INCLUDE_DIR})


### PR DESCRIPTION
I have tested the PR and it works for my OS X 10.11.6.  Please review it whether it's OK for you.