### PR TITLE
libobs-d3d11: Fixed second source with same display being black

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <map>
 
 #include <windows.h>
 #include <dxgi.h>
@@ -558,9 +559,12 @@ struct gs_vertex_shader : gs_shader {
 };
 
 struct gs_duplicator : gs_obj {
+	static std::map<int, gs_duplicator*> instances;
+
 	ComPtr<IDXGIOutputDuplication> duplicator;
 	gs_texture_2d *texture;
 	int idx;
+	uint32_t nReferences;
 
 	void Start();
 


### PR DESCRIPTION
This commit fixes a bug that occurs on Windows when 2 or more
"Display Capture" sources with the same display are
simultaneously active.

Only one of these active sources works, all other ones are black.
and error messages with E_INVALIDARG are printed.
The issue can be reproduced by starting OBS, adding 2 display
capture sources with the same display and viewing them both.

The cause of the issue is that a seperate gs_duplicator object is made
for each display capture source. In the constructor for this class,
Start() is called which then calls DuplicateOutput with the display id.
However, the documentation for DuplicateOutput states the following:
  ...
  E_INVALIDARG (is returned) for one of the following reasons:
    The calling application is already duplicating this desktop output.
  ...
source: msdn.microsoft.com/en-us/library/windows/desktop/hh404600.aspx

In conclusion, instances of gs_duplicator must be shared between
display capture sources if the display that is being captured
is the same, which is exactly what this commit implements.

device_duplicator_create now first checks a map to see if an instance
of gs_duplicator already exists for a perticular display id. If not,
a new instance is created and added to the map. In both cases, a
reference counter is incremented and the object is returned.
gs_duplicator_destroy now decrements the reference counter and only
destroys the object if the resulting reference count is zero.
That is, if no more active sources are using this gs_duplicator.