### PR TITLE
libobs/media-io: Change speaker layout to match FFmpeg aac.

### DIFF
--- a/libobs/media-io/audio-resampler-ffmpeg.c
+++ b/libobs/media-io/audio-resampler-ffmpeg.c
@@ -63,10 +63,10 @@ static inline uint64_t convert_speaker_layout(enum speaker_layout layout)
 	case SPEAKERS_UNKNOWN:          return 0;
 	case SPEAKERS_MONO:             return AV_CH_LAYOUT_MONO;
 	case SPEAKERS_STEREO:           return AV_CH_LAYOUT_STEREO;
-	case SPEAKERS_2POINT1:          return AV_CH_LAYOUT_2_1;
+	case SPEAKERS_2POINT1:          return AV_CH_LAYOUT_SURROUND;
 	case SPEAKERS_4POINT0:          return AV_CH_LAYOUT_4POINT0;
 	case SPEAKERS_4POINT1:          return AV_CH_LAYOUT_4POINT1;
-	case SPEAKERS_5POINT1:          return AV_CH_LAYOUT_5POINT1;
+	case SPEAKERS_5POINT1:          return AV_CH_LAYOUT_5POINT1_BACK;
 	case SPEAKERS_7POINT1:          return AV_CH_LAYOUT_7POINT1;
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -62,10 +62,10 @@ static inline uint64_t convert_speaker_layout(enum speaker_layout layout)
 	case SPEAKERS_UNKNOWN:          return 0;
 	case SPEAKERS_MONO:             return AV_CH_LAYOUT_MONO;
 	case SPEAKERS_STEREO:           return AV_CH_LAYOUT_STEREO;
-	case SPEAKERS_2POINT1:          return AV_CH_LAYOUT_2_1;
+	case SPEAKERS_2POINT1:          return AV_CH_LAYOUT_SURROUND;
 	case SPEAKERS_4POINT0:          return AV_CH_LAYOUT_4POINT0;
 	case SPEAKERS_4POINT1:          return AV_CH_LAYOUT_4POINT1;
-	case SPEAKERS_5POINT1:          return AV_CH_LAYOUT_5POINT1;
+	case SPEAKERS_5POINT1:          return AV_CH_LAYOUT_5POINT1_BACK;
 	case SPEAKERS_7POINT1:          return AV_CH_LAYOUT_7POINT1;
 	}
 
@@ -78,10 +78,10 @@ static inline enum speaker_layout convert_ff_channel_layout(uint64_t  channel_la
 	switch (channel_layout) {
 	case AV_CH_LAYOUT_MONO:              return SPEAKERS_MONO;
 	case AV_CH_LAYOUT_STEREO:            return SPEAKERS_STEREO;
-	case AV_CH_LAYOUT_2_1:               return SPEAKERS_2POINT1;
+	case AV_CH_LAYOUT_SURROUND:          return SPEAKERS_2POINT1;
 	case AV_CH_LAYOUT_4POINT0:           return SPEAKERS_4POINT0;
 	case AV_CH_LAYOUT_4POINT1:           return SPEAKERS_4POINT1;
-	case AV_CH_LAYOUT_5POINT1:           return SPEAKERS_5POINT1;
+	case AV_CH_LAYOUT_5POINT1_BACK:      return SPEAKERS_5POINT1;
 	case AV_CH_LAYOUT_7POINT1:           return SPEAKERS_7POINT1;
 	}
 


### PR DESCRIPTION
(also changes obs-ffmpeg).
The default channel layouts from aac spec are implemented in FFmpeg native
aac encoder as:
    AV_CH_LAYOUT_MONO,
    AV_CH_LAYOUT_STEREO,
    AV_CH_LAYOUT_SURROUND,
    AV_CH_LAYOUT_4POINT0,
    AV_CH_LAYOUT_5POINT0_BACK,
    AV_CH_LAYOUT_5POINT1_bACK,
    AV_CH_LAYOUT_7POINT1,

The correspondence of speaker layouts to AV_CH_LAYOUT from FFmpeg is
changed to reflect the previous table.
Although FFmpeg native aac encoder can now encode all the layouts listed
in avutil channel_layout.h (on master), there might be issues with older FFmpeg
binaries. This PR fixes those issues for 2.1 and 5.1 layouts.

NB:
Note that 2.1 speaker layout will be encoded as AV_CH_LAYOUT_SURROUND
(FL FR FC) because it is not listed as the default layout for three
channels.
This just means some optimizations for LFE channel will not be used by
the encoder which will treat it as an SCE (single channel element).