### PR TITLE
UI: Fix windowed projector title in Studio Mode

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5503,14 +5503,18 @@ void OBSBasic::OpenSceneProjector()
 void OBSBasic::OpenStudioProgramWindow()
 {
 	int monitor = sender()->property("monitor").toInt();
-	QString title = QTStr("StudioProgramWindow");
+	//by user's side it's just Preview Window
+	QString title = QTStr("PreviewWindow");
 	OpenProjector(nullptr, monitor, true, title, true);
 }
 
 void OBSBasic::OpenPreviewWindow()
 {
 	int monitor = sender()->property("monitor").toInt();
-	QString title = QTStr("PreviewWindow");
+	//in program mode swap the titles
+	QString title = QTStr(IsPreviewProgramMode()
+			      ? "StudioProgramWindow"
+			      : "PreviewWindow");
 	OpenProjector(nullptr, monitor, true, title);
 }
 


### PR DESCRIPTION
Swaps the windowed projector title according to:
https://github.com/jp9000/obs-studio/pull/1071#issuecomment-347111531

It keeps the consistency of window title and pop-up menu calls for 
Studio Mode.