### PR TITLE
rtmp-services: Add Twitch Salt Lake City ingest

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 75,
+	"version": 76,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 75
+			"version": 76
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -130,6 +130,10 @@
                     "url": "rtmp://live-hou.twitch.tv/app"
                 },
                 {
+                    "name": "US Central: Salt Lake City, UT",
+                    "url": "rtmp://live-slc.twitch.tv/app"
+                },
+                {
                     "name": "US East: Ashburn, VA",
                     "url": "rtmp://live-iad.twitch.tv/app"
                 },


### PR DESCRIPTION
Not sure if Salt Lake City should count as US Central, unfortunately Twitch remains inconsisten with their ingest naming and did not include the region with this one.