### PR TITLE
UI: Don't draw bounding boxes for sources without video flag

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1105,6 +1105,9 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *scene,
 	if (obs_sceneitem_locked(item))
 		return true;
 
+	if (!SceneItemHasVideo(item))
+		return true;
+
 	if (!obs_sceneitem_selected(item))
 		return true;
 


### PR DESCRIPTION
Audio Input or Output, for instance, don't have the OBS_SOURCE_VIDEO
output flag so there is no need to draw the compositing helper bounding
boxes.