### PR TITLE
cmake: Correct CMake checks for LINUX

### DIFF
--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -5,7 +5,7 @@ if(APPLE)
 	include_directories(${COCOA})
 endif()
 
-if(LINUX)
+if(UNIX AND NOT APPLE)
 	find_package(X11 REQUIRED)
 	link_libraries(${X11_LIBRARIES})
 	include_directories(${X11_INCLUDE_DIR})

--- a/deps/glad/CMakeLists.txt
+++ b/deps/glad/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 set(glad_include_dirs
 	PRIVATE ${OPENGL_INCLUDE_DIR})
 
-if (LINUX)
+if (UNIX AND NOT APPLE)
 list (APPEND glad_include_dirs
 	PRIVATE ${X11_X11_INCLUDE_PATH})
 endif()


### PR DESCRIPTION
Some CMake checks were recently switched from UNIX to LINUX to get them to not apply to macOS/OSX. Since LINUX doesn't seem to be defined, switch these checks to UNIX AND NOT APPLE.

@juvester and I looked into this a bit, and we cannot find evidence of LINUX actually being supported.  Nonetheless, it still seems to build and run on Ubuntu without failing, but neither of us know why.  All the same, @juvester, @DDRBoxman, and I concur that these checks should probably be using `UNIX AND NOT APPLE`.