### PR TITLE
libobs: Fix pulseaudio monitor playback stuttering

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.c
@@ -328,3 +328,14 @@ void pulseaudio_write_callback(pa_stream *p, pa_stream_request_cb_t cb,
 	pa_stream_set_write_callback(p, cb, userdata);
 	pulseaudio_unlock();
 }
+
+void pulseaudio_set_underflow_callback(pa_stream *p, pa_stream_notify_cb_t cb,
+		void *userdata)
+{
+	if (pulseaudio_context_ready() < 0)
+		return;
+
+	pulseaudio_lock();
+	pa_stream_set_underflow_callback(p, cb, userdata);
+	pulseaudio_unlock();
+}

--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
@@ -173,3 +173,13 @@ int_fast32_t pulseaudio_connect_playback(pa_stream *s, const char *name,
  */
 void pulseaudio_write_callback(pa_stream *p, pa_stream_request_cb_t cb,
 		void *userdata);
+
+/**
+ * Sets a callback function for when an underflow happen
+ *
+ * @param p pa_stream to connect to. NULL for default
+ * @param cb pa_stream_notify_cb_t
+ * @param userdata pointer to userdata the callback will be called with
+ */
+void pulseaudio_set_underflow_callback(pa_stream *p, pa_stream_notify_cb_t cb,
+		void *userdata);


### PR DESCRIPTION
Listen for underflows on playback stream and adjust the tlength accordindly

This fixes Mantis Issue [0001076](https://obsproject.com/mantis/view.php?id=1076)