### PR TITLE
cmake: Search for Python 3.4

### DIFF
--- a/CI/install-dependencies-linux.sh
+++ b/CI/install-dependencies-linux.sh
@@ -20,6 +20,7 @@ sudo apt-get install -y \
         libgl1-mesa-dev \
         libjack-jackd2-dev \
         libjansson-dev \
+        libluajit-5.1-dev \
         libpulse-dev \
         libqt5x11extras5-dev \
         libspeexdsp-dev \
@@ -35,4 +36,6 @@ sudo apt-get install -y \
         libxcomposite-dev \
         libxinerama-dev \
         pkg-config \
-        qtbase5-dev
+        python3-dev \
+        qtbase5-dev \
+        swig

--- a/cmake/Modules/FindPythonDeps.cmake
+++ b/cmake/Modules/FindPythonDeps.cmake
@@ -9,6 +9,7 @@
 #  PYTHON_INCLUDE_DIR
 
 if(NOT WIN32)
+	set(Python_ADDITIONAL_VERSIONS 3.4)
 	find_package(PythonLibs QUIET 3.4)
 	return()
 endif()


### PR DESCRIPTION
Fixes an issue where Python libraries aren't found on Ubuntu 14.04 because CMake 2.8 only searches up to Python 3.3.

Also edits CI by enabling scripting in Linux builds.