### PR TITLE
Fix for issues experienced by obs-websocket plugin

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -2527,7 +2527,8 @@ PublisherAuth(RTMP *r, AVal *description)
             else if(r->Link.pubUser.av_len && r->Link.pubPasswd.av_len)
             {
                 pubToken.av_val = malloc(r->Link.pubUser.av_len + av_authmod_adobe.av_len + 8);
-                pubToken.av_len = sprintf(pubToken.av_val, "?%s&user=%s",
+                pubToken.av_len = sprintf(pubToken.av_val, "%s%s&user=%s",
+										  strstr(r->Link.app.av_val, "?") != NULL ? "&":"?",
                                           av_authmod_adobe.av_val,
                                           r->Link.pubUser.av_val);
                 RTMP_Log(RTMP_LOGDEBUG, "%s, pubToken1: %s", __FUNCTION__, pubToken.av_val);

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -30,32 +30,45 @@ static void rtmp_common_update(void *data, obs_data_t *settings)
 {
 	struct rtmp_common *service = data;
 
-	bfree(service->service);
 	bfree(service->server);
-	bfree(service->output);
 	bfree(service->key);
 
-	service->service = bstrdup(obs_data_get_string(settings, "service"));
 	service->server  = bstrdup(obs_data_get_string(settings, "server"));
 	service->key     = bstrdup(obs_data_get_string(settings, "key"));
-	service->output  = NULL;
+	
+	if (!service->output || strcmp(obs_data_get_string(settings, "service"), service->service) != 0)
+	{
+		bfree(service->service);
+		service->service = bstrdup(obs_data_get_string(settings, "service"));
 
-	json_t *root = open_services_file();
-	if (root) {
-		json_t *serv = find_service(root, service->service);
-		if (serv) {
-			json_t *rec = json_object_get(serv, "recommended");
-			if (rec && json_is_object(rec)) {
-				const char *out = get_string_val(rec, "output");
-				if (out)
-					service->output = bstrdup(out);
+		json_t *root = open_services_file();
+		if (root)
+		{
+			json_t *serv = find_service(root, service->service);
+			if (serv)
+			{
+				json_t *rec = json_object_get(serv, "recommended");
+				if (rec && json_is_object(rec))
+				{
+					const char *out = get_string_val(rec, "output");
+					if (out)
+					{
+						bfree(service->output);
+						service->output = bstrdup(out);
+					}
+				}
 			}
 		}
+		json_decref(root);
+		
+		if (!service->output)
+			service->output = bstrdup("rtmp_output");
+		
 	}
-	json_decref(root);
-
-	if (!service->output)
-		service->output = bstrdup("rtmp_output");
+	
+	obs_data_set_string(settings, "service", service->service);
+	obs_data_set_string(settings, "server", service->server);
+	obs_data_set_string(settings, "key", service->key);
 }
 
 static void rtmp_common_destroy(void *data)

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -18,12 +18,20 @@ static void rtmp_custom_update(void *data, obs_data_t *settings)
 
 	bfree(service->server);
 	bfree(service->key);
+	bfree(service->username);
+	bfree(service->password);
 
 	service->server = bstrdup(obs_data_get_string(settings, "server"));
 	service->key    = bstrdup(obs_data_get_string(settings, "key"));
 	service->use_auth = obs_data_get_bool(settings, "use_auth");
 	service->username = bstrdup(obs_data_get_string(settings, "username"));
 	service->password = bstrdup(obs_data_get_string(settings, "password"));
+	
+	//set duplicated strings back on settings
+	obs_data_set_string(settings, "server", service->server);
+	obs_data_set_string(settings, "key", service->key);
+	obs_data_set_string(settings, "username", service->username);
+	obs_data_set_string(settings, "password", service->password);
 }
 
 static void rtmp_custom_destroy(void *data)


### PR DESCRIPTION
We found an issue with the new version of the obs-websocket plugin when updating the settings of the RTMP service based on a remote request.  The issue was caused by the RTMP service receiving the update but the string used came from the web socket request and was freed at the end of the request. While the RTMP service had it's configuration updated, the obs_data_t *settings maintained a reference to the string created in the request.  Initially this doesn't cause a problem but when the settings are later retrieved and merged with the settings from the request, the update could contain freed memory pointing to something else.

I also included a small fix for FMS authentication to allow RTMP urls that already have a query string parameter.