### PR TITLE
ui: Fix unsaved changes dialog showing twice

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -288,6 +288,7 @@ bool OBSBasicProperties::ConfirmQuit()
 
 	switch (button) {
 	case QMessageBox::Save:
+		acceptClicked = true;
 		if (view->DeferUpdate())
 			view->UpdateSettings();
 		// Do nothing because the settings are already updated


### PR DESCRIPTION
When clicking the close button with unsaved changes in a source properties
dialog closeEvent and reject are called, which both call ConfirmQuit.
This fixes it by setting the acceptClicked flag correctly in ConfirmQuit

https://obsproject.com/mantis/view.php?id=1051