### PR TITLE
libobs: Fix property text typo

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -236,7 +236,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
 {
 	const char    *name = obs_property_name(prop);
 	const char    *val  = obs_data_get_string(settings, name);
-	obs_text_type type  = obs_proprety_text_type(prop);
+	obs_text_type type  = obs_property_text_type(prop);
 
 	if (type == OBS_TEXT_MULTILINE) {
 		QPlainTextEdit *edit = new QPlainTextEdit(QT_UTF8(val));
@@ -1529,7 +1529,7 @@ void WidgetInfo::FloatChanged(const char *setting)
 
 void WidgetInfo::TextChanged(const char *setting)
 {
-	obs_text_type type  = obs_proprety_text_type(property);
+	obs_text_type type  = obs_property_text_type(property);
 
 	if (type == OBS_TEXT_MULTILINE) {
 		QPlainTextEdit *edit = static_cast<QPlainTextEdit*>(widget);

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -383,7 +383,7 @@ Property Enumeration Functions
 
 ---------------------
 
-.. function:: enum obs_text_type     obs_proprety_text_type(obs_property_t *p)
+.. function:: enum obs_text_type     obs_property_text_type(obs_property_t *p)
 
 ---------------------
 

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -738,7 +738,7 @@ enum obs_number_type obs_property_float_type(obs_property_t *p)
 	return data ? data->type : OBS_NUMBER_SCROLLER;
 }
 
-enum obs_text_type obs_proprety_text_type(obs_property_t *p)
+enum obs_text_type obs_property_text_type(obs_property_t *p)
 {
 	struct text_data *data = get_type_data(p, OBS_PROPERTY_TEXT);
 	return data ? data->type : OBS_TEXT_DEFAULT;

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -263,7 +263,7 @@ EXPORT double                 obs_property_float_min(obs_property_t *p);
 EXPORT double                 obs_property_float_max(obs_property_t *p);
 EXPORT double                 obs_property_float_step(obs_property_t *p);
 EXPORT enum obs_number_type   obs_property_float_type(obs_property_t *p);
-EXPORT enum obs_text_type     obs_proprety_text_type(obs_property_t *p);
+EXPORT enum obs_text_type     obs_property_text_type(obs_property_t *p);
 EXPORT enum obs_path_type     obs_property_path_type(obs_property_t *p);
 EXPORT const char *           obs_property_path_filter(obs_property_t *p);
 EXPORT const char *           obs_property_path_default_path(obs_property_t *p);


### PR DESCRIPTION
Corrects a few typos for obs_property_text_type for libobs, ui, and docs.