### PR TITLE
graphics-hook: blacklist OpenGL capture for "cm_client.exe"

### DIFF
--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -877,7 +877,8 @@ bool hook_gl(void)
 	/* "life is feudal: your own" somehow uses both opengl and directx at
 	 * the same time, so blacklist it from capturing opengl */
 	const char *process_name = get_process_name();
-	if (_strcmpi(process_name, "yo_cm_client.exe") == 0) {
+	if ((_strcmpi(process_name, "yo_cm_client.exe") == 0)
+		|| (_strcmpi(process_name, "cm_client.exe") == 0)) {
 		hlog("Ignoring opengl for game: %s", process_name);
 		return true;
 	}


### PR DESCRIPTION
Hi, that's me again with simultaneous GL/D3D usage problems.

It seems that the last time we discussed this we forgot to blacklist GL capture for our second executable, so here's a pull request for this.

Thanks in advance.

