### PR TITLE
UI: Rework volume-meters, adding more information

### DIFF
--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -464,10 +464,16 @@ QSlider::handle:disabled {
 /* Volume Control */
 
 VolumeMeter {
-    qproperty-bkColor: rgb(31,30,31); /* veryDark */
-    qproperty-magColor:;
-    qproperty-peakColor:;
-    qproperty-peakHoldColor: rgb(225,224,225); /* veryLight */
+    qproperty-backgroundNominalColor: rgb(38, 127, 38);
+    qproperty-backgroundWarningColor: rgb(127, 127, 38);
+    qproperty-backgroundErrorColor: rgb(127, 38, 38);
+    qproperty-foregroundNominalColor: rgb(76, 255, 76);
+    qproperty-foregroundWarningColor: rgb(255, 255, 76);
+    qproperty-foregroundErrorColor: rgb(255, 76, 76);
+    qproperty-magnitudeColor: rgb(0, 0, 0);
+    qproperty-majorTickColor: rgb(225,224,225); /* veryLight */
+    qproperty-minorTickColor: rgb(122,121,122); /* light */
+    qproperty-peakDecayRate: 23.4; /* Override of the standard PPM Type I rate. */
 }
 
 

--- a/UI/data/themes/Default.qss
+++ b/UI/data/themes/Default.qss
@@ -55,10 +55,16 @@ OBSHotkeyLabel[hotkeyPairHover=true] {
 /* Volume Control */
 
 VolumeMeter {
-    qproperty-bkColor: rgb(221, 221, 221);
-    qproperty-magColor: rgb(32, 125, 23);
-    qproperty-peakColor: rgb(62, 241, 43);
-    qproperty-peakHoldColor: rgb(0, 0, 0);
+    qproperty-backgroundNominalColor: rgb(15, 100, 15);
+    qproperty-backgroundWarningColor: rgb(100, 100, 15);
+    qproperty-backgroundErrorColor: rgb(100, 15, 15);
+    qproperty-foregroundNominalColor: rgb(50, 200, 50);
+    qproperty-foregroundWarningColor: rgb(255, 200, 50);
+    qproperty-foregroundErrorColor: rgb(200, 50, 50);
+    qproperty-magnitudeColor: rgb(0, 0, 0);
+    qproperty-majorTickColor: rgb(0, 0, 0);
+    qproperty-minorTickColor: rgb(50, 50, 50);
+    qproperty-peakDecayRate: 23.4; /* Override of the standard PPM Type I rate. */
 }
 
 

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -670,12 +670,16 @@ QProgressBar::chunk {
 /**************************/
 
 VolumeMeter {
-	qproperty-bkColor: rgb(35, 38, 41); /* Dark Gray */
-	qproperty-magColor: rgb(153, 204, 0);
-	qproperty-peakColor: rgb(96, 128, 0);
-	qproperty-peakHoldColor: rgb(210, 255, 77);
-	qproperty-clipColor1: rgb(230, 40, 50);
-	qproperty-clipColor2: rgb(140, 0, 40);
+	qproperty-backgroundNominalColor: rgb(0, 128, 79);
+	qproperty-backgroundWarningColor: rgb(128, 57, 0);
+	qproperty-backgroundErrorColor: rgb(128, 9, 0);
+	qproperty-foregroundNominalColor: rgb(119, 255, 143);
+	qproperty-foregroundWarningColor: rgb(255, 157, 76);
+	qproperty-foregroundErrorColor: rgb(255, 89, 76);
+	qproperty-magnitudeColor: rgb(49, 54, 59); /* Blue-gray */
+	qproperty-majorTickColor: rgb(239, 240, 241); /* White */
+	qproperty-minorTickColor: rgb(118, 121, 124); /* Light Gray */
+	qproperty-peakDecayRate: 23.4; /* Override of the standard PPM Type I rate. */
 }
 
 /*******************/

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -13,45 +13,178 @@ class VolumeMeterTimer;
 class VolumeMeter : public QWidget
 {
 	Q_OBJECT
-	Q_PROPERTY(QColor bkColor READ getBkColor WRITE setBkColor DESIGNABLE true)
-	Q_PROPERTY(QColor magColor READ getMagColor WRITE setMagColor DESIGNABLE true)
-	Q_PROPERTY(QColor peakColor READ getPeakColor WRITE setPeakColor DESIGNABLE true)
-	Q_PROPERTY(QColor peakHoldColor READ getPeakHoldColor WRITE setPeakHoldColor DESIGNABLE true)
-	Q_PROPERTY(QColor clipColor1 READ getClipColor1 WRITE setClipColor1 DESIGNABLE true)
-	Q_PROPERTY(QColor clipColor2 READ getClipColor2 WRITE setClipColor2 DESIGNABLE true)
+	Q_PROPERTY(QColor backgroundNominalColor
+		READ getBackgroundNominalColor
+		WRITE setBackgroundNominalColor DESIGNABLE true)
+	Q_PROPERTY(QColor backgroundWarningColor
+		READ getBackgroundWarningColor
+		WRITE setBackgroundWarningColor DESIGNABLE true)
+	Q_PROPERTY(QColor backgroundErrorColor
+		READ getBackgroundErrorColor
+		WRITE setBackgroundErrorColor DESIGNABLE true)
+	Q_PROPERTY(QColor foregroundNominalColor
+		READ getForegroundNominalColor
+		WRITE setForegroundNominalColor DESIGNABLE true)
+	Q_PROPERTY(QColor foregroundWarningColor
+		READ getForegroundWarningColor
+		WRITE setForegroundWarningColor DESIGNABLE true)
+	Q_PROPERTY(QColor foregroundErrorColor
+		READ getForegroundErrorColor
+		WRITE setForegroundErrorColor DESIGNABLE true)
+	Q_PROPERTY(QColor clipColor
+		READ getClipColor
+		WRITE setClipColor DESIGNABLE true)
+	Q_PROPERTY(QColor magnitudeColor
+		READ getMagnitudeColor
+		WRITE setMagnitudeColor DESIGNABLE true)
+	Q_PROPERTY(QColor majorTickColor
+		READ getMajorTickColor
+		WRITE setMajorTickColor DESIGNABLE true)
+	Q_PROPERTY(QColor minorTickColor
+		READ getMinorTickColor
+		WRITE setMinorTickColor DESIGNABLE true)
+
+	// Levels are denoted in dBFS.
+	Q_PROPERTY(qreal minimumLevel
+		READ getMinimumLevel
+		WRITE setMinimumLevel DESIGNABLE true)
+	Q_PROPERTY(qreal warningLevel
+		READ getWarningLevel
+		WRITE setWarningLevel DESIGNABLE true)
+	Q_PROPERTY(qreal errorLevel
+		READ getErrorLevel
+		WRITE setErrorLevel DESIGNABLE true)
+	Q_PROPERTY(qreal clipLevel
+		READ getClipLevel
+		WRITE setClipLevel DESIGNABLE true)
+	Q_PROPERTY(qreal minimumInputLevel
+		READ getMinimumInputLevel
+		WRITE setMinimumInputLevel DESIGNABLE true)
+
+	// Rates are denoted in dB/second.
+	Q_PROPERTY(qreal peakDecayRate
+		READ getPeakDecayRate
+		WRITE setPeakDecayRate DESIGNABLE true)
+
+	// Time in seconds for the VU meter to integrate over.
+	Q_PROPERTY(qreal magnitudeIntegrationTime
+		READ getMagnitudeIntegrationTime
+		WRITE setMagnitudeIntegrationTime DESIGNABLE true)
+
+	// Duration is denoted in seconds.
+	Q_PROPERTY(qreal peakHoldDuration
+		READ getPeakHoldDuration
+		WRITE setPeakHoldDuration DESIGNABLE true)
+	Q_PROPERTY(qreal inputPeakHoldDuration
+		READ getInputPeakHoldDuration
+		WRITE setInputPeakHoldDuration DESIGNABLE true)
 
 private:
+	obs_volmeter_t *obs_volmeter;
 	static QWeakPointer<VolumeMeterTimer> updateTimer;
 	QSharedPointer<VolumeMeterTimer> updateTimerRef;
-	float curMag = 0.0f, curPeak = 0.0f, curPeakHold = 0.0f;
 
-	inline void calcLevels();
+	inline void resetLevels();
+	inline void handleChannelCofigurationChange();
+	inline bool detectIdle(uint64_t ts);
+	inline void calculateBallistics(uint64_t ts,
+		qreal timeSinceLastRedraw=0.0);
+	inline void calculateBallisticsForChannel(int channelNr,
+		uint64_t ts, qreal timeSinceLastRedraw);
+
+	void paintInputMeter(QPainter &painter, int x, int y,
+		int width, int height, float peakHold);
+	void paintMeter(QPainter &painter, int x, int y,
+		int width, int height,
+		float magnitude, float peak, float peakHold);
+	void paintTicks(QPainter &painter, int x, int y, int width, int height);
 
 	QMutex dataMutex;
-	float mag = 0.0f, peak = 0.0f, peakHold = 0.0f;
-	float multiple = 0.0f;
-	uint64_t lastUpdateTime = 0;
 
-	QColor bkColor, magColor, peakColor, peakHoldColor;
-	QColor clipColor1, clipColor2;
+	uint64_t currentLastUpdateTime = 0;
+	float currentMagnitude[MAX_AUDIO_CHANNELS];
+	float currentPeak[MAX_AUDIO_CHANNELS];
+	float currentInputPeak[MAX_AUDIO_CHANNELS];
+
+	QPixmap *tickPaintCache = NULL;
+	int displayNrAudioChannels = 0;
+	float displayMagnitude[MAX_AUDIO_CHANNELS];
+	float displayPeak[MAX_AUDIO_CHANNELS];
+	float displayPeakHold[MAX_AUDIO_CHANNELS];
+	uint64_t displayPeakHoldLastUpdateTime[MAX_AUDIO_CHANNELS];
+	float displayInputPeakHold[MAX_AUDIO_CHANNELS];
+	uint64_t displayInputPeakHoldLastUpdateTime[MAX_AUDIO_CHANNELS];
+
+	QColor backgroundNominalColor;
+	QColor backgroundWarningColor;
+	QColor backgroundErrorColor;
+	QColor foregroundNominalColor;
+	QColor foregroundWarningColor;
+	QColor foregroundErrorColor;
+	QColor clipColor;
+	QColor magnitudeColor;
+	QColor majorTickColor;
+	QColor minorTickColor;
+	qreal minimumLevel;
+	qreal warningLevel;
+	qreal errorLevel;
+	qreal clipLevel;
+	qreal minimumInputLevel;
+	qreal peakDecayRate;
+	qreal magnitudeIntegrationTime;
+	qreal peakHoldDuration;
+	qreal inputPeakHoldDuration;
+
+	uint64_t lastRedrawTime = 0;
 
 public:
-	explicit VolumeMeter(QWidget *parent = 0);
+	explicit VolumeMeter(QWidget *parent = 0,
+		obs_volmeter_t *obs_volmeter = 0);
 	~VolumeMeter();
 
-	void setLevels(float nmag, float npeak, float npeakHold);
-	QColor getBkColor() const;
-	void setBkColor(QColor c);
-	QColor getMagColor() const;
-	void setMagColor(QColor c);
-	QColor getPeakColor() const;
-	void setPeakColor(QColor c);
-	QColor getPeakHoldColor() const;
-	void setPeakHoldColor(QColor c);
-	QColor getClipColor1() const;
-	void setClipColor1(QColor c);
-	QColor getClipColor2() const;
-	void setClipColor2(QColor c);
+	void setLevels(
+		const float magnitude[MAX_AUDIO_CHANNELS],
+		const float peak[MAX_AUDIO_CHANNELS],
+		const float inputPeak[MAX_AUDIO_CHANNELS]);
+
+	QColor getBackgroundNominalColor() const;
+	void setBackgroundNominalColor(QColor c);
+	QColor getBackgroundWarningColor() const;
+	void setBackgroundWarningColor(QColor c);
+	QColor getBackgroundErrorColor() const;
+	void setBackgroundErrorColor(QColor c);
+	QColor getForegroundNominalColor() const;
+	void setForegroundNominalColor(QColor c);
+	QColor getForegroundWarningColor() const;
+	void setForegroundWarningColor(QColor c);
+	QColor getForegroundErrorColor() const;
+	void setForegroundErrorColor(QColor c);
+	QColor getClipColor() const;
+	void setClipColor(QColor c);
+	QColor getMagnitudeColor() const;
+	void setMagnitudeColor(QColor c);
+	QColor getMajorTickColor() const;
+	void setMajorTickColor(QColor c);
+	QColor getMinorTickColor() const;
+	void setMinorTickColor(QColor c);
+	qreal getMinimumLevel() const;
+	void setMinimumLevel(qreal v);
+	qreal getWarningLevel() const;
+	void setWarningLevel(qreal v);
+	qreal getErrorLevel() const;
+	void setErrorLevel(qreal v);
+	qreal getClipLevel() const;
+	void setClipLevel(qreal v);
+	qreal getMinimumInputLevel() const;
+	void setMinimumInputLevel(qreal v);
+	qreal getPeakDecayRate() const;
+	void setPeakDecayRate(qreal v);
+	qreal getMagnitudeIntegrationTime() const;
+	void setMagnitudeIntegrationTime(qreal v);
+	qreal getPeakHoldDuration() const;
+	void setPeakHoldDuration(qreal v);
+	qreal getInputPeakHoldDuration() const;
+	void setInputPeakHoldDuration(qreal v);
 
 protected:
 	void paintEvent(QPaintEvent *event);
@@ -92,8 +225,10 @@ private:
 	obs_volmeter_t  *obs_volmeter;
 
 	static void OBSVolumeChanged(void *param, float db);
-	static void OBSVolumeLevel(void *data, float level, float mag,
-			float peak, float muted);
+	static void OBSVolumeLevel(void *data,
+		const float magnitude[MAX_AUDIO_CHANNELS],
+		const float peak[MAX_AUDIO_CHANNELS],
+		const float inputPeak[MAX_AUDIO_CHANNELS]);
 	static void OBSVolumeMuted(void *data, calldata_t *calldata);
 
 	void EmitConfigClicked();

--- a/libobs/obs-audio-controls.h
+++ b/libobs/obs-audio-controls.h
@@ -229,29 +229,20 @@ EXPORT void obs_volmeter_set_update_interval(obs_volmeter_t *volmeter,
 EXPORT unsigned int obs_volmeter_get_update_interval(obs_volmeter_t *volmeter);
 
 /**
- * @brief Set the peak hold time for the volume meter
+ * @brief Get the number of channels which are configured for this source.
  * @param volmeter pointer to the volume meter object
- * @param ms peak hold time in ms
  */
-EXPORT void obs_volmeter_set_peak_hold(obs_volmeter_t *volmeter,
-		const unsigned int ms);
+EXPORT int obs_volmeter_get_nr_channels(obs_volmeter_t *volmeter);
 
-/**
- * @brief Get the peak hold time for the volume meter
- * @param volmeter pointer to the volume meter object
- * @return the peak hold time in ms
- */
-EXPORT unsigned int obs_volmeter_get_peak_hold(obs_volmeter_t *volmeter);
-
-typedef void (*obs_volmeter_updated_t)(void *param, float level,
-		float magnitude, float peak, float muted);
+typedef void (*obs_volmeter_updated_t)(void *param,
+		const float magnitude[MAX_AUDIO_CHANNELS],
+		const float peak[MAX_AUDIO_CHANNELS],
+		const float input_peak[MAX_AUDIO_CHANNELS]);
 
 EXPORT void obs_volmeter_add_callback(obs_volmeter_t *volmeter,
 		obs_volmeter_updated_t callback, void *param);
 EXPORT void obs_volmeter_remove_callback(obs_volmeter_t *volmeter,
 		obs_volmeter_updated_t callback, void *param);
-
-EXPORT float obs_volmeter_get_cur_db(enum obs_fader_type type, const float def);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The following features have been added to the audio-meters:
 * Stereo PPM-level meter, with 20 dB/1.7s decay rate.
 * Stereo VU-level meter, with 300 ms integration time.
 * Stereo Peak-hold meter, with 20 second sustain.
 * Input level peak level color-dot.
 * Minor-ticks for each dB.
 * Major-ticks for every 5 dB.
 * Meter is divided in sections at -20 dB and -9 dB.

The ballistic parameters chosen here where taken from:
 * https://en.wikipedia.org/wiki/Peak_programme_meter (SMPTE RP.0155)
 * https://en.wikipedia.org/wiki/VU_meter

In the rework I have removed any ballistic calculations from
libobs/obs-audio-controls.c making the calculations here a lot more
simple doing only MAX and RMS calculations for only the samples in
the current update. The actual ballistics are now done by just
the UI/volume-control.cpp because ballistics need to be updated
based on the repaint-rate of the user-interface.

The dB to pixel conversion has been moved from
libobs/obs-audio-controls.c to UI/volume-control.cpp as well to reduce
coupling between these two objects, especially when implementing the
major- and minor-ticks and the sections.

All colors and ballistic parameters are adjustable via QT style sheets.
There are slight differences in colors for each of the themes.