### PR TITLE
CI: Fix macOS builds on Travis CI's Xcode 8.3 image

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -45,6 +45,8 @@ security create-keychain -p mysecretpassword build.keychain
 security default-keychain -s build.keychain
 security unlock-keychain -p mysecretpassword build.keychain
 security set-keychain-settings -t 3600 -u build.keychain
+security set-key-partition-list -S apple-tool:,apple: -s -k mysecretpassword build.keychain
+security list-keychains -s build.keychain
 hr "Importing certs into keychain"
 security import ./Certificates.p12 -k build.keychain -T /usr/bin/productsign -P ""
 hr "Signing Package"

--- a/CI/install/osx/build_app.py
+++ b/CI/install/osx/build_app.py
@@ -84,7 +84,8 @@ for i in candidate_paths:
 		for file_ in files:
 			path = root + "/" + file_
 			try:
-				out = check_output("{0}otool -L '{1}'".format(args.prefix, path), shell=True,
+				out = check_output("{0}otool -L '{1}'".format(args.prefix, path),
+						stderr=subprocess.STDOUT, shell=True,
 						universal_newlines=True)
 				if "The file was not recognized as a valid object file" in out:
 					continue


### PR DESCRIPTION
The Travis CI Xcode 8.3 image uses macOS 10.12, where some OS and Xcode components were changed. This commit should hopefully fix macOS deployments on Travis for Xcode 8.3.

Take two!  I'd found a few references to `security set-key-partition-list` being required for keychain/codesigning operations in macOS 10.12+.  Hopefully this fixes the issues.  If it doesn't, I have _maybe_ one or two other leads, but I really hope this gets it, or at least gets us some output from `productsign`.  If there are security concerns from listing the keychain, feel free to remove this line from `before-deploy-osx.sh`:

`security list-keychains -s build.keychain`


My revised opinion on the log spam from the "Packaging .app" step in `build_app.py` is that the call to `otool` is producing error output on stderr, and I think it was previously outputting the errors to stdout.  I've revised the call to `check_output` to catch stderr.