### PR TITLE
linux-pulseaudio: Default sample format float32le

### DIFF
--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -238,7 +238,7 @@ static void pulseaudio_source_info(pa_context *c, const pa_source_info *i,
 
 	pa_sample_format_t format = i->sample_spec.format;
 	if (pulseaudio_to_obs_audio_format(format) == AUDIO_FORMAT_UNKNOWN) {
-		format = PA_SAMPLE_S16LE;
+		format = PA_SAMPLE_FLOAT32LE;
 
 		blog(LOG_INFO, "Sample format %s not supported by OBS,"
 				"using %s instead for recording",

--- a/plugins/linux-pulseaudio/pulse-input.c
+++ b/plugins/linux-pulseaudio/pulse-input.c
@@ -220,7 +220,7 @@ static void pulse_source_info(pa_context *c, const pa_source_info *i, int eol,
 
 	pa_sample_format_t format = i->sample_spec.format;
 	if (pulse_to_obs_audio_format(format) == AUDIO_FORMAT_UNKNOWN) {
-		format = PA_SAMPLE_S16LE;
+		format = PA_SAMPLE_FLOAT32LE;
 
 		blog(LOG_INFO, "Sample format %s not supported by OBS,"
 			"using %s instead for recording",


### PR DESCRIPTION
This pull request changes the fallback sample format for pulse-audio
to from PA_SAMPLE_S16LE to PA_SAMPLE_FLOAT32LE.

The pulseaudio plugin can handle the following sample format:
* PA_SAMPlE_U8
* PA_SAMPLE_S16LE
* PA_SAMPLE_S32LE
* PA_SAMPLE_FLOAT32LE

When an audio device advertises itself as another format, the pulseaudio-plugin
will ask pulse audio to convert to the fallback sample format.

The fallback PA_SAMPLE_S16LE is not ideal when your audio interface advertises
as PA_SAMPLE_S24LE since the conversion will lose precision.
With PA_SAMPLE_FLOAT32LE there is no precision loss and it is also equals OBS's
internal format.