### PR TITLE
rtmp-services: Add us-west1 Picarto ingress

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 74,
+	"version": 75,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 74
+			"version": 75
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -885,11 +885,15 @@
             "name": "Picarto",
             "servers": [
                 {
-                    "name": "US East",
+                    "name": "US East (Chicago, USA)",
                     "url": "rtmp://live.us-east1.picarto.tv/golive"
                 },
                 {
-                    "name": "EU West",
+                    "name": "US West (Los Angeles, USA)",
+                    "url": "rtmp://live.us-west1.picarto.tv/golive"
+                },
+                {
+                    "name": "EU West (Düsseldorf, Germany)",
                     "url": "rtmp://live.eu-west1.picarto.tv/golive"
                 }
             ],


### PR DESCRIPTION
Hey! Here's another ingress we're adding. We also changed the naming scheme to include more information. Let us know if it checks out on your side.

We're also interested if there's a special decision process for when a service gets the common flag - not that we think we're entitled to having it, someone in the office just wanted to know how well we'd need to do :)

If you want to check that this request comes from a Picarto staff member you can send a mail to schittler@picarto.tv

Thank you!