### PR TITLE
vlc-video: add adjustable speed

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.c
+++ b/plugins/vlc-video/vlc-video-plugin.c
@@ -34,6 +34,8 @@ LIBVLC_MEDIA_PLAYER_STOP libvlc_media_player_stop_;
 LIBVLC_MEDIA_PLAYER_GET_TIME libvlc_media_player_get_time_;
 LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
 LIBVLC_MEDIA_PLAYER_EVENT_MANAGER libvlc_media_player_event_manager_;
+LIBVLC_MEDIA_PLAYER_GET_RATE libvlc_media_player_get_rate_;
+LIBVLC_MEDIA_PLAYER_SET_RATE libvlc_media_player_set_rate_;
 
 /* libvlc media list */
 LIBVLC_MEDIA_LIST_NEW libvlc_media_list_new_;
@@ -98,6 +100,8 @@ static bool load_vlc_funcs(void)
 	LOAD_VLC_FUNC(libvlc_media_player_get_time);
 	LOAD_VLC_FUNC(libvlc_video_get_size);
 	LOAD_VLC_FUNC(libvlc_media_player_event_manager);
+	LOAD_VLC_FUNC(libvlc_media_player_get_rate);
+	LOAD_VLC_FUNC(libvlc_media_player_set_rate);
 
 	/* libvlc media list */
 	LOAD_VLC_FUNC(libvlc_media_list_new);

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -77,6 +77,11 @@ typedef int (*LIBVLC_VIDEO_GET_SIZE)(
 		unsigned *py);
 typedef libvlc_event_manager_t *(*LIBVLC_MEDIA_PLAYER_EVENT_MANAGER)(
 		libvlc_media_player_t *p_mp);
+typedef float (*LIBVLC_MEDIA_PLAYER_GET_RATE)(
+		libvlc_media_player_t *p_mi);
+typedef int (*LIBVLC_MEDIA_PLAYER_SET_RATE)(
+		libvlc_media_player_t *p_mi,
+		float rate);
 
 /* libvlc media list */
 typedef libvlc_media_list_t *(*LIBVLC_MEDIA_LIST_NEW)(
@@ -144,6 +149,8 @@ extern LIBVLC_MEDIA_PLAYER_STOP libvlc_media_player_stop_;
 extern LIBVLC_MEDIA_PLAYER_GET_TIME libvlc_media_player_get_time_;
 extern LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
 extern LIBVLC_MEDIA_PLAYER_EVENT_MANAGER libvlc_media_player_event_manager_;
+extern LIBVLC_MEDIA_PLAYER_GET_RATE libvlc_media_player_get_rate_;
+extern LIBVLC_MEDIA_PLAYER_SET_RATE libvlc_media_player_set_rate_;
 
 /* libvlc media list */
 extern LIBVLC_MEDIA_LIST_NEW libvlc_media_list_new_;


### PR DESCRIPTION
Add possibility to change the playback speed of the vlc plugin.

This can be used for adjusting the speed while playing a replay.
So you can make the most important part of the replay extra slow.