### PR TITLE
UI: Add the -60 volume control marker

### DIFF
--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -115,6 +115,7 @@ private:
 	float displayInputPeakHold[MAX_AUDIO_CHANNELS];
 	uint64_t displayInputPeakHoldLastUpdateTime[MAX_AUDIO_CHANNELS];
 
+	QFont tickFont;
 	QColor backgroundNominalColor;
 	QColor backgroundWarningColor;
 	QColor backgroundErrorColor;


### PR DESCRIPTION
Added the "-60" ticker to the left most side of the meter. This also do some minor code clean-up to better fit the contributing style and clear all gcc warnings