### PR TITLE
libobs: Add format conversion utility functions

### DIFF
--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -168,7 +168,7 @@ static inline bool is_audio_planar(enum audio_format format)
 	return false;
 }
 
-static inline audio_format get_planar_format(audio_format format) {
+static inline enum audio_format get_planar_format(enum audio_format format) {
 	switch (format) {
 	case AUDIO_FORMAT_U8BIT:
 		return AUDIO_FORMAT_U8BIT_PLANAR;
@@ -186,7 +186,7 @@ static inline audio_format get_planar_format(audio_format format) {
 	return format;
 }
 
-static inline audio_format get_interleaved_format(audio_format format) {
+static inline enum audio_format get_interleaved_format(enum audio_format format) {
 	switch (format) {
 	case AUDIO_FORMAT_U8BIT_PLANAR:
 		return AUDIO_FORMAT_U8BIT;

--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -168,6 +168,42 @@ static inline bool is_audio_planar(enum audio_format format)
 	return false;
 }
 
+static inline audio_format get_planar_format(audio_format format) {
+	switch (format) {
+	case AUDIO_FORMAT_U8BIT:
+		return AUDIO_FORMAT_U8BIT_PLANAR;
+
+	case AUDIO_FORMAT_16BIT:
+		return AUDIO_FORMAT_16BIT_PLANAR;
+
+	case AUDIO_FORMAT_32BIT:
+		return AUDIO_FORMAT_32BIT_PLANAR;
+
+	case AUDIO_FORMAT_FLOAT:
+		return AUDIO_FORMAT_FLOAT_PLANAR;
+	}
+
+	return format;
+}
+
+static inline audio_format get_interleaved_format(audio_format format) {
+	switch (format) {
+	case AUDIO_FORMAT_U8BIT_PLANAR:
+		return AUDIO_FORMAT_U8BIT;
+
+	case AUDIO_FORMAT_16BIT_PLANAR:
+		return AUDIO_FORMAT_16BIT;
+
+	case AUDIO_FORMAT_32BIT_PLANAR:
+		return AUDIO_FORMAT_32BIT;
+
+	case AUDIO_FORMAT_FLOAT_PLANAR:
+		return AUDIO_FORMAT_FLOAT;
+	}
+
+	return format;
+}
+
 static inline size_t get_audio_planes(enum audio_format format,
 		enum speaker_layout speakers)
 {


### PR DESCRIPTION
libobs: Add format conversion utility functions

For potential migratory purposes in audio plugin settings, or to force 
a format change if preprocessing (deinterleaving / interleaving) data
before obs_source_output_audio(...).

Example: a device is activated w/ a supported interleaved format, an
audio callback processes the data and presents it as planar and sets 
obs_source_audio's .data[] member appropriately, obs_source_audio's 
.format is then set to the planar version of the setting before
obs_source_output_audio(...) is called.

Example2: a plugin is initially designed to use planar formats, and
stores the audio_format enum as is, a later update uses interleaved. 
The audio_format enum is immediately checked from the settings using 
is_audio_planar() and swapped in the event the format stored wasn't 
expected, successfully migrating from the previous format required.