### PR TITLE
libobs-d3d11: Fix gs_enable_color for D3D backend

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -341,7 +341,10 @@ ID3D11BlendState *gs_device::AddBlendState()
 		bd.RenderTarget[i].DestBlendAlpha =
 			ConvertGSBlendType(blendState.destFactorA);
 		bd.RenderTarget[i].RenderTargetWriteMask =
-			D3D11_COLOR_WRITE_ENABLE_ALL;
+			(blendState.redEnabled   ? D3D11_COLOR_WRITE_ENABLE_RED   : 0) |
+			(blendState.greenEnabled ? D3D11_COLOR_WRITE_ENABLE_GREEN : 0) |
+			(blendState.blueEnabled  ? D3D11_COLOR_WRITE_ENABLE_BLUE  : 0) |
+			(blendState.alphaEnabled ? D3D11_COLOR_WRITE_ENABLE_ALPHA : 0) ;
 	}
 
 	SavedBlendState savedState(blendState, bd);


### PR DESCRIPTION
It looks like the link between the gs layer rgba enable flags
and the underlying D3D states never got fully implemented.

This change adds the missing piece, fixing an issue I had in
a plugin wherein I couldn't write a blended value to a RGBA
render target without also changing the alpha of the dest pixel.
Debugging that led to the missing gs_enable_color functionality.