### PR TITLE
CI: Fix Linux build on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,17 @@ matrix:
       env:
        - CMAKE_PREFIX_PATH=/usr/local/opt/qt5/lib/cmake
        - CEF_BUILD_VERSION=3.3112.1656.g9ec3e42
-      before_install: "./CI/install-dependencies-osx.sh"
-      before_script: "./CI/before-script-osx.sh"
       before_deploy: "./CI/before-deploy-osx.sh"
-
     - os: linux
-      dist: trusty
       sudo: required
-      before_install: "./CI/install-dependencies-linux.sh"
-      before_script: "./CI/before-script-linux.sh"
+    - os: linux
+      sudo: required
+      env: USE_FFMPEG_MASTER=true
+  allow_failures:
+    - env: USE_FFMPEG_MASTER=true
 
+before_install: "./CI/install-dependencies-${TRAVIS_OS_NAME}.sh"
+before_script: "./CI/before-script-${TRAVIS_OS_NAME}.sh"
 script: cd ./build && make -j4 && cd -
 
 deploy:
@@ -65,4 +66,3 @@ notifications:
       - secure: T5RBY818nO40nr5eC8pdrCfAdQKGkjQdbyYw7mfFrhxWxgt/U5tyKXpX0l9zNGfobS0SnLSqF71OrfW04V97oijXx3q5Y24xV6mSrlLQZOq19+XvGp82LDpkVd4yi2N0kBYpoANB9Pkof4jWT/rKfdQCQttluOLjgr5SM0uWHRg=
     on_success: change
     on_failure: always
-

--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -32,9 +32,18 @@ sudo apt-get install -y \
         zlib1g-dev
 
 # FFmpeg
-cd ..
-git clone --depth 1 git://source.ffmpeg.org/ffmpeg.git
-cd ffmpeg
-./configure --enable-shared
-make -j2
-sudo make install
+if [ "$USE_FFMPEG_MASTER" = true ] ; then
+  cd ..
+  git clone --depth 1 git://source.ffmpeg.org/ffmpeg.git
+  cd ffmpeg
+  ./configure --enable-shared
+  make -j2
+  sudo make install
+else
+  sudo add-apt-repository ppa:kirillshkrogalev/ffmpeg-next -y
+  sudo apt-get -qq update
+  sudo apt-get install -y \
+        libavcodec-ffmpeg-dev \
+        libavdevice-ffmpeg-dev \
+        libavfilter-ffmpeg-dev
+fi


### PR DESCRIPTION
Changes the build script to do two separate Linux builds with different FFmpeg versions: one with a very old FFmpeg that is still required by the Ubuntu 14.04 PPA, and one with the latest FFmpeg master branch. The latter build is allowed to fail so that unexpected changes in FFmpeg master don't cause the whole CI job to fail.