### PR TITLE
plugins: Add CMake option to enable/disable building plugins

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,3 +1,8 @@
+option(BUILD_PLUGINS "Build OBS plugins" ON)
+if(NOT BUILD_PLUGINS)
+	message(STATUS "OBS plugins disabled")
+	return()
+endif()
 
 if(WIN32)
 	option(BUILD_CA_ENCODER "Build CoreAudio encoder module" ON)


### PR DESCRIPTION
This PR adds a CMake flag to allow users to enable/disable building non-frontend OBS plugins.  This allows the build time to be shortened when you only need to build the libobs and the OBS UI components.  This is particularly useful for things like building OBS in CI services for frontend plugins where Windows and Mac build times can get a bit lengthy.

Tested on Windows 10 Pro 64-bit.  Feedback and reviews are welcome.