### PR TITLE
CI: OSX - Use Xcode7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 matrix:
   include:
     - os: osx
+      osx_image: xcode7.3
       env:
        - CMAKE_PREFIX_PATH=/usr/local/opt/qt5/lib/cmake
        - CEF_BUILD_VERSION=3.3112.1656.g9ec3e42


### PR DESCRIPTION
Travis changed the default OS X build environment from Xcode7.3 to
Xcode8.3 and it seems to have broken the packaging step somehow.
Fixes the issue by reverting to Xcode7.3.