### PR TITLE
image-source: check empty list when update slideshow

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -656,7 +656,21 @@ static void ss_video_tick(void *data, float seconds)
 
 	if (ss->pause_on_deactivate || ss->manual || ss->stop || ss->paused)
 		return;
+	
+	/* ------------------------------------------------------------- */
+	/* transition to null when the file list becomes empty */
+	if (!ss->files.num)
+	{
+		obs_source_t* active_transition_source = obs_transition_get_active_source(ss->transition);
+		if (active_transition_source)
+		{
+			obs_source_release(active_transition_source);
+			do_transition(ss, true);
+		}
+	}
 
+	/* ----------------------------------------------- */
+	/* do transition when slide time reached */
 	ss->elapsed += seconds;
 
 	if (ss->elapsed > ss->slide_time) {


### PR DESCRIPTION
Fix bug that when updating slideshow's file list to empty without 
touching transition mode, the last shown picture will stay forever.

How to reproduce:
1. Run OBS 21.0.1
2. Add a slideshow source
3. Add some picture files into the slideshow list
4. Select all files in the slideshow list, press "-" button ( don't touch the transition mode)
5. The last shown picture will not disappear.

Environment:

i5-4690 3.5GHz / 16G / 256G SSD / GTX 760
Windows 10 x64 (1709) zh-cn