### PR TITLE
libobs: fix race between filter rendering and remove

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1720,9 +1720,11 @@ static inline void obs_source_render_async_video(obs_source_t *source)
 
 static inline void obs_source_render_filters(obs_source_t *source)
 {
+	pthread_mutex_lock(&source->filter_mutex);
 	source->rendering_filter = true;
 	obs_source_video_render(source->filters.array[0]);
 	source->rendering_filter = false;
+	pthread_mutex_unlock(&source->filter_mutex);
 }
 
 void obs_source_default_render(obs_source_t *source)


### PR DESCRIPTION
block filter list operation during rendering.

There may be a race when:
1. The obs_video_thread runs info a filter's render procedure, and it calls obs_source_process_filter_begin
2. Context switched to UI thread, user removed the filter. The filter's parent becomes null.
3. Context switched back to obs_video_thread, it calls obs_source_process_filter_end. It crashes since parent is null.

I tested my patch and not reproduced, but it may be over-killed.