### PR TITLE
deps/obs-scripting: Fix tick function arg number

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -377,7 +377,7 @@ static void obs_lua_tick_callback(void *priv, float seconds)
 	lock_callback();
 
 	lua_pushnumber(script, (lua_Number)seconds);
-	call_func(obs_lua_tick_callback, 2, 0);
+	call_func(obs_lua_tick_callback, 1, 0);
 
 	unlock_callback();
 }


### PR DESCRIPTION
Tick function was smashing stack every time it was called due to arg number mismatch.