### PR TITLE
UI: Allow keyboard events on X11 fullscreen projector

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -81,6 +81,7 @@ void OBSProjector::Init(int monitor, bool window, QString title)
 		addAction(action);
 		connect(action, SIGNAL(triggered()), this,
 				SLOT(EscapeTriggered()));
+		activateWindow();
 	}
 
 	savedMonitor = monitor;


### PR DESCRIPTION
X11BypassWindowManagerHint  Bypass the window
           manager completely. This results in a borderless window
           that is not managed at all (i.e., no keyboard input unless
you call QWidget::activateWindow() manually).

This allows the Esc key to close the projector on X11