### PR TITLE
libobs: Fix scene filters duplication

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6146,6 +6146,7 @@ void OBSBasic::on_actionPasteFilters_triggered()
 		return;
 
 	obs_source_copy_filters(dstSource, source);
+	obs_source_release(source);
 }
 
 void OBSBasic::on_autoConfigure_triggered()

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1095,6 +1095,9 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 	new_scene = make_private ?
 		obs_scene_create_private(name) : obs_scene_create(name);
 
+	//copy scene filters
+	obs_source_copy_filters(new_scene->source, scene->source);
+
 	obs_data_apply(new_scene->source->private_settings,
 			scene->source->private_settings);
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -447,7 +447,6 @@ obs_source_t *obs_source_duplicate(obs_source_t *source,
 				create_private ? OBS_SCENE_DUP_PRIVATE_COPY :
 					OBS_SCENE_DUP_COPY);
 		obs_source_t *new_source = obs_scene_get_source(new_scene);
-		duplicate_filters(new_source, source, create_private);
 		return new_source;
 	}
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -425,8 +425,6 @@ void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src)
 	duplicate_filters(dst, src, dst->context.private ?
 					OBS_SCENE_DUP_PRIVATE_COPY :
 					OBS_SCENE_DUP_COPY);
-
-	obs_source_release(src);
 }
 
 obs_source_t *obs_source_duplicate(obs_source_t *source,


### PR DESCRIPTION
Fixes issue when duplicated scene doesn't inherit filters.