### PR TITLE
CI: Fix Mac builds on Travis CI's Xcode 8.3 image

### DIFF
--- a/CI/before-deploy-osx.sh
+++ b/CI/before-deploy-osx.sh
@@ -45,10 +45,10 @@ security create-keychain -p mysecretpassword build.keychain
 security default-keychain -s build.keychain
 security unlock-keychain -p mysecretpassword build.keychain
 security set-keychain-settings -t 3600 -u build.keychain
-security set-key-partition-list -S apple-tool:,apple: -s -k mysecretpassword build.keychain
-security list-keychains -s build.keychain
 hr "Importing certs into keychain"
 security import ./Certificates.p12 -k build.keychain -T /usr/bin/productsign -P ""
+# macOS 10.12+
+security set-key-partition-list -S apple-tool:,apple: -s -k mysecretpassword build.keychain
 hr "Signing Package"
 productsign --sign 2MMRE5MTB8 ./OBS.pkg ./$FILENAME
 

--- a/CI/install/osx/build_app.py
+++ b/CI/install/osx/build_app.py
@@ -84,10 +84,9 @@ for i in candidate_paths:
 		for file_ in files:
 			path = root + "/" + file_
 			try:
-				out = check_output("{0}otool -L '{1}'".format(args.prefix, path),
-						stderr=subprocess.STDOUT, shell=True,
+				out = check_output("{0}otool -L '{1}'".format(args.prefix, path), shell=True,
 						universal_newlines=True)
-				if "The file was not recognized as a valid object file" in out:
+				if "is not an object file" in out:
 					continue
 			except:
 				continue


### PR DESCRIPTION
The Travis CI Xcode 8.3 image uses macOS 10.12, where some OS and Xcode components were changed. This commit finally fixes macOS deployments on Travis for Xcode 8.3. This commit also reverts a few changes that got into master while we were trying to fix this.

I may spend some more time later debugging the log spam from Xcode/otool/objdump in `build_app.py` during the deployment step, but this should at least get macOS CI builds back up and running.  For whatever reason, the log spam only occurs on the Xcode 8.3 image.  It does not occur in the Xcode 7.3 image or the Xcode 9.1 image.

In the future, we'll have to remember to create a testing branch if we need to debug/test the CI deployment steps.  Many thanks to everyone* who helped out with this fix!

\* @jp9000, @DDRBoxman, @juvester, @pkviet