### PR TITLE
CI: Fix Mac builds on Travis CI's Xcode 8.3 image

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -48,7 +48,7 @@ security set-keychain-settings -t 3600 -u build.keychain
 hr "Importing certs into keychain"
 security import ./Certificates.p12 -k build.keychain -T /usr/bin/productsign -P ""
 hr "Signing Package"
-productsign --sign 'Developer ID Installer: Hugh Bailey (2MMRE5MTB8)' ./OBS.pkg ./$FILENAME
+productsign --sign 2MMRE5MTB8 ./OBS.pkg ./$FILENAME
 
 # Move to the folder that travis uses to upload artifacts from
 hr "Moving package to nightly folder for distribution"

--- a/CI/install/osx/build_app.py
+++ b/CI/install/osx/build_app.py
@@ -86,7 +86,7 @@ for i in candidate_paths:
 			try:
 				out = check_output("{0}otool -L '{1}'".format(args.prefix, path), shell=True,
 						universal_newlines=True)
-				if "is not an object file" in out:
+				if "The file was not recognized as a valid object file" in out:
 					continue
 			except:
 				continue


### PR DESCRIPTION
The Travis CI Xcode 8.3 image uses macOS 10.12, where some changes were made to the `productsign` utility, and Apple's documentation didn't clearly reflect this. This commit should fix Mac builds on Travis for Xcode 8.3 and clean up the job log.

This PR will require reverting ca835ddfd2c021bc72985d06b62a58c5437ff57b / 64911222e9604c1604b7ef0fc374dfbd8fabd1e4 before applying this..  The only way to tell if this patch fixes the Mac CI deploy step would be to apply the new syntax and either simulate the CI build locally or to actually make the Travis CI build run through the deploy steps (which only seem to happen on a commit to the master branch).

The changes to CI/before-deploy-osx.sh should hopefully fix the package signing step.  The changes to CI/install/osx/build_app.py are to handle a changed error message between Xcode 7.3 and Xcode 8.3.

Here are some threads that reference the change in `productsign` syntax:

- https://forums.developer.apple.com/thread/75429
- https://forums.developer.apple.com/thread/76288

-----

Somewhat related, it does seem that [there are some compatibility issues with Packages and macOS Sierra (10.12)](http://s.sudre.free.fr/Software/Packages/Q&A_6.html), which the Travis Xcode 8.3 image uses.  At some point, updating the Packages.pkg that the build script uses might be a good idea, and might enable the build script to use Packages for signing instead of productsign, if desired.