### PR TITLE
UI: Add Studio Mode layout option for portrait mode displays

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -715,6 +715,8 @@ Basic.Settings.Advanced.Network="Network"
 Basic.Settings.Advanced.Network.BindToIP="Bind to IP"
 Basic.Settings.Advanced.Network.EnableNewSocketLoop="Enable new networking code"
 Basic.Settings.Advanced.Network.EnableLowLatencyMode="Low latency mode"
+Basic.Settings.Advanced.UI="User Interface"
+Basic.Settings.Advanced.UI.EnableStudioPortraitLayout="Enable portrait/vertical layout for Studio Mode"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -4226,6 +4226,25 @@
                  </widget>
                 </item>
                 <item>
+                 <widget class="QGroupBox" name="advUIGroupBox">
+                  <property name="title">
+                   <string>Basic.Settings.Advanced.UI</string>
+                  </property>
+                  <layout class="QFormLayout" name="formLayout_30">
+                   <property name="fieldGrowthPolicy">
+                    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                   </property>
+                   <item row="0" column="1">
+                    <widget class="QCheckBox" name="enableStudioPortraitLayout">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.UI.EnableStudioPortraitLayout</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
                  <widget class="QLabel" name="advancedMsg">
                   <property name="styleSheet">
                    <string notr="true">color: rgb(255, 0, 4);</string>

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1010,6 +1010,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		ui->previewLayout->addWidget(programOptions);
 		ui->previewLayout->addWidget(program);
+		ui->previewLayout->setAlignment(programOptions, Qt::AlignCenter);
 		program->show();
 
 		if (api)
@@ -1053,6 +1054,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 				"-------------------");
 	}
 
+	ResetUI();
 	UpdateTitleBar();
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1091,6 +1091,9 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_bool  (basicConfig, "Output", "LowLatencyEnable",
 			false);
 
+	config_set_default_bool  (basicConfig, "UI",
+			"EnableStudioPortraitLayout", false);
+
 	int i = 0;
 	uint32_t scale_cx = cx;
 	uint32_t scale_cy = cy;
@@ -2889,6 +2892,17 @@ static inline enum video_format GetVideoFormatFromName(const char *name)
 #endif
 	else
 		return VIDEO_FORMAT_RGBA;
+}
+
+void OBSBasic::ResetUI()
+{
+	bool enableStudioPortraitLayout = config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "EnableStudioPortraitLayout");
+
+	if (enableStudioPortraitLayout)
+		ui->previewLayout->setDirection(QBoxLayout::TopToBottom);
+	else
+		ui->previewLayout->setDirection(QBoxLayout::LeftToRight);
 }
 
 int OBSBasic::ResetVideo()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -482,6 +482,7 @@ public:
 	bool StreamingActive() const;
 	bool Active() const;
 
+	void ResetUI();
 	int  ResetVideo();
 	bool ResetAudio();
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -433,6 +433,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->bindToIP,             COMBO_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->enableNewSocketLoop,  CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->enableLowLatencyMode, CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->enableStudioPortraitLayout, CHECK_CHANGED, ADV_CHANGED);
 
 #if !defined(_WIN32) && !defined(__APPLE__) && !HAVE_PULSEAUDIO
 	delete ui->enableAutoUpdates;
@@ -2153,6 +2154,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 			"NewSocketLoopEnable");
 	bool enableLowLatencyMode = config_get_bool(main->Config(), "Output",
 			"LowLatencyEnable");
+	bool enableStudioPortraitLayout = config_get_bool(GetGlobalConfig(),
+			"BasicWindow", "EnableStudioPortraitLayout");
 
 	int idx = ui->processPriority->findData(processPriority);
 	if (idx == -1)
@@ -2161,6 +2164,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	ui->enableNewSocketLoop->setChecked(enableNewSocketLoop);
 	ui->enableLowLatencyMode->setChecked(enableLowLatencyMode);
+	ui->enableStudioPortraitLayout->setChecked(enableStudioPortraitLayout);
 #endif
 
 	loading = false;
@@ -2650,6 +2654,14 @@ void OBSBasicSettings::SaveAdvancedSettings()
 
 	SaveCheckBox(ui->enableNewSocketLoop, "Output", "NewSocketLoopEnable");
 	SaveCheckBox(ui->enableLowLatencyMode, "Output", "LowLatencyEnable");
+
+	if (WidgetChanged(ui->enableStudioPortraitLayout)) {
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"EnableStudioPortraitLayout",
+				ui->enableStudioPortraitLayout->isChecked());
+
+		main->ResetUI();
+	}
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
This commit adds an advanced UI setting to allow users to enable a vertically oriented layout for Studio Mode. This commit addresses [Mantis Issue 827](https://obsproject.com/mantis/view.php?id=827).  I've also seen this requested in the forums over the past year.

I had to modify the alignment of the programOptions widget within the previewLayout layout to prevent the items in that widget from stretching completely across the window when in portrait mode.  Other than that, everything was pretty simple and straightforward - make an option available, change the Qt Direction of the previewLayout layout based on the user's selection.

I've compiled and tested this on Windows 10 Pro 64-bit.

As always, feedback and testing is appreciated.  I wasn't sure if this setting was best placed under Advanced or General, or if it made more sense to start a new settings tab like something called "User Interface".