### PR TITLE
obs-ffmpeg: Fix ffmpeg output recording in x264

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -704,8 +704,8 @@ static void receive_video(void *param, struct video_data *frame)
 				data->vframe->linesize);
 	else
 		copy_data(data->vframe, frame, context->height, context->pix_fmt);
-
-	if (data->output->flags) {
+#if LIBAVFORMAT_VERSION_MAJOR < 58
+	if (data->output->flags & AVFMT_RAWPICTURE) {
 		packet.flags        |= AV_PKT_FLAG_KEY;
 		packet.stream_index  = data->video->index;
 		packet.data          = data->vframe->data[0];
@@ -717,6 +717,7 @@ static void receive_video(void *param, struct video_data *frame)
 		os_sem_post(output->write_sem);
 
 	} else {
+#endif
 		data->vframe->pts = data->total_frames;
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 40, 101)
 		ret = avcodec_send_frame(context, data->vframe);
@@ -753,8 +754,9 @@ static void receive_video(void *param, struct video_data *frame)
 		} else {
 			ret = 0;
 		}
+#if LIBAVFORMAT_VERSION_MAJOR < 58
 	}
-
+#endif
 	if (ret != 0) {
 		blog(LOG_WARNING, "receive_video: Error writing video: %s",
 				av_err2str(ret));


### PR DESCRIPTION
Fixes ticket 1070.
See also
https://obsproject.com/forum/threads/ffmpeg-recording.77378/#post-330473
(related bugs).
The ffmpeg constant AVFMT_RAWPICTURE was deprecated in october 2015
and marked for removal at avformat major bump to version 58
(ffmpeg commit 34ed5c2 , oct 12, 2015).
The bump occured with commit 69b5ce6 (oct21, 2017).
The constant was subsequently removed (commit 693a11b, oct 26 2017).
It was removed from obs-studio with commit d670d7b (from me).
But the code block which was executed with this constant was not
removed, causing issues with ffmpeg output.
The commit fixes the issue for old ffmpeg builds as well as new ones.
The constant is reintegrated for avformat major version < 58 and removed
for version >= 58 (along with its accompanying code).
Thanks to J Lowe for help in solving the bug.
(tested on win 10, macos 10.13, ubuntu 17.10 with ffmpeg head & ffmpeg
3.4.1)