### PR TITLE
cmake: Fix LuaJIT search

### DIFF
--- a/cmake/Modules/FindLuajit.cmake
+++ b/cmake/Modules/FindLuajit.cmake
@@ -15,7 +15,7 @@ ELSE()
 ENDIF()
 
 FIND_PATH(LUAJIT_INCLUDE_DIR
-	NAMES lua.h
+	NAMES lua.h lualib.h
 	HINTS
 		ENV LuajitPath${_LIB_SUFFIX}
 		ENV LuajitPath


### PR DESCRIPTION
Out of the box, cmake doesn't include lualib.h in compiling, which causes obs-scripting-lua.c to throw a C99 warning for implicit use of luaopen_ffi().

