### PR TITLE
UI: Fix crash on freeing OBS context data

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3980,7 +3980,8 @@ void OBSBasic::on_scenes_itemDoubleClicked(QListWidgetItem *witem)
 			OBSScene scene = GetCurrentScene();
 
 			if (scene)
-				SetCurrentScene(scene, false, true);
+				//because we are in PreviewProgramMode
+				TransitionToScene(scene);
 		}
 	}
 }


### PR DESCRIPTION
Fixes the crash on application exit when

Studio Mode is ON
Duplicate Scene is ON
Duplicate Sources is ON
destination scene has at least 1 source

and double click transition performed.