### PR TITLE
UI: Allow nested docks

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -33,6 +33,9 @@
   <property name="styleSheet">
    <string notr="true"/>
   </property>
+  <property name="dockOptions">
+   <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks</set>
+  </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>


### PR DESCRIPTION
This change enables the ability to use nested docks, with the dependency of Qt5.10 or later being used to build OBS. 

Similar to the Lock UI option we could add a toggle to the menu. Not sure if this is necessary, maybe you guys have some ideas.

Example screenshots of nesting OBS:
http://img.jack0r.com/Share/obs64_2018-01-29_01-03-34.png
http://img.jack0r.com/Share/obs64_2018-01-29_00-10-24.png