### PR TITLE
Frontend API updates - preview enabled and StartStreaming obs_service_t optional parameter

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -204,9 +204,10 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		}
 	}
 
-	void obs_frontend_streaming_start(void) override
+	void obs_frontend_streaming_start(obs_service_t* _service) override
 	{
-		QMetaObject::invokeMethod(main, "StartStreaming");
+		//must be executed synchronously
+		QMetaObject::invokeMethod(main, "StartStreaming", Q_ARG(OBSService, OBSService(_service)));
 	}
 
 	void obs_frontend_streaming_stop(void) override

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -373,10 +373,22 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	{
 		return main->IsPreviewProgramMode();
 	}
-
+	
 	void obs_frontend_set_preview_program_mode(bool enable) override
 	{
 		main->SetPreviewProgramMode(enable);
+		
+	}
+	
+	bool obs_frontend_preview_enabled(void) override
+	{
+		return main->previewEnabled;
+	}
+	
+	void obs_frontend_set_preview_enabled(bool enable) override
+	{
+		if (main->previewEnabled != enable)
+			main->TogglePreview();
 	}
 
 	obs_source_t *obs_frontend_get_current_preview_scene(void) override

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -171,9 +171,9 @@ void obs_frontend_set_current_profile(const char *profile)
 		c->obs_frontend_set_current_profile(profile);
 }
 
-void obs_frontend_streaming_start(void)
+void obs_frontend_streaming_start(obs_service_t* _service)
 {
-	if (callbacks_valid()) c->obs_frontend_streaming_start();
+	if (callbacks_valid()) c->obs_frontend_streaming_start(_service);
 }
 
 void obs_frontend_streaming_stop(void)

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -350,6 +350,19 @@ void obs_frontend_set_preview_program_mode(bool enable)
 		c->obs_frontend_set_preview_program_mode(enable);
 }
 
