### PR TITLE
rtmp-services: Add Mobcrush to services list

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -467,6 +467,21 @@
             }
         },
         {
+            "name": "Mobcrush",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://live.mobcrush.net/mob"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "main",
+                "max video bitrate": 6000,
+                "max audio bitrate": 160
+            }
+        },
+        {
             "name": "DailyMotion",
             "common": true,
             "servers": [


### PR DESCRIPTION
This commit adds Mobcrush RTMP ingest to services.json.