### PR TITLE
Revert "CI: Linux - Install FFmpeg from source"

### DIFF
--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
 set -ex
 
+sudo add-apt-repository ppa:kirillshkrogalev/ffmpeg-next -y
 sudo apt-get -qq update
 sudo apt-get install -y \
         build-essential \
         checkinstall \
         cmake \
         libasound2-dev \
+        libavcodec-ffmpeg-dev \
+        libavdevice-ffmpeg-dev \
+        libavfilter-ffmpeg-dev \
+        libavformat-ffmpeg-dev \
+        libavutil-ffmpeg-dev \
         libcurl4-openssl-dev \
         libfdk-aac-dev \
         libfontconfig-dev \
@@ -17,6 +23,8 @@ sudo apt-get install -y \
         libpulse-dev \
         libqt5x11extras5-dev \
         libspeexdsp-dev \
+        libswresample-ffmpeg-dev \
+        libswscale-ffmpeg-dev \
         libudev-dev \
         libv4l-dev \
         libvlc-dev \
@@ -27,14 +35,4 @@ sudo apt-get install -y \
         libxcomposite-dev \
         libxinerama-dev \
         pkg-config \
-        qtbase5-dev \
-        yasm \
-        zlib1g-dev
-
-# FFmpeg
-cd ..
-git clone --depth 1 git://source.ffmpeg.org/ffmpeg.git
-cd ffmpeg
-./configure --enable-shared
-make -j2
-sudo make install
+        qtbase5-dev


### PR DESCRIPTION
This reverts commit de32d89fc6ac1cc85346732f722fe74ac1cb1eca.

Fixes an issue where Linux CI builds fail because FFmpeg fails to
compile. Using FFmpeg git master in CI builds was obviously not the
smartest idea because changes in FFmpeg can break things unexpectedly.
Sorry about that.

The reason for the original commit was that OBS failed to compile
with FFmpeg 2.4. That has been fixed since.