+void obs_frontend_set_preview_enabled(bool enable)
+{
+	if (callbacks_valid())
+		c->obs_frontend_set_preview_enabled(enable);
+}
+
+bool obs_frontend_preview_enabled(void)
+{
+	return !!callbacks_valid()
+	? c->obs_frontend_preview_enabled()
+	: false;
+}
+
 obs_source_t *obs_frontend_get_current_preview_scene(void)
 {
 	return !!callbacks_valid()

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -62,7 +62,7 @@ EXPORT char **obs_frontend_get_profiles(void);
 EXPORT char *obs_frontend_get_current_profile(void);
 EXPORT void obs_frontend_set_current_profile(const char *profile);
 
-EXPORT void obs_frontend_streaming_start(void);
+EXPORT void obs_frontend_streaming_start(obs_service_t* _service = NULL);
 EXPORT void obs_frontend_streaming_stop(void);
 EXPORT bool obs_frontend_streaming_active(void);
 

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -148,6 +148,9 @@ EXPORT void obs_frontend_save_streaming_service(void);
 EXPORT bool obs_frontend_preview_program_mode_active(void);
 EXPORT void obs_frontend_set_preview_program_mode(bool enable);
 
+EXPORT void obs_frontend_set_preview_enabled(bool enable);
+EXPORT bool obs_frontend_preview_enabled(void);
+
 EXPORT obs_source_t *obs_frontend_get_current_preview_scene(void);
 EXPORT void obs_frontend_set_current_preview_scene(obs_source_t *scene);
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -77,6 +77,8 @@ struct obs_frontend_callbacks {
 
 	virtual bool obs_frontend_preview_program_mode_active(void)=0;
 	virtual void obs_frontend_set_preview_program_mode(bool enable)=0;
+	virtual bool obs_frontend_preview_enabled(void)=0;
+	virtual void obs_frontend_set_preview_enabled(bool enable)=0;
 
 	virtual obs_source_t *obs_frontend_get_current_preview_scene(void)=0;
 	virtual void obs_frontend_set_current_preview_scene(obs_source_t *scene)=0;

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -32,7 +32,7 @@ struct obs_frontend_callbacks {
 	virtual char *obs_frontend_get_current_profile(void)=0;
 	virtual void obs_frontend_set_current_profile(const char *profile)=0;
 
-	virtual void obs_frontend_streaming_start(void)=0;
+	virtual void obs_frontend_streaming_start(obs_service_t* service)=0;
 	virtual void obs_frontend_streaming_stop(void)=0;
 	virtual bool obs_frontend_streaming_active(void)=0;
 

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -754,7 +754,7 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 
 	obs_output_set_reconnect_settings(streamOutput, maxRetries,
 			retryDelay);
-
+	
 	if (obs_output_start(streamOutput)) {
 		return true;
 	}

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4169,12 +4169,15 @@ void OBSBasic::OpenSceneFilters()
 #define STREAMING_STOP \
 	"==== Streaming Stop ================================================"
 
-void OBSBasic::StartStreaming()
+void OBSBasic::StartStreaming(OBSService _service)
 {
 	if (outputHandler->StreamingActive())
 		return;
 	if (disableOutputsRef)
 		return;
+	
+	if (_service == nullptr)
+		_service = service;
 
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_STREAMING_STARTING);
@@ -4189,7 +4192,7 @@ void OBSBasic::StartStreaming()
 		sysTrayStream->setText(ui->streamButton->text());
 	}
 
-	if (!outputHandler->StartStreaming(service)) {
+	if (!outputHandler->StartStreaming(_service)) {
 		ui->streamButton->setText(QTStr("Basic.Main.StartStreaming"));
 		ui->streamButton->setEnabled(true);
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -358,7 +358,7 @@ private:
 		obs_data_array_t *savedPreviewProjectors);
 
 public slots:
-	void StartStreaming();
+	void StartStreaming(OBSService _service = OBSService());
 	void StopStreaming();
 	void ForceStopStreaming();
 

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -2527,7 +2527,8 @@ PublisherAuth(RTMP *r, AVal *description)
             else if(r->Link.pubUser.av_len && r->Link.pubPasswd.av_len)
             {
                 pubToken.av_val = malloc(r->Link.pubUser.av_len + av_authmod_adobe.av_len + 8);
-                pubToken.av_len = sprintf(pubToken.av_val, "?%s&user=%s",
+                pubToken.av_len = sprintf(pubToken.av_val, "%s%s&user=%s",
+										  strstr(r->Link.app.av_val, "?") != NULL ? "&":"?",
                                           av_authmod_adobe.av_val,
                                           r->Link.pubUser.av_val);
                 RTMP_Log(RTMP_LOGDEBUG, "%s, pubToken1: %s", __FUNCTION__, pubToken.av_val);

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -65,10 +65,6 @@ static void rtmp_common_update(void *data, obs_data_t *settings)
 			service->output = bstrdup("rtmp_output");
 		
 	}
-	
-	obs_data_set_string(settings, "service", service->service);
-	obs_data_set_string(settings, "server", service->server);
-	obs_data_set_string(settings, "key", service->key);
 }
 
 static void rtmp_common_destroy(void *data)

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -30,32 +30,45 @@ static void rtmp_common_update(void *data, obs_data_t *settings)
 {
 	struct rtmp_common *service = data;
 
-	bfree(service->service);
 	bfree(service->server);
-	bfree(service->output);
 	bfree(service->key);
 
-	service->service = bstrdup(obs_data_get_string(settings, "service"));
 	service->server  = bstrdup(obs_data_get_string(settings, "server"));
 	service->key     = bstrdup(obs_data_get_string(settings, "key"));
-	service->output  = NULL;
+	
+	if (!service->output || strcmp(obs_data_get_string(settings, "service"), service->service) != 0)
+	{
+		bfree(service->service);
+		service->service = bstrdup(obs_data_get_string(settings, "service"));
 
-	json_t *root = open_services_file();
-	if (root) {
-		json_t *serv = find_service(root, service->service);
-		if (serv) {
-			json_t *rec = json_object_get(serv, "recommended");
-			if (rec && json_is_object(rec)) {
-				const char *out = get_string_val(rec, "output");
-				if (out)
-					service->output = bstrdup(out);
+		json_t *root = open_services_file();
+		if (root)
+		{
+			json_t *serv = find_service(root, service->service);
+			if (serv)
+			{
+				json_t *rec = json_object_get(serv, "recommended");
+				if (rec && json_is_object(rec))
+				{
+					const char *out = get_string_val(rec, "output");
+					if (out)
+					{
+						bfree(service->output);
+						service->output = bstrdup(out);
+					}
+				}
 			}
 		}
+		json_decref(root);
+		
+		if (!service->output)
+			service->output = bstrdup("rtmp_output");
+		
 	}
-	json_decref(root);
-
-	if (!service->output)
-		service->output = bstrdup("rtmp_output");
+	
+	obs_data_set_string(settings, "service", service->service);
+	obs_data_set_string(settings, "server", service->server);
+	obs_data_set_string(settings, "key", service->key);
 }
 
 static void rtmp_common_destroy(void *data)

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -27,11 +27,6 @@ static void rtmp_custom_update(void *data, obs_data_t *settings)
 	service->username = bstrdup(obs_data_get_string(settings, "username"));
 	service->password = bstrdup(obs_data_get_string(settings, "password"));
 	
-	//set duplicated strings back on settings
-	obs_data_set_string(settings, "server", service->server);
-	obs_data_set_string(settings, "key", service->key);
-	obs_data_set_string(settings, "username", service->username);
-	obs_data_set_string(settings, "password", service->password);
 }
 
 static void rtmp_custom_destroy(void *data)

--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -18,12 +18,20 @@ static void rtmp_custom_update(void *data, obs_data_t *settings)
 
 	bfree(service->server);
 	bfree(service->key);
+	bfree(service->username);
+	bfree(service->password);
 
 	service->server = bstrdup(obs_data_get_string(settings, "server"));
 	service->key    = bstrdup(obs_data_get_string(settings, "key"));
 	service->use_auth = obs_data_get_bool(settings, "use_auth");
 	service->username = bstrdup(obs_data_get_string(settings, "username"));
 	service->password = bstrdup(obs_data_get_string(settings, "password"));
+	
+	//set duplicated strings back on settings
+	obs_data_set_string(settings, "server", service->server);
+	obs_data_set_string(settings, "key", service->key);
+	obs_data_set_string(settings, "username", service->username);
+	obs_data_set_string(settings, "password", service->password);
 }
 
 static void rtmp_custom_destroy(void *data)


### PR DESCRIPTION
When working on OBS WebSocket, I was attempting to create a temporary obs_service_t for use during a single request to start streaming the frontend API.  I wanted the functionality to have a custom obs_service configuration that when the stream was stopped would be replaced with the original frontend obs_service (the one you would get through obs_frontend_get_streaming_service()).

#1 obs_output updated to hold a hard reference to the obs_service passed to it when it was started so that if the frontend service configuration was changed it would still maintain the original configuration (it could actually crash with the current code in a race condition).
#2 StartStreaming slot of the main window needed to be updated to take an optional OBSService reference (allowing all legacy code to continue to function but giving a new function to the window interface)
#3 obs-frontend-api updated to support new optional parameter
#4 adding methods to frontend api to expose the preview pane status and allow control of it
#5 fix for FMS authentication to allow for a query string parameter in a RTMP url


  