### PR TITLE
libobs: Fix for int-in-bool-context-warning

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -427,9 +427,7 @@ static void duplicate_filters(obs_source_t *dst, obs_source_t *src,
 
 void obs_source_copy_filters(obs_source_t *dst, obs_source_t *src)
 {
-	duplicate_filters(dst, src, dst->context.private ?
-					OBS_SCENE_DUP_PRIVATE_COPY :
-					OBS_SCENE_DUP_COPY);
+	duplicate_filters(dst, src, dst->context.private);
 }
 
 obs_source_t *obs_source_duplicate(obs_source_t *source,


### PR DESCRIPTION
The 'bool private' variable was receiving either OBS_SCENE_DUP_PRIVATE_COPY or
OBS_SCENE_DUP_COPY hence always being true.