### PR TITLE
rtmp-services: Remove Coderwall / Fix Livestream service name

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -778,18 +778,6 @@
             }
         },
         {
-            "name": "Coderwall",
-            "servers": [
-                {
-                    "name": "Primary",
-                    "url": "rtmp://live.coderwall.com/coderwall"
-                }
-            ],
-            "recommended": {
-                "max video bitrate": 1500
-            }
-        },
-        {
             "name": "Meridix Live Sports Platform",
             "servers": [
                 {
@@ -928,7 +916,7 @@
             ]
         },
         {
-            "name": "LiveStream",
+            "name": "Livestream",
             "servers": [
                 {
                     "name": "Primary",


### PR DESCRIPTION
* Coderwall.com seem to have shut down the livestreaming part, the domain also no longer resolves
* Livestream.com calls the service "Livestream" without the capital "S"