### PR TITLE
UI: Fix grayed out Copy option in sources context menu

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -182,10 +182,7 @@
      <addaction name="actionScaleCanvas"/>
      <addaction name="actionScaleOutput"/>
     </widget>
-    <action name="actionCopySource">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
+    <action name="actionCopySource">    
      <property name="text">
       <string>Copy</string>
      </property>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2858,8 +2858,6 @@ void OBSBasic::SceneItemSelected(void *data, calldata_t *params)
 	QMetaObject::invokeMethod(window, "SelectSceneItem",
 			Q_ARG(OBSScene, scene), Q_ARG(OBSSceneItem, item),
 			Q_ARG(bool, true));
-
-	window->ui->actionCopySource->setEnabled(true);
 }
 
 void OBSBasic::SceneItemDeselected(void *data, calldata_t *params)
@@ -2873,7 +2871,6 @@ void OBSBasic::SceneItemDeselected(void *data, calldata_t *params)
 			Q_ARG(OBSScene, scene), Q_ARG(OBSSceneItem, item),
 			Q_ARG(bool, false));
 
-	window->ui->actionCopySource->setEnabled(false);
 }
 
 void OBSBasic::SourceLoaded(void *data, obs_source_t *source)
@@ -3891,6 +3888,7 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 		popup.addMenu(addSourceMenu);
 
 	ui->actionCopyFilters->setEnabled(false);
+	ui->actionCopySource->setEnabled(false);
 
 	popup.addSeparator();
 	popup.addAction(ui->actionCopySource);
@@ -3969,6 +3967,7 @@ void OBSBasic::CreateSourcePopupMenu(QListWidgetItem *item, bool preview)
 				SLOT(on_actionSourceProperties_triggered()));
 
 		ui->actionCopyFilters->setEnabled(true);
+		ui->actionCopySource->setEnabled(true);
 	}
 
 	popup.exec(QCursor::pos());


### PR DESCRIPTION
This fixes a problem introduced in #1050 where the Copy option would
be grayed out when rightclicking a source above the currently selected
source. This also retains the functionality of not having the Copy option
enabled when no source is selected.