### PR TITLE
libobs: Fix incomplete struct in scaler call

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -302,6 +302,8 @@ static inline bool video_input_init(struct video_input *input,
 			.format = video->info.format,
 			.width  = video->info.width,
 			.height = video->info.height,
+			.range = video->info.range,
+			.colorspace = video->info.colorspace
 		};
 
 		int ret = video_scaler_create(&input->scaler,


### PR DESCRIPTION
Fixes the Rescale Output range and colorspace conversion issue.

When range and colorspace properties were missing and thus undefined:
get_ffmpeg_coeffs returns SWS_CS_ITU601
get_ffmpeg_range_type returns 0 (which is VIDEO_RANGE_PARTIAL).

Should solve mantis: https://obsproject.com/mantis/view.php?id=947
More info: https://obsproject.com/forum/threads/x264-rescale-output-over-saturating-colors.69730/