### PR TITLE
CMake: Fix FindSwigDeps search path

### DIFF
--- a/cmake/Modules/FindSwigDeps.cmake
+++ b/cmake/Modules/FindSwigDeps.cmake
@@ -18,6 +18,7 @@ if(WIN32)
 			${DepsPath}
 			${_PYTHON_INCLUDE_DIRS}
 		PATH_SUFFIXES
+			../swig/Lib
 			swig/Lib
 			)
 
@@ -34,6 +35,7 @@ if(WIN32)
 			${DepsPath}
 			${_PYTHON_INCLUDE_DIRS}
 		PATH_SUFFIXES
+			../swig
 			swig
 			)
 endif()


### PR DESCRIPTION
Fixes a case of `DepsPath` not finding swig when it properly finds ffmpeg. This happens if you strictly follow the install instructions and set `DepsPath` to `win64\include`.