### PR TITLE
obs-ffmpeg: av_register_all before checking for nvenc

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -3,6 +3,7 @@
 #include <util/platform.h>
 #include <libavutil/log.h>
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
 #include <pthread.h>
 
 OBS_DECLARE_MODULE()
@@ -118,6 +119,7 @@ cleanup:
 
 static bool nvenc_supported(void)
 {
+	av_register_all();
 	AVCodec *nvenc = avcodec_find_encoder_by_name("nvenc_h264");
 	void *lib = NULL;
 


### PR DESCRIPTION
avcodec_find_encoder_by_name("nvenc_h264") returns NULL on my system with ffmpeg-3.3.6 and ffmpeg-3.4.1.

This patch adds a call to av_register_all() before avcodec_find_encoder_by_name() so that it is able to find the encoder.