### PR TITLE
Revert "CI: Add Python path for AppVeyor"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,6 @@ install:
   - set VLCPath=%CD%\vlc
   - set QTDIR32=C:\Qt\5.7\msvc2015
   - set QTDIR64=C:\Qt\5.7\msvc2015_64
-  - set PythonPath32=C:\Python36
-  - set PythonPath64=C:\Python36-x64
   - set build_config=RelWithDebInfo
   - move "C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\um\d3d11on12*" "C:\Program Files (x86)\Windows Kits\8.1\Include\um"
   - move "C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\um\d3d12*" "C:\Program Files (x86)\Windows Kits\8.1\Include\um"


### PR DESCRIPTION
This is not necessary with the updated pre-built windows dependencies.
This reverts commit 516e9daa1ccf3f68fe456c1210d1622cee04c511.
Previous PR got merged a bit too fast ;)