### PR TITLE
deps/obs-scripting: Expose obs video info to swig

### DIFF
--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -145,7 +145,6 @@ struct obs_transform_info {
 	struct vec2          bounds;
 };
 
-#ifndef SWIG
 /**
  * Video initialization structure
  */
@@ -176,7 +175,6 @@ struct obs_video_info {
 
 	enum obs_scale_type scale_type;    /**< How to scale if scaling */
 };
-#endif
 
 /**
  * Audio initialization structure
@@ -283,7 +281,6 @@ EXPORT const char *obs_get_locale(void);
  */
 EXPORT profiler_name_store_t *obs_get_profiler_name_store(void);
 
-#ifndef SWIG
 /**
  * Sets base video output base resolution/fps/format.
  *
@@ -301,7 +298,6 @@ EXPORT profiler_name_store_t *obs_get_profiler_name_store(void);
  *               OBS_VIDEO_FAIL for generic failure
  */
 EXPORT int obs_reset_video(struct obs_video_info *ovi);
-#endif
 
 /**
  * Sets base audio output format/channels/samples/etc
@@ -310,10 +306,8 @@ EXPORT int obs_reset_video(struct obs_video_info *ovi);
  */
 EXPORT bool obs_reset_audio(const struct obs_audio_info *oai);
 
-#ifndef SWIG
 /** Gets the current video settings, returns false if no video */
 EXPORT bool obs_get_video_info(struct obs_video_info *ovi);
-#endif
 
 /** Gets the current audio settings, returns false if no audio */
 EXPORT bool obs_get_audio_info(struct obs_audio_info *oai);


### PR DESCRIPTION
Someone requested a way to set the obs output size to a source. This lets you make a script that does that now.

https://gist.github.com/DDRBoxman/e9b057388e0590d9a435688b1b100a95